### PR TITLE
fix(diff): diff with nested dashboard element

### DIFF
--- a/pkg/grizzly/grafana.go
+++ b/pkg/grizzly/grafana.go
@@ -189,10 +189,15 @@ func getDashboard(config Config, uid string) (*Board, error) {
 		return nil, err
 	}
 
-	var board Board
-	if err := json.Unmarshal(data, &board); err != nil {
+	type nestedBoard struct {
+		Dashboard Board `json:"dashboard"`
+	}
+	var b nestedBoard
+	if err := json.Unmarshal(data, &b); err != nil {
 		return nil, APIErr{err, data}
 	}
+
+	board := Board{Dashboard: b.Dashboard.Dashboard}
 
 	return &board, nil
 }


### PR DESCRIPTION
As parseDashboards got refactored out, the nesting from the API didn't
line up anymore with the rendered dashboards. This generated a broken
diff.

Ref for the original change: d58bc1a63f2215072c7053e7c7c9577a075afcc1

This was part of a review on #40, further refactoring may happen from there.