### PR TITLE
Use synthetic monitoring api/v1/register/install for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To interact with Grafana Synthetic Monitoring, you must have these environment v
 
 | Name | Description | Required |
 | --- | --- | --- |
-| `GRAFANA_SM_TOKEN` | Authentication token/api key | true |
+| `GRAFANA_SM_TOKEN` | Authentication token/api key (must have MetricsPublisher permissions) | true |
 | `GRAFANA_SM_STACK_ID` | Grafana instance/stack ID | true |
 | `GRAFANA_SM_LOGS_ID` | Metrics instance ID | true |
 | `GRAFANA_SM_METRICS_ID` | Logs instance ID | true |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ To interact with Grafana Synthetic Monitoring, you must have these environment v
 | Name | Description | Required |
 | --- | --- | --- |
 | `GRAFANA_SM_TOKEN` | Authentication token/api key | true |
+| `GRAFANA_SM_STACK_ID` | Grafana instance/stack ID | true |
+| `GRAFANA_SM_LOGS_ID` | Metrics instance ID | true |
+| `GRAFANA_SM_METRICS_ID` | Logs instance ID | true |
+
+Your stack ID is the number at the end of the url when you view your Grafana instance details, ie. `grafana.com/orgs/myorg/stacks/123456` would be `123456`. Your metrics and logs ID's are the `User` when you view your Prometheus or Loki instance details in Grafana Cloud.
 
 ## Commands
 

--- a/pkg/grafana/synthetic-monitoring.go
+++ b/pkg/grafana/synthetic-monitoring.go
@@ -267,8 +267,8 @@ func getAuthToken() (string, error) {
 
 	client := &http.Client{}
 	req, err := http.NewRequest("POST", url, bytes.NewReader(authRequestJSON))
-	req.Header.Set("Authorization", "Bearer "+apiToken)
-	req.Header.Set("Content-type", "application/json")
+	req.Header.Add("Authorization", "Bearer "+apiToken)
+	req.Header.Add("Content-type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/grafana/synthetic-monitoring.go
+++ b/pkg/grafana/synthetic-monitoring.go
@@ -277,7 +277,8 @@ func getAuthToken() (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("%d response while authenticating", resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		return "", fmt.Errorf("%d response while authenticating: %s", resp.StatusCode, string(body))
 	}
 	type AuthResponse struct {
 		AccessToken string `json:"accessToken"`

--- a/testdata/synthetic-monitoring-simple.libsonnet
+++ b/testdata/synthetic-monitoring-simple.libsonnet
@@ -40,6 +40,8 @@
       ],
       target: 'https://grafana.com/',
       job: 'grafana-com',
+      alertSensitivity: '',
+      basicMetricsOnly: true,
     },
   },
 }


### PR DESCRIPTION
Setting to Draft in case this is needed. The better solution is to use the [SM API client](https://github.com/grafana/synthetic-monitoring-api-go-client) for all calls.

Update to use the newer [api/vi/register/install](https://github.com/grafana/synthetic-monitoring-api-go-client/blob/master/docs/API.md#apiv1registerinstall) synthetic monitoring API call for authentication.

See the README for the three additional environment variables that are required.