### PR TITLE
Use the Grafana token in all requests in the Authorization header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/grafana-tools/sdk v0.0.0-20200326200416-f0431e44c1c3
 	github.com/kylelemons/godebug v1.1.0
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	gopkg.in/fsnotify.v1 v1.4.7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
@@ -6,6 +7,7 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-clix/cli v0.1.0 h1:8QvcZJvtHu3+/Eg4XXlGzhvqf7H8rL438xzvt5dcPME=
 github.com/go-clix/cli v0.1.0/go.mod h1:dYJevXraB9mXZFhz5clyQestG0qGcmT5rRC/P9etoRQ=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-jsonnet v0.15.0 h1:lEUXTDnVsHu+CLLzMeWAdWV4JpCgkJeDqdVNS8RtyuY=
 github.com/google/go-jsonnet v0.15.0/go.mod h1:ex9QcU8vzXQUDeNe4gaN1uhGQbTYpOeZ6AbWdy6JbX4=
 github.com/gosimple/slug v1.1.1 h1:fRu/digW+NMwBIP+RmviTK97Ho/bEj/C9swrCspN3D4=
@@ -38,11 +40,19 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 h1:T5DasATyLQfmbTpfEXx/IOL9vfjzW6up+ZDkmHvIf2s=
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -5,8 +5,10 @@ import (
 	"os"
 )
 
+
 // Config provides configuration to `grafana-dash`
 type Config struct {
+    GrafanaToken string
 	GrafanaURL  string
 	JsonnetPath string
 }
@@ -21,12 +23,14 @@ func ParseEnvironment() (*Config, error) {
 		}
 		config.GrafanaURL = u.String()
 		if token, exists := os.LookupEnv("GRAFANA_TOKEN"); exists {
+	    	config.GrafanaToken = token
 			user, exists := os.LookupEnv("GRAFANA_USER")
 			if !exists {
 				user = "api_key"
 			}
 			u.User = url.UserPassword(user, token)
 			config.GrafanaURL = u.String()
+
 		}
 	}
 	return &config, nil


### PR DESCRIPTION
FIX #26 
# the bug
```
grr apply mydash.libsonnet 
Folder not found and/or configured. Applying to "General" folder.
2020/07/27 12:17:01 Error retrieving dashboard my-dash.json: 401 Unauthorized
```

# the explanation
Per the documentation, Grafana explicitely shows how the call protocol should include the Authentication headers, look!
![Screenshot from 2020-07-27 13-03-14](https://user-images.githubusercontent.com/9152392/88564426-974e5e00-d009-11ea-879a-208e1472d453.png)

Calling **without headers**, like Grizzly does as of now:
```bash 
curl http://api_key:eyJrIjoielBIZ1BYdWJVRWVQQ2dKYkM4S0ZQcmtDd3NSa2hCZFQiLCJuIjoiYXBpX2tleSIsImlkIjoxfQ==@localhost:3000/api/org
{"message":"Basic auth failed"}
```

Calling **with headers**:
```bash
curl http://api_key:eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFeyJrIjoielBIZ1BYdWJVRWVQQ2dKYkM4S0ZQcmtDd3NSa2hCZFQiLCJuIjoiYXBpX2tleSIsImlkIjoxfQ==@localhost:3000/api/org  -H "Authorization: Bearer eyJrIjoidnBBaXhUdVQyS0VaWlJ4bGR6YWF4M3h4U3RTdllQem4iLCJuIjoiYXBpX2tleSIsImlkIjoxfQ=="
{"id":1,"name":"Main Org.","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}
```



# the solution
By setting the Authorization header for all requests to Grafana, now I can hit Grafana successfully. 
![Screenshot from 2020-07-27 13-15-01](https://user-images.githubusercontent.com/9152392/88565598-3758b700-d00b-11ea-8c30-9aa8b9b5811d.png)


