### PR TITLE
Group resources by handler

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -55,8 +55,8 @@ func (h *DashboardHandler) newDashboardResource(uid, filename string, board Dash
 }
 
 // Parse parses an interface{} object into a struct for this resource type
-func (h *DashboardHandler) Parse(i interface{}) (grizzly.Resources, error) {
-	resources := grizzly.Resources{}
+func (h *DashboardHandler) Parse(i interface{}) (grizzly.ResourceList, error) {
+	resources := grizzly.ResourceList{}
 	msi := i.(map[string]interface{})
 	for k, v := range msi {
 		board := Dashboard{}

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -48,8 +48,8 @@ func (h *DatasourceHandler) newDatasourceResource(uid, filename string, source D
 }
 
 // Parse parses an interface{} object into a struct for this resource type
-func (h *DatasourceHandler) Parse(i interface{}) (grizzly.Resources, error) {
-	resources := grizzly.Resources{}
+func (h *DatasourceHandler) Parse(i interface{}) (grizzly.ResourceList, error) {
+	resources := grizzly.ResourceList{}
 	msi := i.(map[string]interface{})
 	for k, v := range msi {
 		source := Datasource{}

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -60,8 +60,8 @@ func (h *SyntheticMonitoringHandler) newCheckResource(filename string, check Che
 }
 
 // Parse parses an interface{} object into a struct for this resource type
-func (h *SyntheticMonitoringHandler) Parse(i interface{}) (grizzly.Resources, error) {
-	resources := grizzly.Resources{}
+func (h *SyntheticMonitoringHandler) Parse(i interface{}) (grizzly.ResourceList, error) {
+	resources := grizzly.ResourceList{}
 	msi := i.(map[string]interface{})
 	for k, v := range msi {
 		check := Check{}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -45,8 +45,11 @@ func (r *Resource) MatchesTarget(targets []string) bool {
 	return false
 }
 
-// Resources represents a set of resources, by path
-type Resources map[string]Resource
+// ResourceList represents a set of named resources
+type ResourceList map[string]Resource
+
+// Resources represents a set of resources by handler
+type Resources map[Handler]ResourceList
 
 // Handler describes a handler for a single API resource handled by a single provider
 type Handler interface {
@@ -56,7 +59,7 @@ type Handler interface {
 	GetExtension() string
 
 	// Parse parses an interface{} object into a struct for this resource type
-	Parse(i interface{}) (Resources, error)
+	Parse(i interface{}) (ResourceList, error)
 
 	// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 	Unprepare(resource Resource) *Resource


### PR DESCRIPTION
Before this PR, the code puts all resources into a single map, regardless of the handler.

With this PR, resources are now grouped by handler. This moves us towards a situation where we hand a whole list of resources to a handler in one go, and the handler is responsible for the whole workflow.

With this change, we're one step closer to being able to implement a `grafanactl` style workflow, independent of jsonnet.