### PR TITLE
Add support for running Grizzly with a config file

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -26,22 +26,18 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	config := grizzly.Config{
-		Registry: registry,
-		Notifier: grizzly.Notifier{},
-	}
 	// workflow commands
 	rootCmd.AddCommand(
-		getCmd(config),
-		listCmd(config),
-		showCmd(config),
-		diffCmd(config),
-		applyCmd(config),
-		watchCmd(config),
-		listenCmd(config),
-		exportCmd(config),
-		previewCmd(config),
-		providersCmd(config),
+		getCmd(registry),
+		listCmd(registry),
+		showCmd(registry),
+		diffCmd(registry),
+		applyCmd(registry),
+		watchCmd(registry),
+		listenCmd(registry),
+		exportCmd(registry),
+		previewCmd(registry),
+		providersCmd(registry),
 	)
 
 	// Run!

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -9,6 +9,13 @@ import (
 	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
+func getGrizzlyOpts(cmd *cli.Command) grizzly.GrizzlyOpts {
+	return grizzly.GrizzlyOpts{
+		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
+		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
+	}
+
+}
 func getCmd(config grizzly.Config) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "get <resource-type>.<resource-uid>",
@@ -28,11 +35,7 @@ func listCmd(config grizzly.Config) *cli.Command {
 		Short: "list resource keys from file",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		resources, err := grizzly.Parse(config, jsonnetFile, opts)
@@ -51,11 +54,7 @@ func showCmd(config grizzly.Config) *cli.Command {
 		Short: "render Jsonnet as json",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		resources, err := grizzly.Parse(config, jsonnetFile, opts)
@@ -73,11 +72,7 @@ func diffCmd(config grizzly.Config) *cli.Command {
 		Short: "compare Jsonnet resources with endpoint(s)",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		resources, err := grizzly.Parse(config, jsonnetFile, opts)
@@ -95,11 +90,7 @@ func applyCmd(config grizzly.Config) *cli.Command {
 		Short: "render Jsonnet and push dashboard(s) to Grafana",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		resources, err := grizzly.Parse(config, jsonnetFile, opts)
@@ -130,11 +121,7 @@ func watchCmd(config grizzly.Config) *cli.Command {
 		Short: "watch for file changes and apply",
 		Args:  cli.ArgsExact(2),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		parser := &jsonnetWatchParser{
 			jsonnetFile: args[1],
@@ -167,10 +154,7 @@ func previewCmd(config grizzly.Config) *cli.Command {
 		Short: "upload a snapshot to preview the rendered file",
 		Args:  cli.ArgsAny(),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
+	opts := getGrizzlyOpts(cmd)
 	expires := cmd.Flags().IntP("expires", "e", 0, "when the preview should expire. Default 0 (never)")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
@@ -180,11 +164,11 @@ func previewCmd(config grizzly.Config) *cli.Command {
 			return err
 		}
 
-		opts := &grizzly.PreviewOpts{
+		previewOpts := &grizzly.PreviewOpts{
 			ExpiresSeconds: *expires,
 		}
 
-		return grizzly.Preview(config, resources, opts)
+		return grizzly.Preview(config, resources, previewOpts)
 	}
 	return cmd
 }
@@ -195,11 +179,7 @@ func exportCmd(config grizzly.Config) *cli.Command {
 		Short: "render Jsonnet and save to a directory",
 		Args:  cli.ArgsExact(2),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		dashboardDir := args[1]

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"text/tabwriter"
 
@@ -51,7 +50,6 @@ func showCmd(registry grizzly.Registry) *cli.Command {
 	opts := NewGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		opts.ConsumeArguments(args)
-		log.Printf("targ %v,%s\n", opts.Targets, *opts.ConfigFile)
 		resources, err := grizzly.Parse(registry, opts)
 		if err != nil {
 			return err
@@ -209,14 +207,13 @@ func providersCmd(registry grizzly.Registry) *cli.Command {
 }
 
 func NewGrizzlyOpts(cmd *cli.Command) grizzly.GrizzlyOpts {
-	g := grizzly.GrizzlyOpts{
+	return grizzly.GrizzlyOpts{
 		ConfigFile:   cmd.Flags().StringP("config", "c", "", "config file"),
 		Targets:      cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
 		JsonnetPaths: cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
 	}
-	log.Println("Targets", g.Targets)
-	return g
 }
+
 func getDefaultJsonnetFolders() []string {
 	return []string{"vendor", "lib", "."}
 }

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -26,7 +26,7 @@ func listCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "list <jsonnet-file>",
 		Short: "list resource keys from file",
-		Args:  cli.ArgsExact(1),
+		Args:  cli.ArgsRange(0, 1),
 	}
 	opts := NewGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
@@ -45,7 +45,7 @@ func showCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "show <jsonnet-file>",
 		Short: "render Jsonnet as json",
-		Args:  cli.ArgsExact(1),
+		Args:  cli.ArgsRange(0, 1),
 	}
 	opts := NewGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
@@ -63,7 +63,7 @@ func diffCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "diff <jsonnet-file>",
 		Short: "compare Jsonnet resources with endpoint(s)",
-		Args:  cli.ArgsExact(1),
+		Args:  cli.ArgsRange(0, 1),
 	}
 	opts := NewGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
@@ -81,7 +81,7 @@ func applyCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "apply <jsonnet-file>",
 		Short: "render Jsonnet and push dashboard(s) to Grafana",
-		Args:  cli.ArgsExact(1),
+		Args:  cli.ArgsRange(0, 1),
 	}
 	opts := NewGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -16,7 +16,7 @@ func getGrizzlyOpts(cmd *cli.Command) grizzly.GrizzlyOpts {
 	}
 
 }
-func getCmd(config grizzly.Config) *cli.Command {
+func getCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "get <resource-type>.<resource-uid>",
 		Short: "retrieve resource",
@@ -24,12 +24,12 @@ func getCmd(config grizzly.Config) *cli.Command {
 	}
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		uid := args[0]
-		return grizzly.Get(config, uid)
+		return grizzly.Get(registry, uid)
 	}
 	return cmd
 }
 
-func listCmd(config grizzly.Config) *cli.Command {
+func listCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "list <jsonnet-file>",
 		Short: "list resource keys from file",
@@ -38,17 +38,17 @@ func listCmd(config grizzly.Config) *cli.Command {
 	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
 
-		return grizzly.List(config, resources)
+		return grizzly.List(registry, resources)
 	}
 	return cmd
 }
 
-func showCmd(config grizzly.Config) *cli.Command {
+func showCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "show <jsonnet-file>",
 		Short: "render Jsonnet as json",
@@ -57,16 +57,16 @@ func showCmd(config grizzly.Config) *cli.Command {
 	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
-		return grizzly.Show(config, resources)
+		return grizzly.Show(registry, resources)
 	}
 	return cmd
 }
 
-func diffCmd(config grizzly.Config) *cli.Command {
+func diffCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "diff <jsonnet-file>",
 		Short: "compare Jsonnet resources with endpoint(s)",
@@ -75,16 +75,16 @@ func diffCmd(config grizzly.Config) *cli.Command {
 	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
-		return grizzly.Diff(config, resources)
+		return grizzly.Diff(registry, resources)
 	}
 	return cmd
 }
 
-func applyCmd(config grizzly.Config) *cli.Command {
+func applyCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "apply <jsonnet-file>",
 		Short: "render Jsonnet and push dashboard(s) to Grafana",
@@ -93,11 +93,11 @@ func applyCmd(config grizzly.Config) *cli.Command {
 	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
-		return grizzly.Apply(config, resources)
+		return grizzly.Apply(registry, resources)
 	}
 	return cmd
 }
@@ -111,11 +111,11 @@ func (p *jsonnetWatchParser) Name() string {
 	return p.jsonnetFile
 }
 
-func (p *jsonnetWatchParser) Parse(config grizzly.Config) (grizzly.Resources, error) {
-	return grizzly.Parse(config, p.jsonnetFile, p.opts)
+func (p *jsonnetWatchParser) Parse(registry grizzly.Registry) (grizzly.Resources, error) {
+	return grizzly.Parse(registry, p.jsonnetFile, p.opts)
 }
 
-func watchCmd(config grizzly.Config) *cli.Command {
+func watchCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "watch <dir-to-watch> <jsonnet-file>",
 		Short: "watch for file changes and apply",
@@ -129,12 +129,12 @@ func watchCmd(config grizzly.Config) *cli.Command {
 		}
 		watchDir := args[0]
 
-		return grizzly.Watch(config, watchDir, parser)
+		return grizzly.Watch(registry, watchDir, parser)
 	}
 	return cmd
 }
 
-func listenCmd(config grizzly.Config) *cli.Command {
+func listenCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "listen <uid-to-watch> <output-file>",
 		Short: "listen for file changes on remote and save locally",
@@ -143,12 +143,12 @@ func listenCmd(config grizzly.Config) *cli.Command {
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		uid := args[0]
 		filename := args[1]
-		return grizzly.Listen(config, uid, filename)
+		return grizzly.Listen(registry, uid, filename)
 	}
 	return cmd
 }
 
-func previewCmd(config grizzly.Config) *cli.Command {
+func previewCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "preview <jsonnet-file>",
 		Short: "upload a snapshot to preview the rendered file",
@@ -159,7 +159,7 @@ func previewCmd(config grizzly.Config) *cli.Command {
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
@@ -168,12 +168,12 @@ func previewCmd(config grizzly.Config) *cli.Command {
 			ExpiresSeconds: *expires,
 		}
 
-		return grizzly.Preview(config, resources, previewOpts)
+		return grizzly.Preview(registry, resources, previewOpts)
 	}
 	return cmd
 }
 
-func exportCmd(config grizzly.Config) *cli.Command {
+func exportCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "export <jsonnet-file> <dashboard-dir>",
 		Short: "render Jsonnet and save to a directory",
@@ -183,16 +183,16 @@ func exportCmd(config grizzly.Config) *cli.Command {
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		dashboardDir := args[1]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
-		return grizzly.Export(config, dashboardDir, resources)
+		return grizzly.Export(registry, dashboardDir, resources)
 	}
 	return cmd
 }
 
-func providersCmd(config grizzly.Config) *cli.Command {
+func providersCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "providers",
 		Short: "Lists all providers registered with Grizzly",
@@ -203,7 +203,7 @@ func providersCmd(config grizzly.Config) *cli.Command {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
 
 		fmt.Fprintf(w, f, "API VERSION", "KIND")
-		for _, provider := range config.Registry.Providers {
+		for _, provider := range registry.Providers {
 			for _, handler := range provider.GetHandlers() {
 				fmt.Fprintf(w, f, provider.APIVersion(), handler.Kind())
 			}

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -14,6 +14,5 @@ type GrizzlyOpts struct {
 
 // PreviewOpts Options to Configure a Preview
 type PreviewOpts struct {
-	GrizzlyOpts
 	ExpiresSeconds int
 }

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -1,11 +1,5 @@
 package grizzly
 
-// Config provides configuration to `grizzly`
-type Config struct {
-	Registry Registry
-	Notifier Notifier
-}
-
 // GrizzlyOpts contains options for all Grizzly commands
 type GrizzlyOpts struct {
 	JsonnetPaths []string

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -1,5 +1,12 @@
 package grizzly
 
+import (
+	"fmt"
+
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/mitchellh/mapstructure"
+)
+
 // GrizzlyOpts contains options for all Grizzly commands
 type GrizzlyOpts struct {
 	ConfigFile   *string
@@ -17,4 +24,43 @@ func (o *GrizzlyOpts) ConsumeArguments(args []string) {
 // PreviewOpts Options to Configure a Preview
 type PreviewOpts struct {
 	ExpiresSeconds int
+}
+
+type OutboundSource struct {
+	Name string `yaml:"name"`
+	Path string `yaml:"path"`
+}
+
+const ConfigKind = "GrizzlyConfig"
+
+type Config struct {
+	Outbound []OutboundSource `yaml:"outbound"`
+}
+
+func NewConfig(configResources Resources) (*Config, error) {
+	if len(configResources) == 0 {
+		return nil, fmt.Errorf("No config resources found")
+	}
+	if len(configResources) > 1 {
+		return nil, fmt.Errorf("Only one config resource allowed")
+	}
+	configResource := configResources[0]
+	if configResource.Kind() != ConfigKind {
+		return nil, fmt.Errorf("Expected resource of type %s, got %s", ConfigKind, configResource.Kind())
+	}
+	var config Config
+
+	err := mapstructure.Decode(configResource["spec"], &config)
+	if err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+type ConfigParser struct{}
+
+// Parse parses a manifest object into a struct for this resource type
+func (p *ConfigParser) Parse(m manifest.Manifest) (Resources, error) {
+	resource := Resource(m)
+	return Resources{resource}, nil
 }

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -2,8 +2,16 @@ package grizzly
 
 // GrizzlyOpts contains options for all Grizzly commands
 type GrizzlyOpts struct {
-	JsonnetPaths []string
-	Targets      []string
+	ConfigFile   *string
+	ResourceFile *string
+	JsonnetPaths *[]string
+	Targets      *[]string
+}
+
+func (o *GrizzlyOpts) ConsumeArguments(args []string) {
+	if len(args) > 0 {
+		o.ResourceFile = &args[0]
+	}
 }
 
 // PreviewOpts Options to Configure a Preview

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -6,7 +6,14 @@ type Config struct {
 	Notifier Notifier
 }
 
+// GrizzlyOpts contains options for all Grizzly commands
+type GrizzlyOpts struct {
+	JsonnetPaths []string
+	Targets      []string
+}
+
 // PreviewOpts Options to Configure a Preview
 type PreviewOpts struct {
+	GrizzlyOpts
 	ExpiresSeconds int
 }

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -1,0 +1,106 @@
+package grizzly
+
+import (
+	"bufio"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-jsonnet"
+	"github.com/grafana/tanka/pkg/jsonnet/native"
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/grafana/tanka/pkg/process"
+	"gopkg.in/yaml.v3"
+)
+
+func Parse(config Config, filename string, opts GrizzlyOpts) (Resources, error) {
+	if strings.HasSuffix(filename, ".yaml") ||
+		strings.HasSuffix(filename, ".yml") {
+		return ParseYAML(config, filename, opts)
+	} else if strings.HasSuffix(filename, ".jsonnet") ||
+		strings.HasSuffix(filename, ".libsonnet") ||
+		strings.HasSuffix(filename, ".json") {
+		return ParseJsonnet(config, filename, opts)
+	} else {
+		return nil, fmt.Errorf("Either a config file or a resource file is required")
+	}
+}
+
+// ParseYAML evaluates a YAML file and parses it into resources
+func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, error) {
+	f, err := os.Open(yamlFile)
+	if err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(f)
+	decoder := yaml.NewDecoder(reader)
+	manifests := map[string]manifest.Manifest{}
+	var m manifest.Manifest
+	var resources Resources
+	for i := 0; decoder.Decode(&m) == nil; i++ {
+		manifests[strconv.Itoa(i)] = m
+		handler, err := config.Registry.GetHandler(m.Kind())
+		if err != nil {
+			return nil, err
+		}
+		parsedResources, err := handler.Parse(m)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, parsedResources...)
+
+	}
+	return resources, nil
+}
+
+//go:embed grizzly.jsonnet
+var script string
+
+// ParseJsonnet evaluates a jsonnet file and parses it into an object tree
+func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
+
+	script := fmt.Sprintf(script, jsonnetFile)
+	vm := jsonnet.MakeVM()
+	vm.Importer(newExtendedImporter(opts.JsonnetPaths))
+	for _, nf := range native.Funcs() {
+		vm.NativeFunction(nf)
+	}
+
+	result, err := vm.EvaluateSnippet(jsonnetFile, script)
+	if err != nil {
+		return nil, err
+	}
+	var data interface{}
+	if err := json.Unmarshal([]byte(result), &data); err != nil {
+		return nil, err
+	}
+
+	extracted, err := process.Extract(data)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unwrap *List types
+	if err := process.Unwrap(extracted); err != nil {
+		return nil, err
+	}
+
+	resources := Resources{}
+	for _, m := range extracted {
+		handler, err := config.Registry.GetHandler(m.Kind())
+		if err != nil {
+			log.Println("Error getting handler", err)
+			continue
+		}
+		parsedResources, err := handler.Parse(m)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, parsedResources...)
+	}
+	return resources, nil
+}

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -17,21 +17,21 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func Parse(config Config, filename string, opts GrizzlyOpts) (Resources, error) {
+func Parse(registry Registry, filename string, opts GrizzlyOpts) (Resources, error) {
 	if strings.HasSuffix(filename, ".yaml") ||
 		strings.HasSuffix(filename, ".yml") {
-		return ParseYAML(config, filename, opts)
+		return ParseYAML(registry, filename, opts)
 	} else if strings.HasSuffix(filename, ".jsonnet") ||
 		strings.HasSuffix(filename, ".libsonnet") ||
 		strings.HasSuffix(filename, ".json") {
-		return ParseJsonnet(config, filename, opts)
+		return ParseJsonnet(registry, filename, opts)
 	} else {
 		return nil, fmt.Errorf("Either a config file or a resource file is required")
 	}
 }
 
 // ParseYAML evaluates a YAML file and parses it into resources
-func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, error) {
+func ParseYAML(registry Registry, yamlFile string, opts GrizzlyOpts) (Resources, error) {
 	f, err := os.Open(yamlFile)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, err
 	var resources Resources
 	for i := 0; decoder.Decode(&m) == nil; i++ {
 		manifests[strconv.Itoa(i)] = m
-		handler, err := config.Registry.GetHandler(m.Kind())
+		handler, err := registry.GetHandler(m.Kind())
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, err
 var script string
 
 // ParseJsonnet evaluates a jsonnet file and parses it into an object tree
-func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
+func ParseJsonnet(registry Registry, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
 
 	script := fmt.Sprintf(script, jsonnetFile)
 	vm := jsonnet.MakeVM()
@@ -91,7 +91,7 @@ func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resource
 
 	resources := Resources{}
 	for _, m := range extracted {
-		handler, err := config.Registry.GetHandler(m.Kind())
+		handler, err := registry.GetHandler(m.Kind())
 		if err != nil {
 			log.Println("Error getting handler", err)
 			continue

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -17,14 +17,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func Parse(registry Registry, filename string, opts GrizzlyOpts) (Resources, error) {
-	if strings.HasSuffix(filename, ".yaml") ||
-		strings.HasSuffix(filename, ".yml") {
-		return ParseYAML(registry, filename, opts)
-	} else if strings.HasSuffix(filename, ".jsonnet") ||
-		strings.HasSuffix(filename, ".libsonnet") ||
-		strings.HasSuffix(filename, ".json") {
-		return ParseJsonnet(registry, filename, opts)
+func Parse(registry Registry, opts GrizzlyOpts) (Resources, error) {
+	if strings.HasSuffix(*opts.ResourceFile, ".yaml") ||
+		strings.HasSuffix(*opts.ResourceFile, ".yml") {
+		return ParseYAML(registry, *opts.ResourceFile, opts)
+	} else if strings.HasSuffix(*opts.ResourceFile, ".jsonnet") ||
+		strings.HasSuffix(*opts.ResourceFile, ".libsonnet") ||
+		strings.HasSuffix(*opts.ResourceFile, ".json") {
+		return ParseJsonnet(registry, *opts.ResourceFile, opts)
 	} else {
 		return nil, fmt.Errorf("Either a config file or a resource file is required")
 	}
@@ -65,7 +65,7 @@ func ParseJsonnet(registry Registry, jsonnetFile string, opts GrizzlyOpts) (Reso
 
 	script := fmt.Sprintf(script, jsonnetFile)
 	vm := jsonnet.MakeVM()
-	vm.Importer(newExtendedImporter(opts.JsonnetPaths))
+	vm.Importer(newExtendedImporter(*opts.JsonnetPaths))
 	for _, nf := range native.Funcs() {
 		vm.NativeFunction(nf)
 	}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -209,3 +209,8 @@ func (r *Registry) GetHandler(path string) (Handler, error) {
 	}
 	return handler, nil
 }
+
+// Notifier returns a notifier for responding to users
+func (r *Registry) Notifier() *Notifier {
+	return &Notifier{}
+}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -177,17 +177,15 @@ type Provider interface {
 
 // Registry records providers
 type Registry struct {
-	Providers     []Provider
-	Handlers      []Handler
-	HandlerByName map[string]Handler
+	Providers []Provider
+	Handlers  map[string]Handler
 }
 
 // NewProviderRegistry returns a new registry instance
 func NewProviderRegistry() Registry {
 	registry := Registry{}
 	registry.Providers = []Provider{}
-	registry.Handlers = []Handler{}
-	registry.HandlerByName = map[string]Handler{}
+	registry.Handlers = map[string]Handler{}
 	return registry
 }
 
@@ -195,15 +193,14 @@ func NewProviderRegistry() Registry {
 func (r *Registry) RegisterProvider(provider Provider) error {
 	r.Providers = append(r.Providers, provider)
 	for _, handler := range provider.GetHandlers() {
-		r.Handlers = append(r.Handlers, handler)
-		r.HandlerByName[handler.Kind()] = handler
+		r.Handlers[handler.Kind()] = handler
 	}
 	return nil
 }
 
 // GetHandler returns a single provider based upon a JSON path
 func (r *Registry) GetHandler(path string) (Handler, error) {
-	handler, exists := r.HandlerByName[path]
+	handler, exists := r.Handlers[path]
 	if !exists {
 		return nil, fmt.Errorf("No handler registered to %s", path)
 	}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -167,6 +167,11 @@ type ListenHandler interface {
 	Listen(notifier Notifier, UID, filename string) error
 }
 
+type Parser interface {
+	// Parse parses a manifest object into a struct for this resource type
+	Parse(m manifest.Manifest) (Resources, error)
+}
+
 // Provider describes a single Endpoint Provider
 type Provider interface {
 	Group() string
@@ -198,13 +203,21 @@ func (r *Registry) RegisterProvider(provider Provider) error {
 	return nil
 }
 
-// GetHandler returns a single provider based upon a JSON path
+// GetHandler returns a single handler based upon a Kind
 func (r *Registry) GetHandler(path string) (Handler, error) {
 	handler, exists := r.Handlers[path]
 	if !exists {
 		return nil, fmt.Errorf("No handler registered to %s", path)
 	}
 	return handler, nil
+}
+
+// GetParser returns a single parser based upon a Kind
+func (r *Registry) GetParser(path string) (Parser, error) {
+	if path == ConfigKind {
+		return &ConfigParser{}, nil
+	}
+	return r.GetHandler(path)
 }
 
 // Notifier returns a notifier for responding to users

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -205,15 +205,15 @@ func Preview(registry Registry, resources Resources, opts *PreviewOpts) error {
 	return nil
 }
 
-// Parser encapsulates the action of parsing a resource (jsonnet or otherwise)
-type Parser interface {
+// WatchParser encapsulates the action of parsing a resource (jsonnet or otherwise)
+type WatchParser interface {
 	Name() string
 	Parse(registry Registry) (Resources, error)
 }
 
 // Watch watches a directory for changes then pushes Jsonnet resource to endpoints
 // when changes are noticed
-func Watch(registry Registry, watchDir string, parser Parser) error {
+func Watch(registry Registry, watchDir string, parser WatchParser) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return err

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -1,26 +1,18 @@
 package grizzly
 
 import (
-	"bufio"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 
-	"github.com/google/go-jsonnet"
 	"github.com/grafana/grizzly/pkg/term"
-	"github.com/grafana/tanka/pkg/jsonnet/native"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
-	"github.com/grafana/tanka/pkg/process"
 	"github.com/pmezard/go-difflib/difflib"
 	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/fsnotify.v1"
-	"gopkg.in/yaml.v3"
 )
 
 var interactive = terminal.IsTerminal(int(os.Stdout.Fd()))
@@ -76,94 +68,6 @@ func List(config Config, resources Resources) error {
 		fmt.Fprintf(w, f, handler.APIVersion(), handler.Kind(), resource.Name())
 	}
 	return w.Flush()
-}
-
-func Parse(config Config, filename string, opts GrizzlyOpts) (Resources, error) {
-	if strings.HasSuffix(filename, ".yaml") ||
-		strings.HasSuffix(filename, ".yml") {
-		return ParseYAML(config, filename, opts)
-	} else if strings.HasSuffix(filename, ".jsonnet") ||
-		strings.HasSuffix(filename, ".libsonnet") ||
-		strings.HasSuffix(filename, ".json") {
-		return ParseJsonnet(config, filename, opts)
-	} else {
-		return nil, fmt.Errorf("Either a config file or a resource file is required")
-	}
-}
-
-// ParseYAML evaluates a YAML file and parses it into resources
-func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, error) {
-	f, err := os.Open(yamlFile)
-	if err != nil {
-		return nil, err
-	}
-	reader := bufio.NewReader(f)
-	decoder := yaml.NewDecoder(reader)
-	manifests := map[string]manifest.Manifest{}
-	var m manifest.Manifest
-	var resources Resources
-	for i := 0; decoder.Decode(&m) == nil; i++ {
-		manifests[strconv.Itoa(i)] = m
-		handler, err := config.Registry.GetHandler(m.Kind())
-		if err != nil {
-			return nil, err
-		}
-		parsedResources, err := handler.Parse(m)
-		if err != nil {
-			return nil, err
-		}
-		resources = append(resources, parsedResources...)
-
-	}
-	return resources, nil
-}
-
-//go:embed grizzly.jsonnet
-var script string
-
-// ParseJsonnet evaluates a jsonnet file and parses it into an object tree
-func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
-
-	script := fmt.Sprintf(script, jsonnetFile)
-	vm := jsonnet.MakeVM()
-	vm.Importer(newExtendedImporter(opts.JsonnetPaths))
-	for _, nf := range native.Funcs() {
-		vm.NativeFunction(nf)
-	}
-
-	result, err := vm.EvaluateSnippet(jsonnetFile, script)
-	if err != nil {
-		return nil, err
-	}
-	var data interface{}
-	if err := json.Unmarshal([]byte(result), &data); err != nil {
-		return nil, err
-	}
-
-	extracted, err := process.Extract(data)
-	if err != nil {
-		return nil, err
-	}
-
-	// Unwrap *List types
-	if err := process.Unwrap(extracted); err != nil {
-		return nil, err
-	}
-
-	resources := Resources{}
-	for _, m := range extracted {
-		handler, err := config.Registry.GetHandler(m.Kind())
-		if err != nil {
-			log.Println("Error getting handler", err)
-			continue
-		}
-		parsedResources, err := handler.Parse(m)
-		if err != nil {
-			return nil, err
-		}
-		resources = append(resources, parsedResources...)
-	}
-	return resources, nil
 }
 
 // Show displays resources

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -78,21 +78,21 @@ func List(config Config, resources Resources) error {
 	return w.Flush()
 }
 
-func Parse(config Config, filename string, jsonnetPaths []string, targets []string) (Resources, error) {
+func Parse(config Config, filename string, opts GrizzlyOpts) (Resources, error) {
 	if strings.HasSuffix(filename, ".yaml") ||
 		strings.HasSuffix(filename, ".yml") {
-		return ParseYAML(config, filename, targets)
+		return ParseYAML(config, filename, opts)
 	} else if strings.HasSuffix(filename, ".jsonnet") ||
 		strings.HasSuffix(filename, ".libsonnet") ||
 		strings.HasSuffix(filename, ".json") {
-		return ParseJsonnet(config, filename, jsonnetPaths, targets)
+		return ParseJsonnet(config, filename, opts)
 	} else {
 		return nil, fmt.Errorf("Either a config file or a resource file is required")
 	}
 }
 
 // ParseYAML evaluates a YAML file and parses it into resources
-func ParseYAML(config Config, yamlFile string, targets []string) (Resources, error) {
+func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, error) {
 	f, err := os.Open(yamlFile)
 	if err != nil {
 		return nil, err
@@ -122,11 +122,11 @@ func ParseYAML(config Config, yamlFile string, targets []string) (Resources, err
 var script string
 
 // ParseJsonnet evaluates a jsonnet file and parses it into an object tree
-func ParseJsonnet(config Config, jsonnetFile string, jsonnetPaths []string, targets []string) (Resources, error) {
+func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
 
 	script := fmt.Sprintf(script, jsonnetFile)
 	vm := jsonnet.MakeVM()
-	vm.Importer(newExtendedImporter(jsonnetPaths))
+	vm.Importer(newExtendedImporter(opts.JsonnetPaths))
 	for _, nf := range native.Funcs() {
 		vm.NativeFunction(nf)
 	}

--- a/testdata/yaml/dashboard-simple.yaml
+++ b/testdata/yaml/dashboard-simple.yaml
@@ -1,0 +1,12 @@
+apiVersion: grizzly.grafana.com/v1alpha1
+kind: Dashboard
+metadata:
+    folder: sample
+    name: prod-overview
+spec:
+    schemaVersion: 17
+    tags:
+        - templated
+    timezone: browser
+    title: Production Overview
+    uid: prod-overview

--- a/testdata/yaml/datasource-prometheus.yaml
+++ b/testdata/yaml/datasource-prometheus.yaml
@@ -1,0 +1,23 @@
+apiVersion: grizzly.grafana.com/v1alpha1
+kind: Datasource
+metadata:
+    name: prometheus
+spec:
+    access: proxy
+    basicAuth: false
+    basicAuthPassword: ""
+    basicAuthUser: ""
+    database: ""
+    isDefault: true
+    jsonData:
+        httpMethod: GET
+    name: prometheus
+    orgId: 1
+    password: ""
+    readOnly: false
+    secureJsonFields: {}
+    type: prometheus
+    typeLogoUrl: ""
+    url: http://localhost/prometheus/
+    user: ""
+    withCredentials: false

--- a/testdata/yaml/prometheus-rules.yaml
+++ b/testdata/yaml/prometheus-rules.yaml
@@ -1,0 +1,16 @@
+apiVersion: grizzly.grafana.com/v1alpha1
+kind: PrometheusRuleGroup
+metadata:
+    name: grizzly_alerts
+    namespace: first_rules
+spec:
+    rules:
+        - alert: PromScrapeFailed
+          annotations:
+            message: Prometheus failed to scrape a target {{ $labels.job }}  / {{ $labels.instance }}
+          expr: up != 1
+          for: 1m
+          labels:
+            severity: critical
+        - expr: sum by(job) (up)
+          record: job:up:sum

--- a/testdata/yaml/synthetic-monitoring-simple.yaml
+++ b/testdata/yaml/synthetic-monitoring-simple.yaml
@@ -1,0 +1,44 @@
+apiVersion: grizzly.grafana.com/v1alpha1
+kind: SyntheticMonitoringCheck
+metadata:
+    name: grafana-com
+    type: http
+spec:
+    alertSensitivity: ""
+    basicMetricsOnly: true
+    enabled: true
+    frequency: 60000
+    job: grafana-com
+    labels: []
+    offset: 0
+    probes:
+        - Atlanta
+        - Chicago
+        - LosAngeles
+        - Miami
+        - Seattle
+        - SanJose
+        - Paris
+        - Tokyo
+        - Seol
+        - NewYork
+        - SanFrancisco
+        - Amsterdam
+        - Singapore
+        - Frankfurt
+        - Bangalore
+        - Dallas
+        - Newark
+        - Toronto
+        - London
+        - Mumbai
+        - Sydney
+    settings:
+        http:
+            failIfNotSSL: false
+            failIfSSL: false
+            ipVersion: V4
+            method: GET
+            noFollowRedirects: false
+    target: https://grafana.com/
+    timeout: 2500


### PR DESCRIPTION
Adds support for a basic config file to drive Grizzly. This will facilitate a number of features to come yet.

An example config file could be:
```
apiVersion: grizzly.grafana.com/v1alpha1
kind: GrizzlyConfig
metadata:
  name: grizzly
spec:
  outbound:
  - name: tests
    path: testdata/yaml/*.yaml
```
Executing Grizzly like this:
```
grr show -c grizzly.yaml
```
would cause Grizzly to consume this yaml file, and expand the 'outbound' globs, then parse each file in turn. At present, this mode only supports YAML. For Jsonnet support, just carry on as before. Jsonnet doesn't make sense in this context, because of its `import` functionality.

This PR has been carefully coded to be reviewed one commit at a time. Each commit should be a distinct, and easily consumed change.