### PR TITLE
Fix when general folder in use

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -38,8 +38,9 @@ func (h *DashboardHandler) GetFullName() string {
 }
 
 const (
-	dashboardsPath      = "grafanaDashboards"
-	dashboardFolderPath = "grafanaDashboardFolder"
+	dashboardsPath         = "grafanaDashboards"
+	dashboardFolderPath    = "grafanaDashboardFolder"
+	dashboardFolderDefault = "General"
 )
 
 // GetJSONPaths returns paths within Jsonnet output that this provider will consume
@@ -104,7 +105,7 @@ func (h *DashboardHandler) Parse(path string, i interface{}) (grizzly.ResourceLi
 
 // Diff compares local resources with remote equivalents and output result
 func (h *DashboardHandler) Diff(notifier grizzly.Notifier, resources grizzly.ResourceList) error {
-	dashboardFolder := "general"
+	dashboardFolder := dashboardFolderDefault
 	dashboardFolderResource, ok := resources[dashboardFolderPath]
 	if ok {
 		dashboardFolder = dashboardFolderResource.Filename
@@ -146,7 +147,7 @@ func (h *DashboardHandler) Diff(notifier grizzly.Notifier, resources grizzly.Res
 
 // Apply local resources to remote endpoint
 func (h *DashboardHandler) Apply(notifier grizzly.Notifier, resources grizzly.ResourceList) error {
-	dashboardFolder := "general"
+	dashboardFolder := dashboardFolderDefault
 	dashboardFolderResource, ok := resources[dashboardFolderPath]
 	if ok {
 		dashboardFolder = dashboardFolderResource.Filename

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -235,7 +235,7 @@ func (f *Folder) toJSON() (string, error) {
 }
 
 func findOrCreateFolder(UID string) (int64, error) {
-	if UID == "0" || UID == "" {
+	if UID == "0" || UID == "" || UID == dashboardFolderDefault {
 		return 0, nil
 	}
 	grafanaURL, err := getGrafanaURL("api/folders/" + UID)

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -209,7 +209,10 @@ func Apply(config Config, resources Resources) error {
 	for handler, resourceList := range resources {
 		if isMultiResource(handler) {
 			multiHandler := handler.(MultiResourceHandler)
-			multiHandler.Apply(config.Notifier, resourceList)
+			err := multiHandler.Apply(config.Notifier, resourceList)
+			if err != nil {
+				return err
+			}
 			continue
 		}
 		for _, resource := range resourceList {


### PR DESCRIPTION
(a) when calling `multiResourceHandler.Apply()`, the returned error was dropped
(b) The UID for the general folder is actually 'General' not 0 as we use names for folders