### PR TITLE
Add preview command that uses snapshot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ to provision dashboards that can be picked up immediately by Grafana.
 $ grr export some-mixin.libsonnet my-provisioning-dir
 ```
 
+### grr preview
+Renders a mixin and uploads each dashboard produced as snapshots to Grafana. Prints out links for each dashboard that was uploaded.
+```sh
+$ grr preview some-mixin.libsonnet
+```
+Snapshots by default do not expire. Expiration can be set via the `-e, --expires` flag which takes a number of seconds as an argument.
+
 ## Flags
 
 ### `-t, --target strings`

--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -27,6 +27,7 @@ func main() {
 		applyCmd(),
 		watchCmd(),
 		exportCmd(),
+		previewCmd(),
 	)
 
 	// Run!

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -111,6 +111,33 @@ func watchCmd() *cli.Command {
 	return cmd
 }
 
+func previewCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "preview <jsonnet-file>",
+		Short: "upload a snapshot to preview the rendered file",
+		Args:  cli.ArgsAny(),
+	}
+	targets := cmd.Flags().StringSliceP("target", "t", nil, "dashboards to target")
+	cmd.Flags().IntP("expires", "e", 0, "when the preview should expire. Default 0 (never)")
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		jsonnetFile := args[0]
+		e, err := cmd.Flags().GetInt("expires")
+		if err != nil {
+			return err
+		}
+		opts := &grizzly.PreviewOpts{
+			ExpiresSeconds: e,
+		}
+
+		config, err := grizzly.ParseEnvironment()
+		if err != nil {
+			return err
+		}
+		return grizzly.Preview(*config, jsonnetFile, targets, opts)
+	}
+	return cmd
+}
+
 func exportCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "export <jsonnet-file> <dashboard-dir>",


### PR DESCRIPTION
:wave: Implemented a preview feature that uploads each dashboard produced from the jsonnet file as snapshots via the snapshot API in grafana, I tried to keep options simple to begin with. 

I'm personally interested in using grizzly within a GH action to produce snapshot URLs of pending changes to dashboards

Some next steps might be adding a preview/snapshot flag to the `watch` command and re-using `grizzly.Preview`. 


Sample output
```
GRAFANA_URL=http://localhost:3000 ./grr preview  node.libsonnet --expires 60
View node-cluster-rsrc-use.json http://localhost:3000/dashboard/snapshot/yA0PjBYl4K3zSDy23oX3mk2iMKDiHfFx
Delete node-cluster-rsrc-use.json http://localhost:3000/api/snapshots-delete/kLFtRGyEAQOpNnOtTA9DiVO9fmKmyeZc
View node-rsrc-use.json http://localhost:3000/dashboard/snapshot/DHguHxfiScxWHDDnqC0RDd2TDiAUP4Rs
Delete node-rsrc-use.json http://localhost:3000/api/snapshots-delete/YOtPNrmSXWtng8afs6RhgIewp9ETtn2N
View nodes.json http://localhost:3000/dashboard/snapshot/W0W2Gkw1N8H45qdluH3xv7oQpQTQ15C4
Delete nodes.json http://localhost:3000/api/snapshots-delete/y0jvdaP4XTCQ76wf3rG89X8fYQ76G60Y
Previews will expire and be deleted automatically in 60 seconds
```