### PR TITLE
Fix folderName injection on dashboard creation

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -177,6 +177,7 @@ func (h *DashboardHandler) Apply(notifier grizzly.Notifier, resources grizzly.Re
 		if resource.JSONPath == dashboardFolderPath {
 			continue
 		}
+		resource = dashboardWithFolderSet(resource, dashboardFolder)
 		existingResource, err := h.GetRemote(resource.UID)
 		if err == grizzly.ErrNotFound {
 			err := h.Add(resource)
@@ -188,7 +189,6 @@ func (h *DashboardHandler) Apply(notifier grizzly.Notifier, resources grizzly.Re
 		} else if err != nil {
 			return err
 		}
-		resource = dashboardWithFolderSet(resource, dashboardFolder)
 		resourceRepresentation, err := resource.GetRepresentation()
 		if err != nil {
 			return err
@@ -265,10 +265,7 @@ func (h *DashboardHandler) GetRemote(uid string) (*grizzly.Resource, error) {
 func (h *DashboardHandler) Add(resource grizzly.Resource) error {
 	board := newDashboard(resource)
 
-	if err := postDashboard(board); err != nil {
-		return err
-	}
-	return nil
+	return postDashboard(board)
 }
 
 // Update pushes a dashboard to Grafana via the API

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -174,7 +174,7 @@ func (d *Dashboard) toJSON() (string, error) {
 
 // folderUID retrieves the folder UID for a dashboard
 func (d *Dashboard) folderUID() string {
-	folderUID, ok := (*d)["folderName"]
+	folderUID, ok := (*d)[folderNameField]
 	if ok {
 		return folderUID.(string)
 	}


### PR DESCRIPTION
When a new dashboard was added through `DashboardHandler.Apply`, the folder was not injected in the resource before calling `DashboardHandler.Add`, as this was only done below before calling Update. This PR moves the call to `dashboardWithFolderSet
` before checking if the dashboard already exists, so that it will be done both in the Add and Update cases.

Might be fixing https://github.com/grafana/grizzly/issues/70