### PR TITLE
Fix jsonnet unhide for string values

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -3,7 +3,6 @@ package grafana
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/mitchellh/mapstructure"
@@ -86,8 +85,7 @@ func (h *DashboardHandler) newDashboardFolderResource(path, folderName string) g
 func (h *DashboardHandler) Parse(path string, i interface{}) (grizzly.ResourceList, error) {
 	resources := grizzly.ResourceList{}
 	if path == dashboardFolderPath {
-		if _, ok := i.(string); ok {
-			folderName := strings.ReplaceAll(i.(string), "{ }", "") // No idea why json parsing adds { } to the end of the parsed string :-(
+		if folderName, ok := i.(string); ok {
 			resource := h.newDashboardFolderResource(path, folderName)
 			resources[dashboardFolderPath] = resource
 			return resources, nil

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -77,14 +77,16 @@ func List(config Config, resources Resources) error {
 func getPrivateElementsScript(jsonnetFile string, handlers []Handler) string {
 	const script = `
     local src = import '%s';
-    src + {
-    %s
-    }
+	local getPrivateElements(x) = {
+	%s
+	};
+    
+	getPrivateElements(src)
 	`
 	handlerStrings := []string{}
 	for _, handler := range handlers {
 		for _, jsonPath := range handler.GetJSONPaths() {
-			handlerStrings = append(handlerStrings, fmt.Sprintf("  %s+::: {},", jsonPath))
+			handlerStrings = append(handlerStrings, fmt.Sprintf("  [if std.objectHasAll(x, '%[1]s') then '%[1]s']: x['%[1]s'],", jsonPath))
 		}
 	}
 	return fmt.Sprintf(script, jsonnetFile, strings.Join(handlerStrings, "\n"))


### PR DESCRIPTION
In the previous version, the jsonnet script to extract private elements didn't work for keys that have string values, like `grafanaDashboardFolder`.

The script did something like:
```
{
  grafanaDashboardFolder:: 'test',
} + {
  grafanaDashboardFolder+::: {}
}
```
and in this case, jsonnet only appends `{ }` as a string to the `grafanaDashboardFolder` value.
Also, all jsonpath from handlers were forced to appear, even if they are not in the source script.

The new script uses a function with the source as argument to check if the field already exists, and force displays it in this case only. The other benefit is that no other handlers keys will be added to the output.