### PR TITLE
Support old style grafana folders

### DIFF
--- a/foo.txt
+++ b/foo.txt
@@ -1,4 +1,0 @@
-this
-that
-the
-other

--- a/foo.txt
+++ b/foo.txt
@@ -1,0 +1,4 @@
+this
+that
+the
+other

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -72,7 +72,7 @@ func (h *DashboardHandler) newDashboardFolderResource(path, folderName string) g
 		Filename: folderName,
 		Handler:  h,
 		Detail:   "",
-		Path:     path,
+		JSONPath: path,
 	}
 	return resource
 }
@@ -108,7 +108,7 @@ func (h *DashboardHandler) Diff(notifier grizzly.Notifier, resources grizzly.Res
 		dashboardFolder = dashboardFolderResource.Filename
 	}
 	for _, resource := range resources {
-		if resource.Path == dashboardFolderPath {
+		if resource.JSONPath == dashboardFolderPath {
 			continue
 		}
 		resource = dashboardWithFolderSet(resource, dashboardFolder)
@@ -150,12 +150,11 @@ func (h *DashboardHandler) Apply(notifier grizzly.Notifier, resources grizzly.Re
 		dashboardFolder = dashboardFolderResource.Filename
 	}
 	for _, resource := range resources {
-		if resource.Path == dashboardFolderPath {
+		if resource.JSONPath == dashboardFolderPath {
 			continue
 		}
 		existingResource, err := h.GetRemote(resource.UID)
 		if err == grizzly.ErrNotFound {
-
 			err := h.Add(resource)
 			if err != nil {
 				return err

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/kylelemons/godebug/diff"
@@ -14,6 +15,8 @@ import (
  * This will be removed from the JSON, and if no folder exists, a dashboard folder
  * will be created with UID and title matching your `folderName`.
  *
+ * Alternatively, create a `grafanaDashboardFolder` root element in your Jsonnet. This
+ * value will be used as a folder name for all of your dashboards.
  */
 
 // DashboardHandler is a Grizzly Provider for Grafana dashboards
@@ -63,9 +66,26 @@ func (h *DashboardHandler) newDashboardResource(path, uid, filename string, boar
 	return resource
 }
 
+func (h *DashboardHandler) newDashboardFolderResource(path, folderName string) grizzly.Resource {
+	resource := grizzly.Resource{
+		UID:      folderName,
+		Filename: folderName,
+		Handler:  h,
+		Detail:   "",
+		Path:     path,
+	}
+	return resource
+}
+
 // Parse parses an interface{} object into a struct for this resource type
 func (h *DashboardHandler) Parse(path string, i interface{}) (grizzly.ResourceList, error) {
 	resources := grizzly.ResourceList{}
+	if path == dashboardFolderPath {
+		folderName := strings.ReplaceAll(i.(string), "{ }", "") // No idea why json parsing adds { } to the end of the parsed string :-(
+		resource := h.newDashboardFolderResource(path, folderName)
+		resources[dashboardFolderPath] = resource
+		return resources, nil
+	}
 	msi := i.(map[string]interface{})
 	for k, v := range msi {
 		board := Dashboard{}
@@ -82,7 +102,16 @@ func (h *DashboardHandler) Parse(path string, i interface{}) (grizzly.ResourceLi
 
 // Diff compares local resources with remote equivalents and output result
 func (h *DashboardHandler) Diff(notifier grizzly.Notifier, resources grizzly.ResourceList) error {
+	dashboardFolder := "general"
+	dashboardFolderResource, ok := resources[dashboardFolderPath]
+	if ok {
+		dashboardFolder = dashboardFolderResource.Filename
+	}
 	for _, resource := range resources {
+		if resource.Path == dashboardFolderPath {
+			continue
+		}
+		resource = dashboardWithFolderSet(resource, dashboardFolder)
 		local, err := resource.GetRepresentation()
 		if err != nil {
 			return nil
@@ -115,7 +144,15 @@ func (h *DashboardHandler) Diff(notifier grizzly.Notifier, resources grizzly.Res
 
 // Apply local resources to remote endpoint
 func (h *DashboardHandler) Apply(notifier grizzly.Notifier, resources grizzly.ResourceList) error {
+	dashboardFolder := "general"
+	dashboardFolderResource, ok := resources[dashboardFolderPath]
+	if ok {
+		dashboardFolder = dashboardFolderResource.Filename
+	}
 	for _, resource := range resources {
+		if resource.Path == dashboardFolderPath {
+			continue
+		}
 		existingResource, err := h.GetRemote(resource.UID)
 		if err == grizzly.ErrNotFound {
 
@@ -128,6 +165,7 @@ func (h *DashboardHandler) Apply(notifier grizzly.Notifier, resources grizzly.Re
 		} else if err != nil {
 			return err
 		}
+		resource = dashboardWithFolderSet(resource, dashboardFolder)
 		resourceRepresentation, err := resource.GetRepresentation()
 		if err != nil {
 			return err

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -245,7 +245,7 @@ func (f *Folder) toJSON() (string, error) {
 }
 
 func findOrCreateFolder(UID string) (int64, error) {
-	if UID == "0" {
+	if UID == "0" || UID == "" {
 		return 0, nil
 	}
 	grafanaURL, err := getGrafanaURL("api/folders/" + UID)

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -12,6 +12,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const folderNameField = "folderName"
+
 // getRemoteDashboard retrieves a dashboard object from Grafana
 func getRemoteDashboard(uid string) (*Dashboard, error) {
 	grafanaURL, err := getGrafanaURL("api/dashboards/uid/" + uid)
@@ -45,7 +47,7 @@ func getRemoteDashboard(uid string) (*Dashboard, error) {
 	}
 	delete(d.Dashboard, "id")
 	delete(d.Dashboard, "version")
-	d.Dashboard["folderName"] = d.Meta.FolderTitle
+	d.Dashboard[folderNameField] = d.Meta.FolderTitle
 	return &d.Dashboard, nil
 }
 
@@ -60,7 +62,7 @@ func postDashboard(board Dashboard) error {
 	if err != nil {
 		return err
 	}
-	delete(board, "folderName")
+	delete(board, folderNameField)
 	wrappedBoard := DashboardWrapper{
 		Dashboard: board,
 		FolderID:  folderID,
@@ -178,6 +180,16 @@ func (d *Dashboard) folderUID() string {
 		return folderUID.(string)
 	}
 	return ""
+}
+
+func dashboardWithFolderSet(resource grizzly.Resource, dashboardFolder string) grizzly.Resource {
+	board := newDashboard(resource)
+	_, ok := board[folderNameField]
+	if !ok {
+		board[folderNameField] = dashboardFolder
+	}
+	resource.Detail = board
+	return resource
 }
 
 // DashboardWrapper adds wrapper to a dashboard JSON. Caters both for Grafana's POST

--- a/testdata/dashboard-simple.libsonnet
+++ b/testdata/dashboard-simple.libsonnet
@@ -1,10 +1,9 @@
 {
-  grafanaDashboardFolder: 'grizzly',
+  grafanaDashboardFolder: 'sample',
   grafanaDashboards+:: {
     'my-dash.json': {
       uid: 'prod-overview',
       title: 'Production Overview',
-      folderName: 'sample',
       tags: ['templated'],
       timezone: 'browser',
       schemaVersion: 17,


### PR DESCRIPTION
Now that we have support for multi-resource handlers, we can implement logic to give us back old-style Grafana folder support.

With this, the dashboard handler can receive resources under both `grafanaDashboards` as well as `grafanaDashboardFolder`. Given that the handler is handed all of these resources in one go, before processing the resources, it can check if it has a `grafanaDashboardFolder` element, and if it does, it can set the folder name for all dashboards. In fact, it only does this if the dashboard does not already have a `folderName` set.

This makes Grizzly ready for a release.