### PR TITLE
Check for missing uid on dashboard

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -99,6 +99,16 @@ func (h *DashboardHandler) Parse(path string, i interface{}) (grizzly.ResourceLi
 		key := resource.Key()
 		resources[key] = resource
 	}
+	// check uids missing
+	var missing ErrUidsMissing
+	for _, resource := range resources {
+		if resource.UID == "" {
+			missing = append(missing, resource.Filename)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, missing
+	}
 	return resources, nil
 }
 


### PR DESCRIPTION
Somewhere along the line we lost the check for missing UIDs, meaning some dashboards fail silently. This fixes that, causing Grizzly to give a meaningful error.