### PR TITLE
watch-resource action, for live updating dashboards

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -38,7 +38,7 @@ func main() {
 		diffCmd(config),
 		applyCmd(config),
 		watchCmd(config),
-		watchResourceCmd(config),
+		listenCmd(config),
 		exportCmd(config),
 		previewCmd(config),
 		providersCmd(config),

--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -38,6 +38,7 @@ func main() {
 		diffCmd(config),
 		applyCmd(config),
 		watchCmd(config),
+		watchResourceCmd(config),
 		exportCmd(config),
 		previewCmd(config),
 		providersCmd(config),

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -128,16 +128,16 @@ func watchCmd(config grizzly.Config) *cli.Command {
 	return cmd
 }
 
-func watchResourceCmd(config grizzly.Config) *cli.Command {
+func listenCmd(config grizzly.Config) *cli.Command {
 	cmd := &cli.Command{
-		Use:   "watch-resource <uid-to-watch> <output-file>",
-		Short: "watch for file changes on remove and save locally",
+		Use:   "listen <uid-to-watch> <output-file>",
+		Short: "listen for file changes on remove and save locally",
 		Args:  cli.ArgsExact(2),
 	}
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		uid := args[0]
 		filename := args[1]
-		return grizzly.WatchResource(config, uid, filename)
+		return grizzly.Listen(config, uid, filename)
 	}
 	return cmd
 }

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -128,6 +128,20 @@ func watchCmd(config grizzly.Config) *cli.Command {
 	return cmd
 }
 
+func watchResourceCmd(config grizzly.Config) *cli.Command {
+	cmd := &cli.Command{
+		Use:   "watch-resource <uid-to-watch> <output-file>",
+		Short: "watch for file changes on remove and save locally",
+		Args:  cli.ArgsExact(2),
+	}
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		uid := args[0]
+		filename := args[1]
+		return grizzly.WatchResource(config, uid, filename)
+	}
+	return cmd
+}
+
 func previewCmd(config grizzly.Config) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "preview <jsonnet-file>",

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -131,7 +131,7 @@ func watchCmd(config grizzly.Config) *cli.Command {
 func listenCmd(config grizzly.Config) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "listen <uid-to-watch> <output-file>",
-		Short: "listen for file changes on remove and save locally",
+		Short: "listen for file changes on remote and save locally",
 		Args:  cli.ArgsExact(2),
 	}
 	cmd.Run = func(cmd *cli.Command, args []string) error {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/grizzly
 go 1.13
 
 require (
+	github.com/centrifugal/centrifuge-go v0.6.2
 	github.com/cortexproject/cortex v1.2.0
 	github.com/fatih/color v1.9.0
 	github.com/gdamore/tcell v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,10 @@ github.com/cenkalti/backoff v0.0.0-20181003080854-62661b46c409/go.mod h1:90ReRw6
 github.com/cenkalti/backoff v1.0.0/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/centrifugal/centrifuge-go v0.6.2 h1:vYdrvuuU9C8ETGRa7CMcA1ZAW5f4teFyygYJIlwSMjM=
+github.com/centrifugal/centrifuge-go v0.6.2/go.mod h1:YW9BKhnEMOBPU7C/wfqdqzhIiF0xRd0R4sHW82a7sf8=
+github.com/centrifugal/protocol v0.3.4 h1:9q22iSp4CQOdQahfopvfmWWxDbj1Lo7ERG2j56mAxkE=
+github.com/centrifugal/protocol v0.3.4/go.mod h1:2YbBCaDwQHl37ErRdMrKSj18X2yVvpkQYtSX6aVbe5A=
 github.com/cespare/xxhash v0.0.0-20181017004759-096ff4a8a059/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -372,6 +376,7 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/status v1.0.3/go.mod h1:SavQ51ycCLnc7dGyJxp8YAmudx8xqiVrRf+6IXRsugc=
 github.com/golang-migrate/migrate/v4 v4.7.0/go.mod h1:Qvut3N4xKWjoH3sokBccML6WyHSnggXm/DvMMnTsQIc=
@@ -457,6 +462,8 @@ github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=
@@ -541,6 +548,7 @@ github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/jsimonetti/rtnetlink v0.0.0-20190830100107-3784a6c7c552/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=

--- a/pkg/grafana/config.go
+++ b/pkg/grafana/config.go
@@ -27,30 +27,33 @@ func getGrafanaURL(urlPath string) (string, error) {
 }
 
 func getWSGrafanaURL(urlPath string) (string, string, error) {
-	if grafanaURL, exists := os.LookupEnv("GRAFANA_URL"); exists {
-		u, err := url.Parse(grafanaURL)
-		if err != nil {
-			return "", "", err
-		}
-		if u.Scheme == "https" {
-			u.Scheme = "wss"
-		} else {
-			u.Scheme = "ws"
-		}
-		u.Path = path.Join(u.Path, urlPath)
-		grafanaURL = u.String()
-		if token, exists := os.LookupEnv("GRAFANA_TOKEN"); exists {
-			u.User = nil
-			return u.String(), token, nil
-		} else if u.User != nil {
-			token, ok := u.User.Password()
-			if ok {
-				u.User = nil
-				return u.String(), token, nil
-			}
+	grafanaURL, exists := os.LookupEnv("GRAFANA_URL")
+	if !exists {
+		return "", "", fmt.Errorf("Require GRAFANA_URL (optionally GRAFANA_TOKEN if auth required) for websocket actions")
+	}
+	u, err := url.Parse(grafanaURL)
+	if err != nil {
+		return "", "", err
+	}
+	if u.Scheme == "https" {
+		u.Scheme = "wss"
+	} else {
+		u.Scheme = "ws"
+	}
+	u.Path = path.Join(u.Path, urlPath)
+	grafanaURL = u.String()
+	token, ok := os.LookupEnv("GRAFANA_TOKEN")
+	if ok {
+		u.User = nil
+		return u.String(), token, nil
+	}
+	if u.User != nil {
+		token, ok := u.User.Password()
+		if !ok {
 			return u.String(), "", nil
 		}
-		return u.String(), "", nil
+		u.User = nil
+		return u.String(), token, nil
 	}
-	return "", "", fmt.Errorf("Require GRAFANA_URL (optionally GRAFANA_TOKEN if auth required) for websocket actions")
+	return u.String(), "", nil
 }

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -272,7 +272,7 @@ func (h *DashboardHandler) Preview(resource grizzly.Resource, notifier grizzly.N
 	return nil
 }
 
-// WatchResource watches a resource and update local file on changes
-func (h *DashboardHandler) WatchResource(notifier grizzly.Notifier, UID, filename string) error {
+// Listen watches a resource and updates local file on changes
+func (h *DashboardHandler) Listen(notifier grizzly.Notifier, UID, filename string) error {
 	return watchDashboard(notifier, UID, filename)
 }

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -264,10 +264,10 @@ func (h *DashboardHandler) Preview(resource grizzly.Resource, notifier grizzly.N
 	if err != nil {
 		return err
 	}
-	notifier.Info(resource, "view: "+s.URL)
-	notifier.Error(resource, "delete: "+s.DeleteURL)
+	notifier.Info(&resource, "view: "+s.URL)
+	notifier.Error(&resource, "delete: "+s.DeleteURL)
 	if opts.ExpiresSeconds > 0 {
-		notifier.Warn(resource, fmt.Sprintf("Previews will expire and be deleted automatically in %d seconds\n", opts.ExpiresSeconds))
+		notifier.Warn(&resource, fmt.Sprintf("Previews will expire and be deleted automatically in %d seconds\n", opts.ExpiresSeconds))
 	}
 	return nil
 }

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -271,3 +271,8 @@ func (h *DashboardHandler) Preview(resource grizzly.Resource, notifier grizzly.N
 	}
 	return nil
 }
+
+// WatchResource watches a resource and update local file on changes
+func (h *DashboardHandler) WatchResource(notifier grizzly.Notifier, UID, filename string) error {
+	return watchDashboard(notifier, UID, filename)
+}

--- a/pkg/grafana/dashboard-watcher.go
+++ b/pkg/grafana/dashboard-watcher.go
@@ -1,0 +1,139 @@
+package grafana
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"github.com/centrifugal/centrifuge-go"
+	"github.com/grafana/grizzly/pkg/grizzly"
+)
+
+type eventHandler struct {
+	filename string
+}
+
+func (h *eventHandler) OnConnect(c *centrifuge.Client, e centrifuge.ConnectEvent) {
+	log.Printf("Connected to chat with ID %s", e.ClientID)
+	return
+}
+
+func (h *eventHandler) OnError(c *centrifuge.Client, e centrifuge.ErrorEvent) {
+	log.Printf("Error: %s", e.Message)
+	return
+}
+
+func (h *eventHandler) OnDisconnect(c *centrifuge.Client, e centrifuge.DisconnectEvent) {
+	log.Printf("Disconnected from chat: %s", e.Reason)
+	return
+}
+func (h *eventHandler) OnSubscribeSuccess(sub *centrifuge.Subscription, e centrifuge.SubscribeSuccessEvent) {
+	log.Printf("Subscribed on channel %s, resubscribed: %v, recovered: %v", sub.Channel(), e.Resubscribed, e.Recovered)
+}
+
+func (h *eventHandler) OnSubscribeError(sub *centrifuge.Subscription, e centrifuge.SubscribeErrorEvent) {
+	log.Printf("Subscribed on channel %s failed, error: %s", sub.Channel(), e.Error)
+}
+
+func (h *eventHandler) OnUnsubscribe(sub *centrifuge.Subscription, e centrifuge.UnsubscribeEvent) {
+	log.Printf("Unsubscribed from channel %s", sub.Channel())
+}
+
+func (h *eventHandler) OnMessage(_ *centrifuge.Client, e centrifuge.MessageEvent) {
+	log.Printf("Message from server: %s", string(e.Data))
+}
+func (h *eventHandler) OnServerPublish(c *centrifuge.Client, e centrifuge.ServerPublishEvent) {
+	log.Printf("Publication from server-side channel %s: %s", e.Channel, e.Data)
+}
+func (h *eventHandler) OnServerSubscribe(_ *centrifuge.Client, e centrifuge.ServerSubscribeEvent) {
+	log.Printf("Subscribe to server-side channel %s: (resubscribe: %t, recovered: %t)", e.Channel, e.Resubscribed, e.Recovered)
+}
+
+func (h *eventHandler) OnServerUnsubscribe(_ *centrifuge.Client, e centrifuge.ServerUnsubscribeEvent) {
+	log.Printf("Unsubscribe from server-side channel %s", e.Channel)
+}
+
+func (h *eventHandler) OnServerJoin(_ *centrifuge.Client, e centrifuge.ServerJoinEvent) {
+	log.Printf("Server-side join to channel %s: %s (%s)", e.Channel, e.User, e.Client)
+}
+
+func (h *eventHandler) OnServerLeave(_ *centrifuge.Client, e centrifuge.ServerLeaveEvent) {
+	log.Printf("Server-side leave from channel %s: %s (%s)", e.Channel, e.User, e.Client)
+}
+
+func (h *eventHandler) OnPublish(sub *centrifuge.Subscription, e centrifuge.PublishEvent) {
+	response := struct {
+		UID    string `json:"uid"`
+		Action string `json:"action"`
+		UserID int64  `json:"userId"`
+	}{}
+	err := json.Unmarshal(e.Data, &response)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	if response.Action != "saved" {
+		log.Println("Unknown action received", string(e.Data))
+	}
+	dashboard, err := getRemoteDashboard(response.UID)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	dashboardJSON, err := dashboard.toJSON()
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	ioutil.WriteFile(h.filename, []byte(dashboardJSON), 0644)
+	log.Printf("%s updated from dashboard %s", h.filename, response.UID)
+}
+
+func watchDashboard(notifier grizzly.Notifier, UID, filename string) error {
+	wsURL, token, err := getWSGrafanaURL("live/ws?format=json")
+	if err != nil {
+		return err
+	}
+	//mt.Sprintf("ws://%s/live/ws?format=protobuf"
+	log.Printf("Connect to %s\n", wsURL)
+
+	c := centrifuge.New(wsURL, centrifuge.DefaultConfig())
+	handler := &eventHandler{
+		filename: filename,
+	}
+	c.OnConnect(handler)
+	c.OnError(handler)
+	c.OnDisconnect(handler)
+	c.OnMessage(handler)
+	c.OnServerPublish(handler)
+	c.OnServerSubscribe(handler)
+	c.OnServerUnsubscribe(handler)
+	c.OnServerJoin(handler)
+	c.OnServerLeave(handler)
+	c.SetToken(token)
+
+	channel := fmt.Sprintf("grafana/dashboard/%s", UID)
+	sub, err := c.NewSubscription(channel)
+	if err != nil {
+		return err
+	}
+
+	sub.OnSubscribeSuccess(handler)
+	sub.OnSubscribeError(handler)
+	sub.OnUnsubscribe(handler)
+	sub.OnPublish(handler)
+
+	err = sub.Subscribe()
+	if err != nil {
+		return err
+	}
+
+	err = c.Connect()
+	if err != nil {
+		return err
+	}
+
+	// Run until CTRL+C.
+	select {}
+}

--- a/pkg/grafana/dashboard-watcher.go
+++ b/pkg/grafana/dashboard-watcher.go
@@ -20,18 +20,15 @@ type eventHandler struct {
 
 func (h *eventHandler) OnConnect(c *centrifuge.Client, e centrifuge.ConnectEvent) {
 	log.Println("Connected to", h.url)
-	return
 }
 
 func (h *eventHandler) OnError(c *centrifuge.Client, e centrifuge.ErrorEvent) {
 	log.Printf("Error: %s", e.Message)
-	return
 }
 
 func (h *eventHandler) OnDisconnect(c *centrifuge.Client, e centrifuge.DisconnectEvent) {
 	log.Println("Disconnected from", h.url)
 	h.stop = true
-	return
 }
 func (h *eventHandler) OnSubscribeSuccess(sub *centrifuge.Subscription, e centrifuge.SubscribeSuccessEvent) {
 	log.Printf("Subscribed to channel %s, resubscribed: %v, recovered: %v", sub.Channel(), e.Resubscribed, e.Recovered)

--- a/pkg/grizzly/notifier.go
+++ b/pkg/grizzly/notifier.go
@@ -47,16 +47,28 @@ func (n *Notifier) NotSupported(resource Resource, behaviour string) {
 }
 
 // Info announces a message in green
-func (n *Notifier) Info(resource Resource, msg string) {
-	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, green(msg))
+func (n *Notifier) Info(resource *Resource, msg string) {
+	if resource == nil {
+		fmt.Println(green(msg))
+	} else {
+		fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, green(msg))
+	}
 }
 
 // Warn announces a message in yellow
-func (n *Notifier) Warn(resource Resource, msg string) {
-	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, yellow(msg))
+func (n *Notifier) Warn(resource *Resource, msg string) {
+	if resource == nil {
+		fmt.Println(yellow(msg))
+	} else {
+		fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, yellow(msg))
+	}
 }
 
 // Error announces a message in yellow
-func (n *Notifier) Error(resource Resource, msg string) {
-	fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, red(msg))
+func (n *Notifier) Error(resource *Resource, msg string) {
+	if resource == nil {
+		fmt.Println(red(msg))
+	} else {
+		fmt.Printf("%s/%s %s\n", resource.JSONPath, resource.UID, red(msg))
+	}
 }

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -100,11 +100,11 @@ type MultiResourceHandler interface {
 	Apply(notifier Notifier, resources ResourceList) error
 }
 
-// WatchResourceHandler describes a handler that has the ability to watch a single
+// ListenHandler describes a handler that has the ability to watch a single
 // resource for changes, and write changes to that resource to a local file
-type WatchResourceHandler interface {
-	// WatchResource watches a resource and update local file on changes
-	WatchResource(notifier Notifier, UID, filename string) error
+type ListenHandler interface {
+	// Listen watches a resource and update local file on changes
+	Listen(notifier Notifier, UID, filename string) error
 }
 
 // Provider describes a single Endpoint Provider

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -100,6 +100,13 @@ type MultiResourceHandler interface {
 	Apply(notifier Notifier, resources ResourceList) error
 }
 
+// WatchResourceHandler describes a handler that has the ability to watch a single
+// resource for changes, and write changes to that resource to a local file
+type WatchResourceHandler interface {
+	// WatchResource watches a resource and update local file on changes
+	WatchResource(notifier Notifier, UID, filename string) error
+}
+
 // Provider describes a single Endpoint Provider
 type Provider interface {
 	GetName() string

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -316,6 +316,40 @@ func Watch(config Config, watchDir string, parser Parser) error {
 	return nil
 }
 
+// WatchResource waits for remote changes to a resource and saves them to disk
+func WatchResource(config Config, UID, filename string) error {
+	count := strings.Count(UID, ".")
+	var handlerName, resourceID string
+	if count == 1 {
+		parts := strings.SplitN(UID, ".", 2)
+		handlerName = parts[0]
+		resourceID = parts[1]
+	} else if count == 2 {
+		parts := strings.SplitN(UID, ".", 3)
+		handlerName = parts[0] + "." + parts[1]
+		resourceID = parts[2]
+
+	} else {
+		return fmt.Errorf("UID must be <provider>.<uid>: %s", UID)
+	}
+
+	handler, err := config.Registry.GetHandler(handlerName)
+	if err != nil {
+		return err
+	}
+	watchResourceHandler, ok := handler.(WatchResourceHandler)
+	if !ok {
+		tmpResource := Resource{
+			JSONPath: "",
+			UID:      resourceID,
+			Handler:  handler,
+		}
+		config.Notifier.NotSupported(tmpResource, "watch-resource")
+		return nil
+	}
+	return watchResourceHandler.WatchResource(config.Notifier, resourceID, filename)
+}
+
 // Export renders Jsonnet resources then saves them to a directory
 func Export(config Config, exportDir string, resources Resources) error {
 	if _, err := os.Stat(exportDir); os.IsNotExist(err) {

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -316,8 +316,8 @@ func Watch(config Config, watchDir string, parser Parser) error {
 	return nil
 }
 
-// WatchResource waits for remote changes to a resource and saves them to disk
-func WatchResource(config Config, UID, filename string) error {
+// Listen waits for remote changes to a resource and saves them to disk
+func Listen(config Config, UID, filename string) error {
 	count := strings.Count(UID, ".")
 	var handlerName, resourceID string
 	if count == 1 {
@@ -337,7 +337,7 @@ func WatchResource(config Config, UID, filename string) error {
 	if err != nil {
 		return err
 	}
-	watchResourceHandler, ok := handler.(WatchResourceHandler)
+	listenHandler, ok := handler.(ListenHandler)
 	if !ok {
 		tmpResource := Resource{
 			JSONPath: "",
@@ -347,7 +347,7 @@ func WatchResource(config Config, UID, filename string) error {
 		config.Notifier.NotSupported(tmpResource, "watch-resource")
 		return nil
 	}
-	return watchResourceHandler.WatchResource(config.Notifier, resourceID, filename)
+	return listenHandler.Listen(config.Notifier, resourceID, filename)
 }
 
 // Export renders Jsonnet resources then saves them to a directory


### PR DESCRIPTION
Grafana 7.3 includes (behind a feature flag) support for live updating of saved dashboards. When a dashboard is saved somewhere, all open dashboards are reloaded.

This feature piggy-backs on that: when invoked, Grizzly connects to a web socket on the remote Grafana instance. It then waits. When a dashboard is saved, it receives a notification, retrieves the dashboard JSON and writes it to a local file.

For a dashboard with a UID `useful-dashboard` Syntax could be:

```
grr watch-resource dashboard.useful-dashboard dashboard.json
```

The principal usecase for this feature is when working on a dashboard that is managed in version control. If we first use `grr apply` to push our dashboard up to Grafana, then use `grr watch-resource` to spot changes, we can now effectively use Grafana itself as a dashboard IDE - dashboard saves are written directly back to the file system where they can be committed back to version control.

Still to do:

- [x] Give useful error message if Grafana instance doesn't have the ws feature flag enabled
- [x] Are all of the event types needed? They were copied wholesale from example code - review is needed.
- [x] Stop listening (end program) if subscription ends, or Grafana disappears
- [ ] Document the feature

Beyond this, given that this feature is not jsonnet specific, it could easily be a part of a more generic `grafanactl` tool, that Grizzly could consume. Grizzly could (relatively) easily be split into a Jsonnet processor and a `grafanactl` tool that could focus simply on lifecycle of static resources.