### PR TITLE
Rename module to reflect its current repo location

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/go-clix/cli"
-	"github.com/malcolmholmes/grizzly/pkg/grizzly"
+	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
 func getCmd() *cli.Command {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/malcolmholmes/grizzly
+module github.com/grafana/grizzly
 
 go 1.13
 


### PR DESCRIPTION
This repo was moved from malcolmholmes/grizzly to grafana/grizzly. Seems appropriate to update the module name to reflect its current location.