### PR TITLE
use constant instead value in logging flag

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -13,7 +13,7 @@ import (
 var Version = "dev"
 
 func main() {
-	log.SetFlags(0)
+	log.SetFlags(log.Ltime)
 
 	rootCmd := &cli.Command{
 		Use:     "grr",


### PR DESCRIPTION
Use constant for logging to make more clear what our intention in code

PS: there are some specific reason why we want only time and not date & time (default behaviour)?