### PR TITLE
Add PreviewHandler resource type

### DIFF
--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -141,11 +141,6 @@ func (h *DatasourceHandler) Update(existing, resource grizzly.Resource) error {
 	return putDatasource(newDatasource(resource))
 }
 
-// Preview renders Jsonnet then pushes them to the endpoint if previews are possible
-func (h *DatasourceHandler) Preview(resource grizzly.Resource, notifier grizzly.Notifier, opts *grizzly.PreviewOpts) error {
-	return grizzly.ErrNotImplemented
-}
-
 func (h *DatasourceHandler) delete(resource grizzly.Resource, key string) {
 	delete(resource.Detail.(Datasource), key)
 }

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -146,8 +146,3 @@ func (h *SyntheticMonitoringHandler) Update(existing, resource grizzly.Resource)
 	url := getURL("api/v1/check/update")
 	return postCheck(url, check)
 }
-
-// Preview renders Jsonnet then pushes them to the endpoint if previews are possible
-func (h *SyntheticMonitoringHandler) Preview(resource grizzly.Resource, notifier grizzly.Notifier, opts *grizzly.PreviewOpts) error {
-	return grizzly.ErrNotImplemented
-}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -84,9 +84,6 @@ type Handler interface {
 
 	// Update pushes an existing resource to the endpoint
 	Update(existing, resource Resource) error
-
-	// Preview renders Jsonnet then pushes them to the endpoint if previews are possible
-	Preview(resource Resource, notifier Notifier, opts *PreviewOpts) error
 }
 
 // MultiResourceHandler describes a handler that can handle multiple resources in one go.
@@ -98,6 +95,13 @@ type MultiResourceHandler interface {
 
 	// Apply local resources to remote endpoint
 	Apply(notifier Notifier, resources ResourceList) error
+}
+
+// PreviewHandler describes a handler that has the ability to render
+// a preview of a resource
+type PreviewHandler interface {
+	// Preview renders Jsonnet then pushes them to the endpoint if previews are possible
+	Preview(resource Resource, notifier Notifier, opts *PreviewOpts) error
 }
 
 // ListenHandler describes a handler that has the ability to watch a single

--- a/pkg/prometheus/rules-handler.go
+++ b/pkg/prometheus/rules-handler.go
@@ -128,8 +128,3 @@ func (h *RuleHandler) Update(existing, resource grizzly.Resource) error {
 	g := resource.Detail.(RuleGroup)
 	return writeRuleGroup(g)
 }
-
-// Preview renders Jsonnet then pushes them to the endpoint if previews are possible
-func (h *RuleHandler) Preview(resource grizzly.Resource, notifier grizzly.Notifier, opts *grizzly.PreviewOpts) error {
-	return grizzly.ErrNotImplemented
-}


### PR DESCRIPTION
Since implementing Preview, we have found a better pattern: have a `XXXXHandler` type that implements a behaviour, and check if a handler implements it. This removes the necessity for all handlers to implement 'go away' functions for something that only one handler actually implements.

This PR moves Preview to this new pattern, and fixes a naming issue (`watch-resource`->`listen`) while we're at it.