### PR TITLE
Multi resource handlers

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -28,6 +28,7 @@ func main() {
 
 	config := grizzly.Config{
 		Registry: registry,
+		Notifier: grizzly.Notifier{},
 	}
 	// workflow commands
 	rootCmd.AddCommand(

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -187,8 +187,9 @@ func providersCmd(config grizzly.Config) *cli.Command {
 		fmt.Fprintf(w, f, "PROVIDER", "HANDLER", "JSON PATH")
 		for _, provider := range config.Registry.Providers {
 			for _, handler := range provider.GetHandlers() {
-				path := handler.GetJSONPath()
-				fmt.Fprintf(w, f, provider.GetName(), handler.GetName(), "/"+path)
+				for _, path := range handler.GetJSONPaths() {
+					fmt.Fprintf(w, f, provider.GetName(), handler.GetName(), "/"+path)
+				}
 			}
 		}
 		return w.Flush()

--- a/foo.txt
+++ b/foo.txt
@@ -1,4 +1,0 @@
-this
-that
-the
-other

--- a/foo.txt
+++ b/foo.txt
@@ -1,0 +1,4 @@
+this
+that
+the
+other

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -34,9 +34,17 @@ func (h *DashboardHandler) GetFullName() string {
 	return "grafana.dashboard"
 }
 
-// GetJSONPath returns a paths within Jsonnet output that this provider will consume
-func (h *DashboardHandler) GetJSONPath() string {
-	return "grafanaDashboards"
+const (
+	dashboardsPath      = "grafanaDashboards"
+	dashboardFolderPath = "grafanaDashboardFolder"
+)
+
+// GetJSONPaths returns paths within Jsonnet output that this provider will consume
+func (h *DashboardHandler) GetJSONPaths() []string {
+	return []string{
+		dashboardsPath,
+		dashboardFolderPath,
+	}
 }
 
 // GetExtension returns the file name extension for a dashboard
@@ -44,19 +52,19 @@ func (h *DashboardHandler) GetExtension() string {
 	return "json"
 }
 
-func (h *DashboardHandler) newDashboardResource(uid, filename string, board Dashboard) grizzly.Resource {
+func (h *DashboardHandler) newDashboardResource(path, uid, filename string, board Dashboard) grizzly.Resource {
 	resource := grizzly.Resource{
 		UID:      uid,
 		Filename: filename,
 		Handler:  h,
 		Detail:   board,
-		Path:     h.GetJSONPath(),
+		Path:     path,
 	}
 	return resource
 }
 
 // Parse parses an interface{} object into a struct for this resource type
-func (h *DashboardHandler) Parse(i interface{}) (grizzly.ResourceList, error) {
+func (h *DashboardHandler) Parse(path string, i interface{}) (grizzly.ResourceList, error) {
 	resources := grizzly.ResourceList{}
 	msi := i.(map[string]interface{})
 	for k, v := range msi {
@@ -65,7 +73,7 @@ func (h *DashboardHandler) Parse(i interface{}) (grizzly.ResourceList, error) {
 		if err != nil {
 			return nil, err
 		}
-		resource := h.newDashboardResource(board.UID(), k, board)
+		resource := h.newDashboardResource(path, board.UID(), k, board)
 		key := resource.Key()
 		resources[key] = resource
 	}
@@ -159,7 +167,7 @@ func (h *DashboardHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving dashboard %s: %v", UID, err)
 	}
-	resource := h.newDashboardResource(UID, "", *board)
+	resource := h.newDashboardResource(dashboardsPath, UID, "", *board)
 	return &resource, nil
 }
 
@@ -188,7 +196,7 @@ func (h *DashboardHandler) GetRemote(uid string) (*grizzly.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
-	resource := h.newDashboardResource(uid, "", *board)
+	resource := h.newDashboardResource(dashboardsPath, uid, "", *board)
 	return &resource, nil
 }
 

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -58,7 +58,7 @@ func (h *DashboardHandler) newDashboardResource(path, uid, filename string, boar
 		Filename: filename,
 		Handler:  h,
 		Detail:   board,
-		Path:     path,
+		JSONPath: path,
 	}
 	return resource
 }

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -46,7 +46,7 @@ func (h *DatasourceHandler) newDatasourceResource(path, uid, filename string, so
 		Filename: filename,
 		Handler:  h,
 		Detail:   source,
-		Path:     path,
+		JSONPath: path,
 	}
 	return resource
 }

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -138,7 +138,7 @@ func (h *DatasourceHandler) Update(existing, resource grizzly.Resource) error {
 }
 
 // Preview renders Jsonnet then pushes them to the endpoint if previews are possible
-func (h *DatasourceHandler) Preview(resource grizzly.Resource, opts *grizzly.PreviewOpts) error {
+func (h *DatasourceHandler) Preview(resource grizzly.Resource, notifier grizzly.Notifier, opts *grizzly.PreviewOpts) error {
 	return grizzly.ErrNotImplemented
 }
 

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -26,9 +26,13 @@ func (h *DatasourceHandler) GetFullName() string {
 	return "grafana.datasource"
 }
 
-// GetJSONPath returns a paths within Jsonnet output that this provider will consume
-func (h *DatasourceHandler) GetJSONPath() string {
-	return "grafanaDatasources"
+const datasourcesPath = "grafanaDatasources"
+
+// GetJSONPaths returns paths within Jsonnet output that this provider will consume
+func (h *DatasourceHandler) GetJSONPaths() []string {
+	return []string{
+		datasourcesPath,
+	}
 }
 
 // GetExtension returns the file name extension for a datasource
@@ -36,19 +40,19 @@ func (h *DatasourceHandler) GetExtension() string {
 	return "json"
 }
 
-func (h *DatasourceHandler) newDatasourceResource(uid, filename string, source Datasource) grizzly.Resource {
+func (h *DatasourceHandler) newDatasourceResource(path, uid, filename string, source Datasource) grizzly.Resource {
 	resource := grizzly.Resource{
 		UID:      uid,
 		Filename: filename,
 		Handler:  h,
 		Detail:   source,
-		Path:     h.GetJSONPath(),
+		Path:     path,
 	}
 	return resource
 }
 
 // Parse parses an interface{} object into a struct for this resource type
-func (h *DatasourceHandler) Parse(i interface{}) (grizzly.ResourceList, error) {
+func (h *DatasourceHandler) Parse(path string, i interface{}) (grizzly.ResourceList, error) {
 	resources := grizzly.ResourceList{}
 	msi := i.(map[string]interface{})
 	for k, v := range msi {
@@ -69,7 +73,7 @@ func (h *DatasourceHandler) Parse(i interface{}) (grizzly.ResourceList, error) {
 		if err != nil {
 			return nil, err
 		}
-		resource := h.newDatasourceResource(source.UID(), k, source)
+		resource := h.newDatasourceResource(path, source.UID(), k, source)
 		key := resource.Key()
 		resources[key] = resource
 	}
@@ -95,7 +99,7 @@ func (h *DatasourceHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving datasource %s: %v", UID, err)
 	}
-	resource := h.newDatasourceResource(UID, "", *source)
+	resource := h.newDatasourceResource(datasourcesPath, UID, "", *source)
 	return &resource, nil
 }
 
@@ -123,7 +127,7 @@ func (h *DatasourceHandler) GetRemote(uid string) (*grizzly.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
-	resource := h.newDatasourceResource(uid, "", *source)
+	resource := h.newDatasourceResource(datasourcesPath, uid, "", *source)
 	return &resource, nil
 }
 

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -58,7 +58,7 @@ func (h *SyntheticMonitoringHandler) newCheckResource(path string, filename stri
 		Filename: filename,
 		Handler:  h,
 		Detail:   check,
-		Path:     path,
+		JSONPath: path,
 	}
 	return resource
 }

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -144,6 +144,6 @@ func (h *SyntheticMonitoringHandler) Update(existing, resource grizzly.Resource)
 }
 
 // Preview renders Jsonnet then pushes them to the endpoint if previews are possible
-func (h *SyntheticMonitoringHandler) Preview(resource grizzly.Resource, opts *grizzly.PreviewOpts) error {
+func (h *SyntheticMonitoringHandler) Preview(resource grizzly.Resource, notifier grizzly.Notifier, opts *grizzly.PreviewOpts) error {
 	return grizzly.ErrNotImplemented
 }

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -38,9 +38,13 @@ func (h *SyntheticMonitoringHandler) GetFullName() string {
 	return "grafana.synthetic-monitor"
 }
 
-// GetJSONPath returns a paths within Jsonnet output that this provider will consume
-func (h *SyntheticMonitoringHandler) GetJSONPath() string {
-	return "syntheticMonitoring"
+const syntheticMonitoringChecksPath = "syntheticMonitoring"
+
+// GetJSONPaths returns paths within Jsonnet output that this provider will consume
+func (h *SyntheticMonitoringHandler) GetJSONPaths() []string {
+	return []string{
+		syntheticMonitoringChecksPath,
+	}
 }
 
 // GetExtension returns the file name extension for a check
@@ -48,19 +52,19 @@ func (h *SyntheticMonitoringHandler) GetExtension() string {
 	return "json"
 }
 
-func (h *SyntheticMonitoringHandler) newCheckResource(filename string, check Check) grizzly.Resource {
+func (h *SyntheticMonitoringHandler) newCheckResource(path string, filename string, check Check) grizzly.Resource {
 	resource := grizzly.Resource{
 		UID:      check.UID(),
 		Filename: filename,
 		Handler:  h,
 		Detail:   check,
-		Path:     h.GetJSONPath(),
+		Path:     path,
 	}
 	return resource
 }
 
 // Parse parses an interface{} object into a struct for this resource type
-func (h *SyntheticMonitoringHandler) Parse(i interface{}) (grizzly.ResourceList, error) {
+func (h *SyntheticMonitoringHandler) Parse(path string, i interface{}) (grizzly.ResourceList, error) {
 	resources := grizzly.ResourceList{}
 	msi := i.(map[string]interface{})
 	for k, v := range msi {
@@ -69,7 +73,7 @@ func (h *SyntheticMonitoringHandler) Parse(i interface{}) (grizzly.ResourceList,
 		if err != nil {
 			return nil, err
 		}
-		resource := h.newCheckResource(k, check)
+		resource := h.newCheckResource(path, k, check)
 		key := resource.Key()
 		resources[key] = resource
 	}
@@ -98,7 +102,7 @@ func (h *SyntheticMonitoringHandler) GetByUID(UID string) (*grizzly.Resource, er
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving check %s: %v", UID, err)
 	}
-	resource := h.newCheckResource("", *check)
+	resource := h.newCheckResource(syntheticMonitoringChecksPath, "", *check)
 	return &resource, nil
 }
 
@@ -126,7 +130,7 @@ func (h *SyntheticMonitoringHandler) GetRemote(uid string) (*grizzly.Resource, e
 	if err != nil {
 		return nil, err
 	}
-	resource := h.newCheckResource("", *check)
+	resource := h.newCheckResource(syntheticMonitoringChecksPath, "", *check)
 	return &resource, nil
 }
 

--- a/pkg/grizzly/notifier.go
+++ b/pkg/grizzly/notifier.go
@@ -47,16 +47,16 @@ func (n *Notifier) NotSupported(resource Resource, behaviour string) {
 }
 
 // Info announces a message in green
-func (n *Notifier) Info(msg string) {
-	fmt.Println(green(msg))
+func (n *Notifier) Info(resource Resource, msg string) {
+	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, green(msg))
 }
 
-// Warning announces a message in yellow
-func (n *Notifier) Warning(resource Resource, msg string) {
+// Warn announces a message in yellow
+func (n *Notifier) Warn(resource Resource, msg string) {
 	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, yellow(msg))
 }
 
 // Error announces a message in yellow
-func (n *Notifier) Error(msg string) {
-	fmt.Println(red(msg))
+func (n *Notifier) Error(resource Resource, msg string) {
+	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, red(msg))
 }

--- a/pkg/grizzly/notifier.go
+++ b/pkg/grizzly/notifier.go
@@ -17,46 +17,46 @@ type Notifier struct{}
 
 // NoChanges announces that nothing has changed
 func (n *Notifier) NoChanges(resource Resource) {
-	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, yellow("no differences"))
+	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, yellow("no differences"))
 }
 
 // HasChanges announces that a resource has changed, and displays the differences
 func (n *Notifier) HasChanges(resource Resource, diff string) {
-	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, red("changes detected:"))
+	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, red("changes detected:"))
 	fmt.Println(diff)
 }
 
 // NotFound announces that a resource was not found on the remote endpoint
 func (n *Notifier) NotFound(resource Resource) {
-	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, yellow("not present in "+resource.Handler.GetName()))
+	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, yellow("not present in "+resource.Handler.GetName()))
 }
 
 // Added announces that a resource has been added to the remote endpoint
 func (n *Notifier) Added(resource Resource) {
-	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, green("added"))
+	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, green("added"))
 }
 
 // Updated announces that a resource has been updated at the remote endpoint
 func (n *Notifier) Updated(resource Resource) {
-	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, green("updated"))
+	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, green("updated"))
 }
 
 // NotSupported announces that a behaviour is not supported by a handler
 func (n *Notifier) NotSupported(resource Resource, behaviour string) {
-	fmt.Printf("%s/%s %s provider %s\n", resource.Path, resource.UID, resource.Handler.GetName(), red("does not support "+behaviour))
+	fmt.Printf("%s/%s %s provider %s\n", resource.JSONPath, resource.UID, resource.Handler.GetName(), red("does not support "+behaviour))
 }
 
 // Info announces a message in green
 func (n *Notifier) Info(resource Resource, msg string) {
-	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, green(msg))
+	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, green(msg))
 }
 
 // Warn announces a message in yellow
 func (n *Notifier) Warn(resource Resource, msg string) {
-	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, yellow(msg))
+	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, yellow(msg))
 }
 
 // Error announces a message in yellow
 func (n *Notifier) Error(resource Resource, msg string) {
-	fmt.Printf("%s/%s %s\n", resource.Path, resource.UID, red(msg))
+	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, red(msg))
 }

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -86,7 +86,18 @@ type Handler interface {
 	Update(existing, resource Resource) error
 
 	// Preview renders Jsonnet then pushes them to the endpoint if previews are possible
-	Preview(resource Resource, opts *PreviewOpts) error
+	Preview(resource Resource, notifier Notifier, opts *PreviewOpts) error
+}
+
+// MultiResourceHandler describes a handler that can handle multiple resources in one go.
+// This could be because it needs to see all resources before sending, or because the
+// endpoint API supports batching of resources.
+type MultiResourceHandler interface {
+	// Diff compares local resources with remote equivalents and output result
+	Diff(notifier Notifier, resources ResourceList) error
+
+	// Apply local resources to remote endpoint
+	Apply(notifier Notifier, resources ResourceList) error
 }
 
 // Provider describes a single Endpoint Provider

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -55,11 +55,11 @@ type Resources map[Handler]ResourceList
 type Handler interface {
 	GetName() string
 	GetFullName() string
-	GetJSONPath() string
+	GetJSONPaths() []string
 	GetExtension() string
 
 	// Parse parses an interface{} object into a struct for this resource type
-	Parse(i interface{}) (ResourceList, error)
+	Parse(path string, i interface{}) (ResourceList, error)
 
 	// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 	Unprepare(resource Resource) *Resource
@@ -129,7 +129,9 @@ func (r *Registry) RegisterProvider(provider Provider) error {
 	r.Providers = append(r.Providers, provider)
 	for _, handler := range provider.GetHandlers() {
 		r.Handlers = append(r.Handlers, handler)
-		r.HandlerByPath[handler.GetJSONPath()] = handler
+		for _, path := range handler.GetJSONPaths() {
+			r.HandlerByPath[path] = handler
+		}
 		r.HandlerByName[handler.GetName()] = handler
 		r.HandlerByName[handler.GetFullName()] = handler
 	}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -8,7 +8,7 @@ type Resource struct {
 	Filename string      `json:"filename"`
 	Handler  Handler     `json:"handler"`
 	Detail   interface{} `json:"detail"`
-	Path     string      `json:"path"`
+	JSONPath string      `json:"path"`
 }
 
 // Kind returns the 'kind' of the resource, i.e. the type of the provider

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -83,8 +83,9 @@ func getPrivateElementsScript(jsonnetFile string, handlers []Handler) string {
 	`
 	handlerStrings := []string{}
 	for _, handler := range handlers {
-		jsonPath := handler.GetJSONPath()
-		handlerStrings = append(handlerStrings, fmt.Sprintf("  %s+::: {},", jsonPath))
+		for _, jsonPath := range handler.GetJSONPaths() {
+			handlerStrings = append(handlerStrings, fmt.Sprintf("  %s+::: {},", jsonPath))
+		}
 	}
 	return fmt.Sprintf(script, jsonnetFile, strings.Join(handlerStrings, "\n"))
 }
@@ -114,7 +115,7 @@ func Parse(config Config, jsonnetFile string, targets []string) (Resources, erro
 			fmt.Println("Skipping unregistered path", k)
 			continue
 		}
-		handlerResources, err := handler.Parse(v)
+		handlerResources, err := handler.Parse(k, v)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -255,8 +255,7 @@ func Preview(config Config, resources Resources, opts *PreviewOpts) error {
 			err := handler.Preview(resource, config.Notifier, opts)
 			if err == ErrNotImplemented {
 				config.Notifier.NotSupported(resource, "preview")
-			}
-			if err != nil {
+			} else if err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
A "multi-resource-handler" is one that accepts all its resources in one go.

Default Grizzly behaviour is to handle resources one at a time, so that the handler does not need to worry about exactly how a diff is evaluated. In most cases, this is fine. However, some handlers require access to all resources in one go. Example cases include:

 * when an API has a batch mode, meaning multiple resources can be delivered to the API server in a single request, making the handler more efficient
 * when a handler processed hierarchical resources, e.g. dashboards and dashboard folders. If the dashboard folder needs to be processed before the dashboard, this allows the handler to deal with this internally. Grizzly just says "here's your resources, do a `diff`, or do an `apply`.