### PR TITLE
Convert resource type to simple map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /grr
 /dist
 .envrc
+.vscode

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -61,7 +61,6 @@ func (h *DashboardHandler) GetExtension() string {
 func (h *DashboardHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
 	resource := grizzly.Resource(m)
 	resource.SetSpecString("uid", resource.GetMetadata("name"))
-	resource.SetSpecString(folderNameField, resource.GetMetadata("folder"))
 	return resource.AsResourceList(), nil
 }
 
@@ -85,8 +84,8 @@ func (h *DashboardHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 }
 
 // GetRemote retrieves a dashboard as a resource
-func (h *DashboardHandler) GetRemote(uid string) (*grizzly.Resource, error) {
-	return getRemoteDashboard(uid)
+func (h *DashboardHandler) GetRemote(resource grizzly.Resource) (*grizzly.Resource, error) {
+	return getRemoteDashboard(resource.Name())
 }
 
 // Add pushes a new dashboard to Grafana via the API

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -1,13 +1,10 @@
 package grafana
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pmezard/go-difflib/difflib"
 )
 
 /*
@@ -60,139 +57,12 @@ func (h *DashboardHandler) GetExtension() string {
 	return "json"
 }
 
-func (h *DashboardHandler) newDashboardResource(path, uid, filename string, board Dashboard) grizzly.Resource {
-	resource := grizzly.Resource{
-		UID:      uid,
-		Filename: filename,
-		Handler:  h,
-		Detail:   board,
-		JSONPath: path,
-	}
-	return resource
-}
-
-func (h *DashboardHandler) newDashboardFolderResource(path, folderName string) grizzly.Resource {
-	resource := grizzly.Resource{
-		UID:      folderName,
-		Filename: folderName,
-		Handler:  h,
-		Detail:   "",
-		JSONPath: path,
-	}
-	return resource
-}
-
 // Parse parses a manifest object into a struct for this resource type
 func (h *DashboardHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
-
-	spec := m["spec"].(map[string]interface{})
-	board := Dashboard{}
-	err := mapstructure.Decode(spec, &board)
-	if err != nil {
-		return nil, err
-	}
-	board["uid"] = m.Metadata().Name()
-	board[folderNameField] = m.Metadata()["folder"].(string)
-	resource := h.newDashboardResource("", board.UID(), "", board)
-	key := resource.Key()
-	resources := grizzly.ResourceList{}
-	resources[key] = resource
-	return resources, nil
-}
-
-// Diff compares local resources with remote equivalents and output result
-func (h *DashboardHandler) Diff(notifier grizzly.Notifier, resources grizzly.ResourceList) error {
-	dashboardFolder := dashboardFolderDefault
-	dashboardFolderResource, ok := resources[dashboardFolderPath]
-	if ok {
-		dashboardFolder = dashboardFolderResource.Filename
-	}
-	for _, resource := range resources {
-		if resource.JSONPath == dashboardFolderPath {
-			continue
-		}
-		resource = dashboardWithFolderSet(resource, dashboardFolder)
-		local, err := resource.GetRepresentation()
-		if err != nil {
-			return nil
-		}
-		resource = *h.Unprepare(resource)
-		uid := resource.UID
-		remote, err := h.GetRemote(resource.UID)
-		if err == grizzly.ErrNotFound {
-			notifier.NotFound(resource)
-			continue
-		}
-		if err != nil {
-			return fmt.Errorf("Error retrieving resource from %s %s: %v", resource.Kind(), uid, err)
-		}
-		remote = h.Unprepare(*remote)
-		remoteRepresentation, err := (*remote).GetRepresentation()
-		if err != nil {
-			return err
-		}
-
-		if local == remoteRepresentation {
-			notifier.NoChanges(resource)
-		} else {
-			diff := difflib.UnifiedDiff{
-				A:        difflib.SplitLines(remoteRepresentation),
-				B:        difflib.SplitLines(local),
-				FromFile: "Remote",
-				ToFile:   "Local",
-				Context:  3,
-			}
-			difference, _ := difflib.GetUnifiedDiffString(diff)
-			notifier.HasChanges(resource, difference)
-		}
-	}
-	return nil
-}
-
-// Apply local resources to remote endpoint
-func (h *DashboardHandler) Apply(notifier grizzly.Notifier, resources grizzly.ResourceList) error {
-	dashboardFolder := dashboardFolderDefault
-	dashboardFolderResource, ok := resources[dashboardFolderPath]
-	if ok {
-		dashboardFolder = dashboardFolderResource.Filename
-	}
-	for _, resource := range resources {
-		if resource.JSONPath == dashboardFolderPath {
-			continue
-		}
-		existingResource, err := h.GetRemote(resource.UID)
-		if err == grizzly.ErrNotFound {
-			err := h.Add(resource)
-			if err != nil {
-				return err
-			}
-			notifier.Added(resource)
-			continue
-		} else if err != nil {
-			return err
-		}
-		resource = dashboardWithFolderSet(resource, dashboardFolder)
-		resourceRepresentation, err := resource.GetRepresentation()
-		if err != nil {
-			return err
-		}
-		resource = *h.Prepare(*existingResource, resource)
-		existingResource = h.Unprepare(*existingResource)
-		existingResourceRepresentation, err := existingResource.GetRepresentation()
-		if err != nil {
-			return nil
-		}
-		if resourceRepresentation == existingResourceRepresentation {
-			notifier.NoChanges(resource)
-		} else {
-			err = h.Update(*existingResource, resource)
-			if err != nil {
-				return err
-			}
-			notifier.Updated(resource)
-		}
-	}
-	return nil
+	resource := grizzly.Resource(m)
+	resource.SetSpecString("uid", resource.GetMetadata("name"))
+	resource.SetSpecString(folderNameField, resource.GetMetadata("folder"))
+	return resource.AsResourceList(), nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
@@ -207,48 +77,21 @@ func (h *DashboardHandler) Prepare(existing, resource grizzly.Resource) *grizzly
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *DashboardHandler) GetByUID(UID string) (*grizzly.Resource, error) {
-	board, err := getRemoteDashboard(UID)
+	resource, err := getRemoteDashboard(UID)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving dashboard %s: %v", UID, err)
 	}
-	resource := h.newDashboardResource(dashboardsPath, UID, "", *board)
-	return &resource, nil
-}
-
-// GetRepresentation renders a resource as JSON or YAML as appropriate
-func (h *DashboardHandler) GetRepresentation(uid string, resource grizzly.Resource) (string, error) {
-	j, err := json.MarshalIndent(resource.Detail, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(j), nil
-}
-
-// GetRemoteRepresentation retrieves a dashboard as JSON
-func (h *DashboardHandler) GetRemoteRepresentation(uid string) (string, error) {
-	board, err := getRemoteDashboard(uid)
-
-	if err != nil {
-		return "", err
-	}
-	return board.toJSON()
+	return resource, nil
 }
 
 // GetRemote retrieves a dashboard as a resource
 func (h *DashboardHandler) GetRemote(uid string) (*grizzly.Resource, error) {
-	board, err := getRemoteDashboard(uid)
-	if err != nil {
-		return nil, err
-	}
-	resource := h.newDashboardResource(dashboardsPath, uid, "", *board)
-	return &resource, nil
+	return getRemoteDashboard(uid)
 }
 
 // Add pushes a new dashboard to Grafana via the API
 func (h *DashboardHandler) Add(resource grizzly.Resource) error {
-	board := newDashboard(resource)
-
-	if err := postDashboard(board); err != nil {
+	if err := postDashboard(resource); err != nil {
 		return err
 	}
 	return nil
@@ -256,18 +99,12 @@ func (h *DashboardHandler) Add(resource grizzly.Resource) error {
 
 // Update pushes a dashboard to Grafana via the API
 func (h *DashboardHandler) Update(existing, resource grizzly.Resource) error {
-	board := newDashboard(resource)
-
-	return postDashboard(board)
+	return postDashboard(resource)
 }
 
 // Preview renders Jsonnet then pushes them to the endpoint if previews are possible
 func (h *DashboardHandler) Preview(resource grizzly.Resource, notifier grizzly.Notifier, opts *grizzly.PreviewOpts) error {
-	if resource.JSONPath == dashboardFolderPath {
-		return nil
-	}
-	board := newDashboard(resource)
-	s, err := postSnapshot(board, opts)
+	s, err := postSnapshot(resource, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/grafana/dashboard-watcher.go
+++ b/pkg/grafana/dashboard-watcher.go
@@ -62,7 +62,7 @@ func (h *eventHandler) OnPublish(sub *centrifuge.Subscription, e centrifuge.Publ
 		h.notifier.Error(nil, fmt.Sprintf("Error: %s", err))
 		return
 	}
-	dashboardJSON, err := dashboard.toJSON()
+	dashboardJSON, err := dashboard.SpecAsJSON()
 	if err != nil {
 		h.notifier.Error(nil, fmt.Sprintf("Error: %s", err))
 		return

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -48,7 +48,7 @@ func getRemoteDashboard(uid string) (*grizzly.Resource, error) {
 	delete(d.Dashboard, "version")
 	h := DashboardHandler{}
 	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, d.Dashboard)
-	resource = resource.SetMetadata("folder", d.Meta.FolderTitle)
+	resource.SetMetadata("folder", d.Meta.FolderTitle)
 	return &resource, nil
 }
 

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -11,8 +11,6 @@ import (
 	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
-const folderNameField = "folderName"
-
 // getRemoteDashboard retrieves a dashboard object from Grafana
 func getRemoteDashboard(uid string) (*grizzly.Resource, error) {
 	grafanaURL, err := getGrafanaURL("api/dashboards/uid/" + uid)

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -14,7 +14,7 @@ import (
 const folderNameField = "folderName"
 
 // getRemoteDashboard retrieves a dashboard object from Grafana
-func getRemoteDashboard(uid string) (*Dashboard, error) {
+func getRemoteDashboard(uid string) (*grizzly.Resource, error) {
 	grafanaURL, err := getGrafanaURL("api/dashboards/uid/" + uid)
 	if err != nil {
 		return nil, err
@@ -46,24 +46,25 @@ func getRemoteDashboard(uid string) (*Dashboard, error) {
 	}
 	delete(d.Dashboard, "id")
 	delete(d.Dashboard, "version")
-	d.Dashboard[folderNameField] = d.Meta.FolderTitle
-	return &d.Dashboard, nil
+	h := DashboardHandler{}
+	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, d.Dashboard)
+	resource = resource.SetMetadata("folder", d.Meta.FolderTitle)
+	return &resource, nil
 }
 
-func postDashboard(board Dashboard) error {
+func postDashboard(resource grizzly.Resource) error {
 	grafanaURL, err := getGrafanaURL("api/dashboards/db")
 	if err != nil {
 		return err
 	}
 
-	folderUID := board.folderUID()
+	folderUID := resource.GetMetadata("folder")
 	folderID, err := findOrCreateFolder(folderUID)
 	if err != nil {
 		return err
 	}
-	delete(board, folderNameField)
 	wrappedBoard := DashboardWrapper{
-		Dashboard: board,
+		Dashboard: resource["spec"].(map[string]interface{}),
 		FolderID:  folderID,
 		Overwrite: true,
 	}
@@ -86,9 +87,9 @@ func postDashboard(board Dashboard) error {
 			return fmt.Errorf("Failed to decode actual error (412 Precondition failed): %s", err)
 		}
 		fmt.Println(wrappedJSON)
-		return fmt.Errorf("Error while applying '%s' to Grafana: %s", board.UID(), r.Message)
+		return fmt.Errorf("Error while applying '%s' to Grafana: %s", resource.Name(), r.Message)
 	default:
-		return NewErrNon200Response("dashboard", board.UID(), resp)
+		return NewErrNon200Response("dashboard", resource.Name(), resp)
 	}
 
 	return nil
@@ -102,7 +103,7 @@ type SnapshotResp struct {
 	URL       string `json:"url"`
 }
 
-func postSnapshot(board Dashboard, opts *grizzly.PreviewOpts) (*SnapshotResp, error) {
+func postSnapshot(resource grizzly.Resource, opts *grizzly.PreviewOpts) (*SnapshotResp, error) {
 
 	url, err := getGrafanaURL("api/snapshots")
 	if err != nil {
@@ -114,7 +115,7 @@ func postSnapshot(board Dashboard, opts *grizzly.PreviewOpts) (*SnapshotResp, er
 	}
 
 	sr := &SnapshotReq{
-		Dashboard: board,
+		Dashboard: resource["spec"].(map[string]interface{}),
 	}
 
 	if opts.ExpiresSeconds > 0 {
@@ -131,7 +132,7 @@ func postSnapshot(board Dashboard, opts *grizzly.PreviewOpts) (*SnapshotResp, er
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, NewErrNon200Response("snapshot", board.UID(), resp)
+		return nil, NewErrNon200Response("snapshot", resource.Name(), resp)
 
 	}
 
@@ -150,10 +151,6 @@ func postSnapshot(board Dashboard, opts *grizzly.PreviewOpts) (*SnapshotResp, er
 
 // Dashboard encapsulates a dashboard
 type Dashboard map[string]interface{}
-
-func newDashboard(resource grizzly.Resource) Dashboard {
-	return resource.Detail.(Dashboard)
-}
 
 // UID retrieves the UID from a dashboard
 func (d *Dashboard) UID() string {
@@ -180,16 +177,6 @@ func (d *Dashboard) folderUID() string {
 		return folderUID.(string)
 	}
 	return ""
-}
-
-func dashboardWithFolderSet(resource grizzly.Resource, dashboardFolder string) grizzly.Resource {
-	board := newDashboard(resource)
-	_, ok := board[folderNameField]
-	if !ok {
-		board[folderNameField] = dashboardFolder
-	}
-	resource.Detail = board
-	return resource
 }
 
 // DashboardWrapper adds wrapper to a dashboard JSON. Caters both for Grafana's POST

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -88,8 +88,8 @@ func (h *DatasourceHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 }
 
 // GetRemote retrieves a datasource as a Resource
-func (h *DatasourceHandler) GetRemote(uid string) (*grizzly.Resource, error) {
-	return getRemoteDatasource(uid)
+func (h *DatasourceHandler) GetRemote(resource grizzly.Resource) (*grizzly.Resource, error) {
+	return getRemoteDatasource(resource.Name())
 }
 
 // Add pushes a datasource to Grafana via the API

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -58,7 +58,7 @@ func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, er
 		"readOnly":          false,
 	}
 	spec := resource["spec"].(map[string]interface{})
-	for k, _ := range defaults {
+	for k := range defaults {
 		_, ok := spec[k]
 		if !ok {
 			spec[k] = defaults[k]

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -1,12 +1,8 @@
 package grafana
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
-	"github.com/mitchellh/mapstructure"
 )
 
 // DatasourceHandler is a Grizzly Handler for Grafana datasources
@@ -45,22 +41,10 @@ func (h *DatasourceHandler) GetExtension() string {
 	return "json"
 }
 
-func (h *DatasourceHandler) newDatasourceResource(path, uid, filename string, source Datasource) grizzly.Resource {
-	resource := grizzly.Resource{
-		UID:      uid,
-		Filename: filename,
-		Handler:  h,
-		Detail:   source,
-		JSONPath: path,
-	}
-	return resource
-}
-
 // Parse parses a manifest object into a struct for this resource type
 func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
-	resources := grizzly.ResourceList{}
-	spec := m["spec"].(map[string]interface{})
-	source := Datasource{
+	resource := grizzly.Resource(m)
+	defaults := map[string]interface{}{
 		"basicAuth":         false,
 		"basicAuthPassword": "",
 		"basicAuthUser":     "",
@@ -73,79 +57,47 @@ func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, er
 		"withCredentials":   false,
 		"readOnly":          false,
 	}
-	err := mapstructure.Decode(spec, &source)
-	if err != nil {
-		return nil, err
+	spec := resource["spec"].(map[string]interface{})
+	for k, _ := range defaults {
+		_, ok := spec[k]
+		if !ok {
+			spec[k] = defaults[k]
+		}
 	}
-	source["name"] = m.Metadata().Name()
-	resource := h.newDatasourceResource("", source.UID(), "", source)
-	key := resource.Key()
-	resources[key] = resource
-
-	return resources, nil
+	spec["name"] = m.Metadata().Name()
+	resource["spec"] = spec
+	return resource.AsResourceList(), nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 func (h *DatasourceHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
-	h.delete(resource, "version")
-	h.delete(resource, "id")
+	resource = *(resource.DeleteSpecKey("version"))
+	resource = *(resource.DeleteSpecKey("id"))
 	return &resource
 }
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *DatasourceHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	resource.Detail.(Datasource)["id"] = existing.Detail.(Datasource)["id"]
+	resource = *(resource.SetSpecString("id", existing.GetSpecString("id")))
 	return &resource
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *DatasourceHandler) GetByUID(UID string) (*grizzly.Resource, error) {
-	source, err := getRemoteDatasource(UID)
-	if err != nil {
-		return nil, fmt.Errorf("Error retrieving datasource %s: %v", UID, err)
-	}
-	resource := h.newDatasourceResource(datasourcesPath, UID, "", *source)
-	return &resource, nil
-}
-
-// GetRepresentation renders a resource as JSON or YAML as appropriate
-func (h *DatasourceHandler) GetRepresentation(uid string, resource grizzly.Resource) (string, error) {
-	j, err := json.MarshalIndent(resource.Detail, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(j), nil
-}
-
-// GetRemoteRepresentation retrieves a datasource as JSON
-func (h *DatasourceHandler) GetRemoteRepresentation(uid string) (string, error) {
-	source, err := getRemoteDatasource(uid)
-	if err != nil {
-		return "", err
-	}
-	return source.toJSON()
+	return getRemoteDatasource(UID)
 }
 
 // GetRemote retrieves a datasource as a Resource
 func (h *DatasourceHandler) GetRemote(uid string) (*grizzly.Resource, error) {
-	source, err := getRemoteDatasource(uid)
-	if err != nil {
-		return nil, err
-	}
-	resource := h.newDatasourceResource(datasourcesPath, uid, "", *source)
-	return &resource, nil
+	return getRemoteDatasource(uid)
 }
 
 // Add pushes a datasource to Grafana via the API
 func (h *DatasourceHandler) Add(resource grizzly.Resource) error {
-	return postDatasource(newDatasource(resource))
+	return postDatasource(resource)
 }
 
 // Update pushes a datasource to Grafana via the API
 func (h *DatasourceHandler) Update(existing, resource grizzly.Resource) error {
-	return putDatasource(newDatasource(resource))
-}
-
-func (h *DatasourceHandler) delete(resource grizzly.Resource, key string) {
-	delete(resource.Detail.(Datasource), key)
+	return putDatasource(resource)
 }

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -71,14 +71,14 @@ func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, er
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 func (h *DatasourceHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
-	resource = *(resource.DeleteSpecKey("version"))
-	resource = *(resource.DeleteSpecKey("id"))
+	resource.DeleteSpecKey("version")
+	resource.DeleteSpecKey("id")
 	return &resource
 }
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *DatasourceHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	resource = *(resource.SetSpecString("id", existing.GetSpecString("id")))
+	resource.SetSpecString("id", existing.GetSpecString("id"))
 	return &resource
 }
 

--- a/pkg/grafana/datasources.go
+++ b/pkg/grafana/datasources.go
@@ -83,7 +83,8 @@ func postDatasource(resource grizzly.Resource) error {
 }
 
 func putDatasource(resource grizzly.Resource) error {
-	id := resource.GetSpecString("id")
+	spec := resource.Spec()
+	id := spec["id"].(int64)
 	grafanaURL, err := getGrafanaURL(fmt.Sprintf("api/datasources/%d", id))
 	if err != nil {
 		return err

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -1,6 +1,8 @@
 package grafana
 
 import (
+	"fmt"
+
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
@@ -65,7 +67,8 @@ func (h *RuleHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 }
 
 // GetRemote retrieves a datasource as a Resource
-func (h *RuleHandler) GetRemote(uid string) (*grizzly.Resource, error) {
+func (h *RuleHandler) GetRemote(resource grizzly.Resource) (*grizzly.Resource, error) {
+	uid := fmt.Sprintf("%s.%s", resource.GetMetadata("namespace"), resource.Name())
 	return getRemoteRuleGroup(uid)
 }
 

--- a/pkg/grafana/rules.go
+++ b/pkg/grafana/rules.go
@@ -13,8 +13,8 @@ import (
 )
 
 // getRemoteRuleGrouping retrieves a datasource object from Grafana
-func getRemoteRuleGroup(uid string) (*PrometheusRuleGroup, error) {
-	parts := strings.SplitN(uid, "-", 2)
+func getRemoteRuleGroup(uid string) (*grizzly.Resource, error) {
+	parts := strings.SplitN(uid, ".", 2)
 	namespace := parts[0]
 	name := parts[1]
 
@@ -31,8 +31,13 @@ func getRemoteRuleGroup(uid string) (*PrometheusRuleGroup, error) {
 		if key == namespace {
 			for _, group := range grouping {
 				if group.Name == name {
-					group.Namespace = namespace
-					return &group, nil
+					spec := map[string]interface{}{
+						"rules": group.Rules,
+					}
+					handler := RuleHandler{}
+					resource := grizzly.NewResource(handler.APIVersion(), handler.Kind(), uid, spec)
+					resource = resource.SetMetadata("namespace", namespace)
+					return &resource, nil
 				}
 			}
 		}
@@ -47,34 +52,20 @@ type PrometheusRuleGroup struct {
 	Rules     []map[string]interface{} `yaml:"rules"`
 }
 
-// UID retrieves the UID from a rule group
-func (g *PrometheusRuleGroup) UID() string {
-	return fmt.Sprintf("%s-%s", g.Namespace, g.Name)
-}
-
-// toYAML returns YAML for a rule group
-func (g *PrometheusRuleGroup) toYAML() (string, error) {
-	y, err := yaml.Marshal(g)
-	if err != nil {
-		return "", err
-	}
-	return string(y), nil
-}
-
-// RuleGrouping encapsulates a set of named rule groups
-type RuleGrouping struct {
+// PrometheusRuleGrouping encapsulates a set of named rule groups
+type PrometheusRuleGrouping struct {
 	Namespace string                `json:"namespace"`
 	Groups    []PrometheusRuleGroup `json:"groups"`
 }
 
-func writeRuleGroup(group PrometheusRuleGroup) error {
+func writeRuleGroup(resource grizzly.Resource) error {
 	tmpfile, err := ioutil.TempFile("", "cortextool-*")
 	newGroup := PrometheusRuleGroup{
-		Name:  group.Name,
-		Rules: group.Rules,
+		Name:  resource.Name(),
+		Rules: resource.Spec()["rules"].([]map[string]interface{}),
 	}
-	grouping := RuleGrouping{
-		Namespace: group.Namespace,
+	grouping := PrometheusRuleGrouping{
+		Namespace: resource.GetMetadata("namespace"),
 		Groups:    []PrometheusRuleGroup{newGroup},
 	}
 	out, err := yaml.Marshal(grouping)

--- a/pkg/grafana/rules.go
+++ b/pkg/grafana/rules.go
@@ -36,7 +36,7 @@ func getRemoteRuleGroup(uid string) (*grizzly.Resource, error) {
 					}
 					handler := RuleHandler{}
 					resource := grizzly.NewResource(handler.APIVersion(), handler.Kind(), uid, spec)
-					resource = resource.SetMetadata("namespace", namespace)
+					resource.SetMetadata("namespace", namespace)
 					return &resource, nil
 				}
 			}

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -57,23 +57,23 @@ func (h *SyntheticMonitoringHandler) GetExtension() string {
 func (h *SyntheticMonitoringHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
 	resource := grizzly.Resource(m)
 	resource.SetSpecString("job", resource.GetMetadata("name"))
-	resource.SetSpecString(folderNameField, resource.GetMetadata("folder"))
+	resource.SetSpecString(folderNameField, resource.GetMetadata("type"))
 	return resource.AsResourceList(), nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 func (h *SyntheticMonitoringHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
-	resource = *(resource.DeleteSpecKey("tenantId"))
-	resource = *(resource.DeleteSpecKey("id"))
-	resource = *(resource.DeleteSpecKey("modified"))
-	resource = *(resource.DeleteSpecKey("created"))
+	resource.DeleteSpecKey("tenantId")
+	resource.DeleteSpecKey("id")
+	resource.DeleteSpecKey("modified")
+	resource.DeleteSpecKey("created")
 	return &resource
 }
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *SyntheticMonitoringHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	resource = *(resource.SetSpecString("tenantId", existing.GetSpecString("tenantId")))
-	resource = *(resource.SetSpecString("id", existing.GetSpecString("id")))
+	resource.SetSpecString("tenantId", existing.GetSpecString("tenantId"))
+	resource.SetSpecString("id", existing.GetSpecString("id"))
 	return &resource
 }
 

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -1,6 +1,8 @@
 package grafana
 
 import (
+	"fmt"
+
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
@@ -57,7 +59,6 @@ func (h *SyntheticMonitoringHandler) GetExtension() string {
 func (h *SyntheticMonitoringHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
 	resource := grizzly.Resource(m)
 	resource.SetSpecString("job", resource.GetMetadata("name"))
-	resource.SetSpecString(folderNameField, resource.GetMetadata("type"))
 	return resource.AsResourceList(), nil
 }
 
@@ -83,7 +84,8 @@ func (h *SyntheticMonitoringHandler) GetByUID(UID string) (*grizzly.Resource, er
 }
 
 // GetRemote retrieves a datasource as a Resource
-func (h *SyntheticMonitoringHandler) GetRemote(uid string) (*grizzly.Resource, error) {
+func (h *SyntheticMonitoringHandler) GetRemote(resource grizzly.Resource) (*grizzly.Resource, error) {
+	uid := fmt.Sprintf("%s.%s", resource.GetMetadata("type"), resource.Name())
 	return getRemoteCheck(uid)
 }
 

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -1,12 +1,8 @@
 package grafana
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
-	"github.com/mitchellh/mapstructure"
 )
 
 /*
@@ -57,96 +53,48 @@ func (h *SyntheticMonitoringHandler) GetExtension() string {
 	return "json"
 }
 
-func (h *SyntheticMonitoringHandler) newCheckResource(path string, filename string, check Check) grizzly.Resource {
-	resource := grizzly.Resource{
-		UID:      check.UID(),
-		Filename: filename,
-		Handler:  h,
-		Detail:   check,
-		JSONPath: path,
-	}
-	return resource
-}
-
 // Parse parses a manifest object into a struct for this resource type
 func (h *SyntheticMonitoringHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
-	resources := grizzly.ResourceList{}
-	spec := m["spec"].(map[string]interface{})
-	check := Check{}
-	err := mapstructure.Decode(spec, &check)
-	if err != nil {
-		return nil, err
-	}
-	check["job"] = m.Metadata().Name()
-	resource := h.newCheckResource("", "", check)
-	key := resource.Key()
-	resources[key] = resource
-	return resources, nil
+	resource := grizzly.Resource(m)
+	resource.SetSpecString("job", resource.GetMetadata("name"))
+	resource.SetSpecString(folderNameField, resource.GetMetadata("folder"))
+	return resource.AsResourceList(), nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 func (h *SyntheticMonitoringHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
-	delete(resource.Detail.(Check), "tenantId")
-	delete(resource.Detail.(Check), "id")
-	delete(resource.Detail.(Check), "modified")
-	delete(resource.Detail.(Check), "created")
+	resource = *(resource.DeleteSpecKey("tenantId"))
+	resource = *(resource.DeleteSpecKey("id"))
+	resource = *(resource.DeleteSpecKey("modified"))
+	resource = *(resource.DeleteSpecKey("created"))
 	return &resource
 }
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *SyntheticMonitoringHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	resource.Detail.(Check)["tenantId"] = existing.Detail.(Check)["tenantId"]
-	resource.Detail.(Check)["id"] = existing.Detail.(Check)["id"]
+	resource = *(resource.SetSpecString("tenantId", existing.GetSpecString("tenantId")))
+	resource = *(resource.SetSpecString("id", existing.GetSpecString("id")))
 	return &resource
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *SyntheticMonitoringHandler) GetByUID(UID string) (*grizzly.Resource, error) {
-	check, err := getRemoteCheck(UID)
-	if err != nil {
-		return nil, fmt.Errorf("Error retrieving check %s: %v", UID, err)
-	}
-	resource := h.newCheckResource(syntheticMonitoringChecksPath, "", *check)
-	return &resource, nil
-}
-
-// GetRepresentation renders a resource as JSON or YAML as appropriate
-func (h *SyntheticMonitoringHandler) GetRepresentation(uid string, resource grizzly.Resource) (string, error) {
-	j, err := json.MarshalIndent(resource.Detail, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(j), nil
-}
-
-// GetRemoteRepresentation retrieves a datasource as JSON
-func (h *SyntheticMonitoringHandler) GetRemoteRepresentation(uid string) (string, error) {
-	check, err := getRemoteCheck(uid)
-	if err != nil {
-		return "", err
-	}
-	return check.toJSON()
+	return getRemoteCheck(UID)
 }
 
 // GetRemote retrieves a datasource as a Resource
 func (h *SyntheticMonitoringHandler) GetRemote(uid string) (*grizzly.Resource, error) {
-	check, err := getRemoteCheck(uid)
-	if err != nil {
-		return nil, err
-	}
-	resource := h.newCheckResource(syntheticMonitoringChecksPath, "", *check)
-	return &resource, nil
+	return getRemoteCheck(uid)
 }
 
 // Add adds a new check to the SyntheticMonitoring endpoint
 func (h *SyntheticMonitoringHandler) Add(resource grizzly.Resource) error {
-	url := getURL("api/v1/check/add")
-	return postCheck(url, newCheck(resource))
+	url := getSyntheticMonitoringURL("api/v1/check/add")
+	return postCheck(url, resource)
 }
 
 // Update pushes an updated check to the SyntheticMonitoring endpoing
 func (h *SyntheticMonitoringHandler) Update(existing, resource grizzly.Resource) error {
-	check := newCheck(resource)
-	url := getURL("api/v1/check/update")
-	return postCheck(url, check)
+	url := getSyntheticMonitoringURL("api/v1/check/update")
+	return postCheck(url, resource)
 }

--- a/pkg/grizzly/notifier.go
+++ b/pkg/grizzly/notifier.go
@@ -17,33 +17,33 @@ type Notifier struct{}
 
 // NoChanges announces that nothing has changed
 func (n *Notifier) NoChanges(resource Resource) {
-	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.UID, yellow("no differences"))
+	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.Name(), yellow("no differences"))
 }
 
 // HasChanges announces that a resource has changed, and displays the differences
 func (n *Notifier) HasChanges(resource Resource, diff string) {
-	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.UID, red("changes detected:"))
+	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.Name(), red("changes detected:"))
 	fmt.Println(diff)
 }
 
 // NotFound announces that a resource was not found on the remote endpoint
 func (n *Notifier) NotFound(resource Resource) {
-	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.UID, yellow("not present in "+resource.Kind()))
+	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.Name(), yellow("not present in "+resource.Kind()))
 }
 
 // Added announces that a resource has been added to the remote endpoint
 func (n *Notifier) Added(resource Resource) {
-	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.UID, green("added"))
+	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.Name(), green("added"))
 }
 
 // Updated announces that a resource has been updated at the remote endpoint
 func (n *Notifier) Updated(resource Resource) {
-	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.UID, green("updated"))
+	fmt.Printf("%s/%s %s\n", resource.Kind(), resource.Name(), green("updated"))
 }
 
 // NotSupported announces that a behaviour is not supported by a handler
-func (n *Notifier) NotSupported(resource Resource, behaviour string) {
-	fmt.Printf("%s/%s %s provider %s\n", resource.Kind(), resource.UID, resource.Kind(), red("does not support "+behaviour))
+func (n *Notifier) NotSupported(kind, name string, behaviour string) {
+	fmt.Printf("%s/%s %s\n", kind, name, red("does not support "+behaviour))
 }
 
 // Info announces a message in green
@@ -51,7 +51,7 @@ func (n *Notifier) Info(resource *Resource, msg string) {
 	if resource == nil {
 		fmt.Println(green(msg))
 	} else {
-		fmt.Printf("%s/%s %s\n", resource.Kind(), resource.UID, green(msg))
+		fmt.Printf("%s/%s %s\n", resource.Kind(), resource.Name(), green(msg))
 	}
 }
 
@@ -60,7 +60,7 @@ func (n *Notifier) Warn(resource *Resource, msg string) {
 	if resource == nil {
 		fmt.Println(yellow(msg))
 	} else {
-		fmt.Printf("%s/%s %s\n", resource.Kind(), resource.UID, yellow(msg))
+		fmt.Printf("%s/%s %s\n", resource.Kind(), resource.Name(), yellow(msg))
 	}
 }
 
@@ -69,6 +69,6 @@ func (n *Notifier) Error(resource *Resource, msg string) {
 	if resource == nil {
 		fmt.Println(red(msg))
 	} else {
-		fmt.Printf("%s/%s %s\n", resource.Kind(), resource.UID, red(msg))
+		fmt.Printf("%s/%s %s\n", resource.Kind(), resource.Name(), red(msg))
 	}
 }

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -49,11 +49,10 @@ func (r *Resource) GetMetadata(key string) string {
 	return metadata[key].(string)
 }
 
-func (r *Resource) SetMetadata(key, value string) Resource {
+func (r *Resource) SetMetadata(key, value string) {
 	metadata := (*r)["metadata"].(map[string]interface{})
 	metadata[key] = value
 	(*r)["metadata"] = metadata
-	return *r
 }
 
 func (r *Resource) GetSpecString(key string) string {
@@ -61,18 +60,16 @@ func (r *Resource) GetSpecString(key string) string {
 	return spec[key].(string)
 }
 
-func (r *Resource) SetSpecString(key, value string) *Resource {
+func (r *Resource) SetSpecString(key, value string) {
 	spec := (*r)["spec"].(map[string]interface{})
 	spec[key] = value
 	(*r)["spec"] = spec
-	return r
 }
 
-func (r *Resource) DeleteSpecKey(key string) *Resource {
+func (r *Resource) DeleteSpecKey(key string) {
 	spec := (*r)["spec"].(map[string]interface{})
 	delete(spec, key)
 	(*r)["spec"] = spec
-	return r
 }
 
 func (r *Resource) Spec() map[string]interface{} {
@@ -95,8 +92,8 @@ func (r *Resource) SpecAsJSON() (string, error) {
 
 }
 
-// GetRepresentation Gets the string representation for this resource
-func (r *Resource) GetRepresentation() (string, error) {
+// AsYAML Gets the string representation for this resource
+func (r *Resource) AsYAML() (string, error) {
 	y, err := yaml.Marshal(*r)
 	if err != nil {
 		return "", err

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -92,8 +92,8 @@ func (r *Resource) SpecAsJSON() (string, error) {
 
 }
 
-// AsYAML Gets the string representation for this resource
-func (r *Resource) AsYAML() (string, error) {
+// YAML Gets the string representation for this resource
+func (r *Resource) YAML() (string, error) {
 	y, err := yaml.Marshal(*r)
 	if err != nil {
 		return "", err
@@ -142,8 +142,8 @@ type Handler interface {
 	// Get retrieves JSON for a resource from an endpoint, by UID
 	GetByUID(UID string) (*Resource, error)
 
-	// GetRemote retrieves a resource as a datastructure
-	GetRemote(uid string) (*Resource, error)
+	// GetRemote retrieves a remote equivalent of a remote resource
+	GetRemote(resource Resource) (*Resource, error)
 
 	// Add pushes a new resource to the endpoint
 	Add(resource Resource) error

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -21,11 +21,6 @@ import (
 
 var interactive = terminal.IsTerminal(int(os.Stdout.Fd()))
 
-func isMultiResource(handler Handler) bool {
-	_, ok := handler.(MultiResourceHandler)
-	return ok
-}
-
 // Get retrieves a resource from a remote endpoint using its UID
 func Get(config Config, UID string) error {
 	count := strings.Count(UID, ".")
@@ -71,7 +66,7 @@ func List(config Config, resources Resources) error {
 	fmt.Fprintf(w, f, "API VERSION", "KIND", "UID")
 	for handler, resourceList := range resources {
 		for _, r := range resourceList {
-			fmt.Fprintf(w, f, handler.APIVersion(), handler.Kind(), r.UID)
+			fmt.Fprintf(w, f, handler.APIVersion(), handler.Kind(), r.Name())
 		}
 	}
 	return w.Flush()
@@ -121,10 +116,11 @@ func Parse(config Config, jsonnetFile string, targets []string) (Resources, erro
 			return nil, err
 		}
 		for _, resource := range parsedResources {
+			handler, err = config.Registry.GetHandler(resource.Kind())
 			if !resource.MatchesTarget(targets) {
 				continue
 			}
-			resourceList, ok := resources[resource.Handler]
+			resourceList, ok := resources[handler]
 			if !ok {
 				resourceList = ResourceList{}
 			}
@@ -149,11 +145,11 @@ func Show(config Config, resources Resources) error {
 			}
 			if interactive {
 				items = append(items, term.PageItem{
-					Name:    fmt.Sprintf("%s/%s", resource.Kind(), resource.UID),
+					Name:    fmt.Sprintf("%s/%s", resource.Kind(), resource.Name()),
 					Content: rep,
 				})
 			} else {
-				fmt.Printf("%s/%s:\n", resource.Kind(), resource.UID)
+				fmt.Printf("%s/%s:\n", resource.Kind(), resource.Name())
 				fmt.Println(rep)
 			}
 		}
@@ -168,20 +164,14 @@ func Show(config Config, resources Resources) error {
 func Diff(config Config, resources Resources) error {
 
 	for handler, resourceList := range resources {
-		if isMultiResource(handler) {
-			multiHandler := handler.(MultiResourceHandler)
-			multiHandler.Diff(config.Notifier, resourceList)
-			continue
-		}
-
 		for _, resource := range resourceList {
 			local, err := resource.GetRepresentation()
 			if err != nil {
 				return nil
 			}
 			resource = *handler.Unprepare(resource)
-			uid := resource.UID
-			remote, err := handler.GetRemote(resource.UID)
+			uid := resource.Name()
+			remote, err := handler.GetRemote(resource.Name())
 			if err == ErrNotFound {
 				config.Notifier.NotFound(resource)
 				continue
@@ -216,16 +206,8 @@ func Diff(config Config, resources Resources) error {
 // Apply pushes resources to endpoints
 func Apply(config Config, resources Resources) error {
 	for handler, resourceList := range resources {
-		if isMultiResource(handler) {
-			multiHandler := handler.(MultiResourceHandler)
-			err := multiHandler.Apply(config.Notifier, resourceList)
-			if err != nil {
-				return err
-			}
-			continue
-		}
 		for _, resource := range resourceList {
-			existingResource, err := handler.GetRemote(resource.UID)
+			existingResource, err := handler.GetRemote(resource.Name())
 			if err == ErrNotFound {
 
 				err := handler.Add(resource)
@@ -267,12 +249,7 @@ func Preview(config Config, resources Resources, opts *PreviewOpts) error {
 		for _, resource := range resourceList {
 			previewHandler, ok := handler.(PreviewHandler)
 			if !ok {
-				tmpResource := Resource{
-					JSONPath: "",
-					UID:      resource.UID,
-					Handler:  handler,
-				}
-				config.Notifier.NotSupported(tmpResource, "preview")
+				config.Notifier.NotSupported(handler.Kind(), resource.Name(), "preview")
 				return nil
 			}
 			err := previewHandler.Preview(resource, config.Notifier, opts)
@@ -359,12 +336,7 @@ func Listen(config Config, UID, filename string) error {
 	}
 	listenHandler, ok := handler.(ListenHandler)
 	if !ok {
-		tmpResource := Resource{
-			JSONPath: "",
-			UID:      resourceID,
-			Handler:  handler,
-		}
-		config.Notifier.NotSupported(tmpResource, "listen")
+		config.Notifier.NotSupported(handler.Kind(), resourceID, "listen")
 		return nil
 	}
 	return listenHandler.Listen(config.Notifier, resourceID, filename)
@@ -393,7 +365,7 @@ func Export(config Config, exportDir string, resources Resources) error {
 					return err
 				}
 			}
-			path := fmt.Sprintf("%s/%s.%s", dir, resource.UID, extension)
+			path := fmt.Sprintf("%s/%s.%s", dir, resource.Name(), extension)
 
 			existingResourceBytes, err := ioutil.ReadFile(path)
 			isNotExist := os.IsNotExist(err)

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -49,7 +49,7 @@ func Get(config Config, UID string) error {
 	}
 
 	resource = handler.Unprepare(*resource)
-	rep, err := resource.AsYAML()
+	rep, err := resource.YAML()
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func Show(config Config, resources Resources) error {
 		for _, resource := range resourceList {
 			resource = *(handler.Unprepare(resource))
 
-			rep, err := resource.AsYAML()
+			rep, err := resource.YAML()
 			if err != nil {
 				return err
 			}
@@ -165,13 +165,13 @@ func Diff(config Config, resources Resources) error {
 
 	for handler, resourceList := range resources {
 		for _, resource := range resourceList {
-			local, err := resource.AsYAML()
+			local, err := resource.YAML()
 			if err != nil {
 				return nil
 			}
 			resource = *handler.Unprepare(resource)
 			uid := resource.Name()
-			remote, err := handler.GetRemote(resource.Name())
+			remote, err := handler.GetRemote(resource)
 			if err == ErrNotFound {
 				config.Notifier.NotFound(resource)
 				continue
@@ -180,7 +180,7 @@ func Diff(config Config, resources Resources) error {
 				return fmt.Errorf("Error retrieving resource from %s %s: %v", resource.Kind(), uid, err)
 			}
 			remote = handler.Unprepare(*remote)
-			remoteRepresentation, err := (*remote).AsYAML()
+			remoteRepresentation, err := (*remote).YAML()
 			if err != nil {
 				return err
 			}
@@ -207,7 +207,7 @@ func Diff(config Config, resources Resources) error {
 func Apply(config Config, resources Resources) error {
 	for handler, resourceList := range resources {
 		for _, resource := range resourceList {
-			existingResource, err := handler.GetRemote(resource.Name())
+			existingResource, err := handler.GetRemote(resource)
 			if err == ErrNotFound {
 
 				err := handler.Add(resource)
@@ -219,13 +219,13 @@ func Apply(config Config, resources Resources) error {
 			} else if err != nil {
 				return err
 			}
-			resourceRepresentation, err := resource.AsYAML()
+			resourceRepresentation, err := resource.YAML()
 			if err != nil {
 				return err
 			}
 			resource = *handler.Prepare(*existingResource, resource)
 			existingResource = handler.Unprepare(*existingResource)
-			existingResourceRepresentation, err := existingResource.AsYAML()
+			existingResourceRepresentation, err := existingResource.YAML()
 			if err != nil {
 				return nil
 			}
@@ -353,7 +353,7 @@ func Export(config Config, exportDir string, resources Resources) error {
 
 	for handler, resourceList := range resources {
 		for _, resource := range resourceList {
-			updatedResource, err := resource.AsYAML()
+			updatedResource, err := resource.YAML()
 			if err != nil {
 				return err
 			}

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -49,7 +49,7 @@ func Get(config Config, UID string) error {
 	}
 
 	resource = handler.Unprepare(*resource)
-	rep, err := resource.GetRepresentation()
+	rep, err := resource.AsYAML()
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func Show(config Config, resources Resources) error {
 		for _, resource := range resourceList {
 			resource = *(handler.Unprepare(resource))
 
-			rep, err := resource.GetRepresentation()
+			rep, err := resource.AsYAML()
 			if err != nil {
 				return err
 			}
@@ -165,7 +165,7 @@ func Diff(config Config, resources Resources) error {
 
 	for handler, resourceList := range resources {
 		for _, resource := range resourceList {
-			local, err := resource.GetRepresentation()
+			local, err := resource.AsYAML()
 			if err != nil {
 				return nil
 			}
@@ -180,7 +180,7 @@ func Diff(config Config, resources Resources) error {
 				return fmt.Errorf("Error retrieving resource from %s %s: %v", resource.Kind(), uid, err)
 			}
 			remote = handler.Unprepare(*remote)
-			remoteRepresentation, err := (*remote).GetRepresentation()
+			remoteRepresentation, err := (*remote).AsYAML()
 			if err != nil {
 				return err
 			}
@@ -219,13 +219,13 @@ func Apply(config Config, resources Resources) error {
 			} else if err != nil {
 				return err
 			}
-			resourceRepresentation, err := resource.GetRepresentation()
+			resourceRepresentation, err := resource.AsYAML()
 			if err != nil {
 				return err
 			}
 			resource = *handler.Prepare(*existingResource, resource)
 			existingResource = handler.Unprepare(*existingResource)
-			existingResourceRepresentation, err := existingResource.GetRepresentation()
+			existingResourceRepresentation, err := existingResource.AsYAML()
 			if err != nil {
 				return nil
 			}
@@ -353,7 +353,7 @@ func Export(config Config, exportDir string, resources Resources) error {
 
 	for handler, resourceList := range resources {
 		for _, resource := range resourceList {
-			updatedResource, err := resource.GetRepresentation()
+			updatedResource, err := resource.AsYAML()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Before converting to use kubernetes style objects, the resources Grizzly managed required wrapping, because they needed metadata that isn't present in the resource itself.

Now that we are representing resources kubernetes style, this is no-longer the case. We can now work with a `Resource` object that is just a `map[string]interface{}` (with a few helpers). This allows for the removal of a lot of code making the Grizzly code simpler and easier to read.