### PR TITLE
JSONPath no longer needed

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -195,15 +195,13 @@ func providersCmd(config grizzly.Config) *cli.Command {
 		Args:  cli.ArgsExact(0),
 	}
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		f := "%s\t%s\t%s\n"
+		f := "%s\t%s\n"
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
 
-		fmt.Fprintf(w, f, "API VERSION", "KIND", "JSON Paths")
+		fmt.Fprintf(w, f, "API VERSION", "KIND")
 		for _, provider := range config.Registry.Providers {
 			for _, handler := range provider.GetHandlers() {
-				for _, path := range handler.GetJSONPaths() {
-					fmt.Fprintf(w, f, provider.APIVersion(), handler.Kind(), "/"+path)
-				}
+				fmt.Fprintf(w, f, provider.APIVersion(), handler.Kind())
 			}
 		}
 		return w.Flush()

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -39,18 +39,8 @@ func (h *DashboardHandler) APIVersion() string {
 }
 
 const (
-	dashboardsPath         = "grafanaDashboards"
-	dashboardFolderPath    = "grafanaDashboardFolder"
 	dashboardFolderDefault = "General"
 )
-
-// GetJSONPaths returns paths within Jsonnet output that this provider will consume
-func (h *DashboardHandler) GetJSONPaths() []string {
-	return []string{
-		dashboardsPath,
-		dashboardFolderPath,
-	}
-}
 
 // GetExtension returns the file name extension for a dashboard
 func (h *DashboardHandler) GetExtension() string {

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -27,15 +27,6 @@ func (h *DatasourceHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-const datasourcesPath = "grafanaDatasources"
-
-// GetJSONPaths returns paths within Jsonnet output that this provider will consume
-func (h *DatasourceHandler) GetJSONPaths() []string {
-	return []string{
-		datasourcesPath,
-	}
-}
-
 // GetExtension returns the file name extension for a datasource
 func (h *DatasourceHandler) GetExtension() string {
 	return "json"

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -29,17 +29,6 @@ func (h *RuleHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-const prometheusAlertsPath = "prometheusAlerts"
-const prometheusRulesPath = "prometheusRules"
-
-// GetJSONPaths returns paths within Jsonnet output that this provider will consume
-func (h *RuleHandler) GetJSONPaths() []string {
-	return []string{
-		prometheusAlertsPath,
-		prometheusRulesPath,
-	}
-}
-
 // GetExtension returns the file name extension for a rule grouping
 func (h *RuleHandler) GetExtension() string {
 	return "yaml"

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -41,15 +41,6 @@ func (h *SyntheticMonitoringHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-const syntheticMonitoringChecksPath = "syntheticMonitoring"
-
-// GetJSONPaths returns paths within Jsonnet output that this provider will consume
-func (h *SyntheticMonitoringHandler) GetJSONPaths() []string {
-	return []string{
-		syntheticMonitoringChecksPath,
-	}
-}
-
 // GetExtension returns the file name extension for a check
 func (h *SyntheticMonitoringHandler) GetExtension() string {
 	return "json"


### PR DESCRIPTION
Because we now process full resources not hidden elements (temporarily, hidden elements are mutated into full resources using embedded jsonnet), we no longer need to worry about JSON paths, i.e. where in the JSON the hidden elements are to be found.