### PR TITLE
Flatten resources types

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -58,10 +58,10 @@ func (h *DashboardHandler) GetExtension() string {
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *DashboardHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
+func (h *DashboardHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
 	resource := grizzly.Resource(m)
 	resource.SetSpecString("uid", resource.GetMetadata("name"))
-	return resource.AsResourceList(), nil
+	return grizzly.Resources{resource}, nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -42,7 +42,7 @@ func (h *DatasourceHandler) GetExtension() string {
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
+func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
 	resource := grizzly.Resource(m)
 	defaults := map[string]interface{}{
 		"basicAuth":         false,
@@ -66,7 +66,7 @@ func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, er
 	}
 	spec["name"] = m.Metadata().Name()
 	resource["spec"] = spec
-	return resource.AsResourceList(), nil
+	return grizzly.Resources{resource}, nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -46,9 +46,9 @@ func (h *RuleHandler) GetExtension() string {
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *RuleHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
+func (h *RuleHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
 	resource := grizzly.Resource(m)
-	return resource.AsResourceList(), nil
+	return grizzly.Resources{resource}, nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -56,10 +56,10 @@ func (h *SyntheticMonitoringHandler) GetExtension() string {
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *SyntheticMonitoringHandler) Parse(m manifest.Manifest) (grizzly.ResourceList, error) {
+func (h *SyntheticMonitoringHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
 	resource := grizzly.Resource(m)
 	resource.SetSpecString("job", resource.GetMetadata("name"))
-	return resource.AsResourceList(), nil
+	return grizzly.Resources{resource}, nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -76,13 +76,6 @@ func (r *Resource) Spec() map[string]interface{} {
 	return (*r)["spec"].(map[string]interface{})
 }
 
-func (r *Resource) AsResourceList() ResourceList {
-	key := r.Key()
-	resources := ResourceList{}
-	resources[key] = *r
-	return resources
-}
-
 func (r *Resource) SpecAsJSON() (string, error) {
 	y, err := yaml.Marshal(*r)
 	if err != nil {
@@ -117,11 +110,8 @@ func (r *Resource) MatchesTarget(targets []string) bool {
 	return false
 }
 
-// ResourceList represents a set of named resources
-type ResourceList map[string]Resource
-
-// Resources represents a set of resources by handler
-type Resources map[Handler]ResourceList
+// Resources represents a set of resources
+type Resources []Resource
 
 // Handler describes a handler for a single API resource handled by a single provider
 type Handler interface {
@@ -131,7 +121,7 @@ type Handler interface {
 	GetExtension() string
 
 	// Parse parses a manifest object into a struct for this resource type
-	Parse(m manifest.Manifest) (ResourceList, error)
+	Parse(m manifest.Manifest) (Resources, error)
 
 	// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 	Unprepare(resource Resource) *Resource


### PR DESCRIPTION
Previously, we grouped resources in a double structure, so that
we could retrieve them grouped by handler, and could retrieve them
by name too.

Now, we're simply working with lists of kubernetes style objects,
so we just need `Resource` and `Resources` where the latter is just
`[]Resource`. The code gets much simpler with this change.
