### PR TITLE
Small fixes

### DIFF
--- a/pkg/grafana/config.go
+++ b/pkg/grafana/config.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 )
 
 func getGrafanaURL(urlPath string) (string, error) {
@@ -13,7 +14,11 @@ func getGrafanaURL(urlPath string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		u.Path = path.Join(u.Path, urlPath)
+		parts := strings.Split(urlPath, "?")
+		u.Path = path.Join(u.Path, parts[0])
+		if len(parts) > 1 {
+			u.RawQuery = parts[1]
+		}
 		if token, exists := os.LookupEnv("GRAFANA_TOKEN"); exists {
 			user, exists := os.LookupEnv("GRAFANA_USER")
 			if !exists {

--- a/testdata/synthetic-monitoring-simple.libsonnet
+++ b/testdata/synthetic-monitoring-simple.libsonnet
@@ -1,6 +1,6 @@
 {
   syntheticMonitoring+:: {
-    odoko: {
+    grafana: {
       frequency: 60000,
       offset: 0,
       timeout: 2500,


### PR DESCRIPTION
Properly split a URL that has a question mark in it. This isn't actually invoked at the moment, but will hit us if we use e.g. the Grafana search HTTP API to list all folders, etc.

Also rename a misnamed element for synthetic monitoring.