### PR TITLE
Prepare for pull functionality

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -26,22 +26,18 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	config := grizzly.Config{
-		Registry: registry,
-		Notifier: grizzly.Notifier{},
-	}
 	// workflow commands
 	rootCmd.AddCommand(
-		getCmd(config),
-		listCmd(config),
-		showCmd(config),
-		diffCmd(config),
-		applyCmd(config),
-		watchCmd(config),
-		listenCmd(config),
-		exportCmd(config),
-		previewCmd(config),
-		providersCmd(config),
+		getCmd(registry),
+		listCmd(registry),
+		showCmd(registry),
+		diffCmd(registry),
+		applyCmd(registry),
+		watchCmd(registry),
+		listenCmd(registry),
+		exportCmd(registry),
+		previewCmd(registry),
+		providersCmd(registry),
 	)
 
 	// Run!

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -9,6 +9,13 @@ import (
 	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
+func getGrizzlyOpts(cmd *cli.Command) grizzly.GrizzlyOpts {
+	return grizzly.GrizzlyOpts{
+		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
+		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
+	}
+
+}
 func getCmd(config grizzly.Config) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "get <resource-type>.<resource-uid>",
@@ -28,11 +35,7 @@ func listCmd(config grizzly.Config) *cli.Command {
 		Short: "list resource keys from file",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		resources, err := grizzly.Parse(config, jsonnetFile, opts)
@@ -51,11 +54,7 @@ func showCmd(config grizzly.Config) *cli.Command {
 		Short: "render Jsonnet as json",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		resources, err := grizzly.Parse(config, jsonnetFile, opts)
@@ -73,11 +72,7 @@ func diffCmd(config grizzly.Config) *cli.Command {
 		Short: "compare Jsonnet resources with endpoint(s)",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		resources, err := grizzly.Parse(config, jsonnetFile, opts)
@@ -95,11 +90,7 @@ func applyCmd(config grizzly.Config) *cli.Command {
 		Short: "render Jsonnet and push dashboard(s) to Grafana",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		resources, err := grizzly.Parse(config, jsonnetFile, opts)
@@ -130,11 +121,7 @@ func watchCmd(config grizzly.Config) *cli.Command {
 		Short: "watch for file changes and apply",
 		Args:  cli.ArgsExact(2),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		parser := &jsonnetWatchParser{
 			jsonnetFile: args[1],
@@ -167,10 +154,7 @@ func previewCmd(config grizzly.Config) *cli.Command {
 		Short: "upload a snapshot to preview the rendered file",
 		Args:  cli.ArgsAny(),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
+	opts := getGrizzlyOpts(cmd)
 	expires := cmd.Flags().IntP("expires", "e", 0, "when the preview should expire. Default 0 (never)")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
@@ -180,11 +164,11 @@ func previewCmd(config grizzly.Config) *cli.Command {
 			return err
 		}
 
-		opts := &grizzly.PreviewOpts{
+		previewOpts := &grizzly.PreviewOpts{
 			ExpiresSeconds: *expires,
 		}
 
-		return grizzly.Preview(config, resources, opts)
+		return grizzly.Preview(config, resources, previewOpts)
 	}
 	return cmd
 }
@@ -195,11 +179,7 @@ func exportCmd(config grizzly.Config) *cli.Command {
 		Short: "render Jsonnet and save to a directory",
 		Args:  cli.ArgsExact(2),
 	}
-	opts := grizzly.GrizzlyOpts{
-		Targets:      *cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
-		JsonnetPaths: *cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
-	}
-
+	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		dashboardDir := args[1]

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"text/tabwriter"
 
@@ -51,7 +50,6 @@ func showCmd(registry grizzly.Registry) *cli.Command {
 	opts := NewGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		opts.ConsumeArguments(args)
-		log.Printf("targ %v,%s\n", opts.Targets, *opts.ConfigFile)
 		resources, err := grizzly.Parse(registry, opts)
 		if err != nil {
 			return err
@@ -209,14 +207,13 @@ func providersCmd(registry grizzly.Registry) *cli.Command {
 }
 
 func NewGrizzlyOpts(cmd *cli.Command) grizzly.GrizzlyOpts {
-	g := grizzly.GrizzlyOpts{
+	return grizzly.GrizzlyOpts{
 		ConfigFile:   cmd.Flags().StringP("config", "c", "", "config file"),
 		Targets:      cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),
 		JsonnetPaths: cmd.Flags().StringSliceP("jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)"),
 	}
-	log.Println("Targets", g.Targets)
-	return g
 }
+
 func getDefaultJsonnetFolders() []string {
 	return []string{"vendor", "lib", "."}
 }

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -16,7 +16,7 @@ func getGrizzlyOpts(cmd *cli.Command) grizzly.GrizzlyOpts {
 	}
 
 }
-func getCmd(config grizzly.Config) *cli.Command {
+func getCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "get <resource-type>.<resource-uid>",
 		Short: "retrieve resource",
@@ -24,12 +24,12 @@ func getCmd(config grizzly.Config) *cli.Command {
 	}
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		uid := args[0]
-		return grizzly.Get(config, uid)
+		return grizzly.Get(registry, uid)
 	}
 	return cmd
 }
 
-func listCmd(config grizzly.Config) *cli.Command {
+func listCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "list <jsonnet-file>",
 		Short: "list resource keys from file",
@@ -38,17 +38,17 @@ func listCmd(config grizzly.Config) *cli.Command {
 	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
 
-		return grizzly.List(config, resources)
+		return grizzly.List(registry, resources)
 	}
 	return cmd
 }
 
-func showCmd(config grizzly.Config) *cli.Command {
+func showCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "show <jsonnet-file>",
 		Short: "render Jsonnet as json",
@@ -57,16 +57,16 @@ func showCmd(config grizzly.Config) *cli.Command {
 	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
-		return grizzly.Show(config, resources)
+		return grizzly.Show(registry, resources)
 	}
 	return cmd
 }
 
-func diffCmd(config grizzly.Config) *cli.Command {
+func diffCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "diff <jsonnet-file>",
 		Short: "compare Jsonnet resources with endpoint(s)",
@@ -75,16 +75,16 @@ func diffCmd(config grizzly.Config) *cli.Command {
 	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
-		return grizzly.Diff(config, resources)
+		return grizzly.Diff(registry, resources)
 	}
 	return cmd
 }
 
-func applyCmd(config grizzly.Config) *cli.Command {
+func applyCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "apply <jsonnet-file>",
 		Short: "render Jsonnet and push dashboard(s) to Grafana",
@@ -93,11 +93,11 @@ func applyCmd(config grizzly.Config) *cli.Command {
 	opts := getGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
-		return grizzly.Apply(config, resources)
+		return grizzly.Apply(registry, resources)
 	}
 	return cmd
 }
@@ -111,11 +111,11 @@ func (p *jsonnetWatchParser) Name() string {
 	return p.jsonnetFile
 }
 
-func (p *jsonnetWatchParser) Parse(config grizzly.Config) (grizzly.Resources, error) {
-	return grizzly.Parse(config, p.jsonnetFile, p.opts)
+func (p *jsonnetWatchParser) Parse(registry grizzly.Registry) (grizzly.Resources, error) {
+	return grizzly.Parse(registry, p.jsonnetFile, p.opts)
 }
 
-func watchCmd(config grizzly.Config) *cli.Command {
+func watchCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "watch <dir-to-watch> <jsonnet-file>",
 		Short: "watch for file changes and apply",
@@ -129,12 +129,12 @@ func watchCmd(config grizzly.Config) *cli.Command {
 		}
 		watchDir := args[0]
 
-		return grizzly.Watch(config, watchDir, parser)
+		return grizzly.Watch(registry, watchDir, parser)
 	}
 	return cmd
 }
 
-func listenCmd(config grizzly.Config) *cli.Command {
+func listenCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "listen <uid-to-watch> <output-file>",
 		Short: "listen for file changes on remote and save locally",
@@ -143,12 +143,12 @@ func listenCmd(config grizzly.Config) *cli.Command {
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		uid := args[0]
 		filename := args[1]
-		return grizzly.Listen(config, uid, filename)
+		return grizzly.Listen(registry, uid, filename)
 	}
 	return cmd
 }
 
-func previewCmd(config grizzly.Config) *cli.Command {
+func previewCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "preview <jsonnet-file>",
 		Short: "upload a snapshot to preview the rendered file",
@@ -159,7 +159,7 @@ func previewCmd(config grizzly.Config) *cli.Command {
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
@@ -168,12 +168,12 @@ func previewCmd(config grizzly.Config) *cli.Command {
 			ExpiresSeconds: *expires,
 		}
 
-		return grizzly.Preview(config, resources, previewOpts)
+		return grizzly.Preview(registry, resources, previewOpts)
 	}
 	return cmd
 }
 
-func exportCmd(config grizzly.Config) *cli.Command {
+func exportCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "export <jsonnet-file> <dashboard-dir>",
 		Short: "render Jsonnet and save to a directory",
@@ -183,16 +183,16 @@ func exportCmd(config grizzly.Config) *cli.Command {
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		jsonnetFile := args[0]
 		dashboardDir := args[1]
-		resources, err := grizzly.Parse(config, jsonnetFile, opts)
+		resources, err := grizzly.Parse(registry, jsonnetFile, opts)
 		if err != nil {
 			return err
 		}
-		return grizzly.Export(config, dashboardDir, resources)
+		return grizzly.Export(registry, dashboardDir, resources)
 	}
 	return cmd
 }
 
-func providersCmd(config grizzly.Config) *cli.Command {
+func providersCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "providers",
 		Short: "Lists all providers registered with Grizzly",
@@ -203,7 +203,7 @@ func providersCmd(config grizzly.Config) *cli.Command {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
 
 		fmt.Fprintf(w, f, "API VERSION", "KIND")
-		for _, provider := range config.Registry.Providers {
+		for _, provider := range registry.Providers {
 			for _, handler := range provider.GetHandlers() {
 				fmt.Fprintf(w, f, provider.APIVersion(), handler.Kind())
 			}

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -28,7 +28,7 @@ func listCmd(registry grizzly.Registry) *cli.Command {
 		Short: "list resource keys from file",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := newGrizzlyOpts(cmd)
+	opts := grizzlyOptsFromCmd(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		if len(args) > 0 {
 			opts.ResourceFile = &args[0]
@@ -49,7 +49,7 @@ func showCmd(registry grizzly.Registry) *cli.Command {
 		Short: "render Jsonnet as json",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := newGrizzlyOpts(cmd)
+	opts := grizzlyOptsFromCmd(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		if len(args) > 0 {
 			opts.ResourceFile = &args[0]
@@ -69,7 +69,7 @@ func diffCmd(registry grizzly.Registry) *cli.Command {
 		Short: "compare Jsonnet resources with endpoint(s)",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := newGrizzlyOpts(cmd)
+	opts := grizzlyOptsFromCmd(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		if len(args) > 0 {
 			opts.ResourceFile = &args[0]
@@ -89,7 +89,7 @@ func applyCmd(registry grizzly.Registry) *cli.Command {
 		Short: "render Jsonnet and push dashboard(s) to Grafana",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := newGrizzlyOpts(cmd)
+	opts := grizzlyOptsFromCmd(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		if len(args) > 0 {
 			opts.ResourceFile = &args[0]
@@ -122,7 +122,7 @@ func watchCmd(registry grizzly.Registry) *cli.Command {
 		Short: "watch for file changes and apply",
 		Args:  cli.ArgsExact(2),
 	}
-	opts := newGrizzlyOpts(cmd)
+	opts := grizzlyOptsFromCmd(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		parser := &jsonnetWatchParser{
 			jsonnetFile: args[1],
@@ -155,7 +155,7 @@ func previewCmd(registry grizzly.Registry) *cli.Command {
 		Short: "upload a snapshot to preview the rendered file",
 		Args:  cli.ArgsAny(),
 	}
-	opts := newGrizzlyOpts(cmd)
+	opts := grizzlyOptsFromCmd(cmd)
 	expires := cmd.Flags().IntP("expires", "e", 0, "when the preview should expire. Default 0 (never)")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
@@ -182,7 +182,7 @@ func exportCmd(registry grizzly.Registry) *cli.Command {
 		Short: "render Jsonnet and save to a directory",
 		Args:  cli.ArgsExact(2),
 	}
-	opts := newGrizzlyOpts(cmd)
+	opts := grizzlyOptsFromCmd(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		if len(args) > 0 {
 			opts.ResourceFile = &args[0]
@@ -218,7 +218,7 @@ func providersCmd(registry grizzly.Registry) *cli.Command {
 	return cmd
 }
 
-func newGrizzlyOpts(cmd *cli.Command) grizzly.GrizzlyOpts {
+func grizzlyOptsFromCmd(cmd *cli.Command) grizzly.GrizzlyOpts {
 	return grizzly.GrizzlyOpts{
 		ConfigFile:   cmd.Flags().StringP("config", "c", "", "config file"),
 		Targets:      cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -28,9 +28,11 @@ func listCmd(registry grizzly.Registry) *cli.Command {
 		Short: "list resource keys from file",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := NewGrizzlyOpts(cmd)
+	opts := newGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		opts.ConsumeArguments(args)
+		if len(args) > 0 {
+			opts.ResourceFile = &args[0]
+		}
 		resources, err := grizzly.Parse(registry, opts)
 		if err != nil {
 			return err
@@ -47,9 +49,11 @@ func showCmd(registry grizzly.Registry) *cli.Command {
 		Short: "render Jsonnet as json",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := NewGrizzlyOpts(cmd)
+	opts := newGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		opts.ConsumeArguments(args)
+		if len(args) > 0 {
+			opts.ResourceFile = &args[0]
+		}
 		resources, err := grizzly.Parse(registry, opts)
 		if err != nil {
 			return err
@@ -65,9 +69,11 @@ func diffCmd(registry grizzly.Registry) *cli.Command {
 		Short: "compare Jsonnet resources with endpoint(s)",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := NewGrizzlyOpts(cmd)
+	opts := newGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		opts.ConsumeArguments(args)
+		if len(args) > 0 {
+			opts.ResourceFile = &args[0]
+		}
 		resources, err := grizzly.Parse(registry, opts)
 		if err != nil {
 			return err
@@ -83,9 +89,11 @@ func applyCmd(registry grizzly.Registry) *cli.Command {
 		Short: "render Jsonnet and push dashboard(s) to Grafana",
 		Args:  cli.ArgsExact(1),
 	}
-	opts := NewGrizzlyOpts(cmd)
+	opts := newGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		opts.ConsumeArguments(args)
+		if len(args) > 0 {
+			opts.ResourceFile = &args[0]
+		}
 		resources, err := grizzly.Parse(registry, opts)
 		if err != nil {
 			return err
@@ -114,7 +122,7 @@ func watchCmd(registry grizzly.Registry) *cli.Command {
 		Short: "watch for file changes and apply",
 		Args:  cli.ArgsExact(2),
 	}
-	opts := NewGrizzlyOpts(cmd)
+	opts := newGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		parser := &jsonnetWatchParser{
 			jsonnetFile: args[1],
@@ -147,11 +155,13 @@ func previewCmd(registry grizzly.Registry) *cli.Command {
 		Short: "upload a snapshot to preview the rendered file",
 		Args:  cli.ArgsAny(),
 	}
-	opts := NewGrizzlyOpts(cmd)
+	opts := newGrizzlyOpts(cmd)
 	expires := cmd.Flags().IntP("expires", "e", 0, "when the preview should expire. Default 0 (never)")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		opts.ConsumeArguments(args)
+		if len(args) > 0 {
+			opts.ResourceFile = &args[0]
+		}
 		resources, err := grizzly.Parse(registry, opts)
 		if err != nil {
 			return err
@@ -172,9 +182,11 @@ func exportCmd(registry grizzly.Registry) *cli.Command {
 		Short: "render Jsonnet and save to a directory",
 		Args:  cli.ArgsExact(2),
 	}
-	opts := NewGrizzlyOpts(cmd)
+	opts := newGrizzlyOpts(cmd)
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		opts.ConsumeArguments(args)
+		if len(args) > 0 {
+			opts.ResourceFile = &args[0]
+		}
 		dashboardDir := args[1]
 		resources, err := grizzly.Parse(registry, opts)
 		if err != nil {
@@ -206,7 +218,7 @@ func providersCmd(registry grizzly.Registry) *cli.Command {
 	return cmd
 }
 
-func NewGrizzlyOpts(cmd *cli.Command) grizzly.GrizzlyOpts {
+func newGrizzlyOpts(cmd *cli.Command) grizzly.GrizzlyOpts {
 	return grizzly.GrizzlyOpts{
 		ConfigFile:   cmd.Flags().StringP("config", "c", "", "config file"),
 		Targets:      cmd.Flags().StringSliceP("target", "t", nil, "resources to target"),

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -253,13 +253,17 @@ func findOrCreateFolder(UID string) (int64, error) {
 	return createFolder(UID)
 }
 
+func makeFolderUID(title string) string {
+	uid := strings.ReplaceAll(title, " ", "-")
+	return uid
+}
 func createFolder(UID string) (int64, error) {
 	grafanaURL, err := getGrafanaURL("api/folders")
 	if err != nil {
 		return 0, err
 	}
 	folder := Folder{
-		UID:   UID,
+		UID:   makeFolderUID(UID),
 		Title: UID,
 	}
 

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -255,20 +255,20 @@ func findOrCreateFolder(UID string) (int64, error) {
 	return createFolder(UID)
 }
 
-func makeFolderUID(title string) string {
-	re, _ := regexp.Compile(`[^A-Za-z0-9_\-]`)
-	uid := strings.ReplaceAll(title, " ", "-")
-	uid = re.ReplaceAllString(uid, "")
-	return uid
-}
-func createFolder(UID string) (int64, error) {
+func createFolder(title string) (int64, error) {
 	grafanaURL, err := getGrafanaURL("api/folders")
 	if err != nil {
 		return 0, err
 	}
+
+	// Convert title to UID (replace space with dash, strip all non alphanumeric characters):
+	UID := strings.ReplaceAll(title, " ", "-")
+	re, _ := regexp.Compile(`[^A-Za-z0-9_\-]`)
+	UID = re.ReplaceAllString(UID, "")
+
 	folder := Folder{
-		UID:   makeFolderUID(UID),
-		Title: UID,
+		UID:   UID,
+		Title: title,
 	}
 
 	folderJSON, err := folder.toJSON()

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
 )
@@ -254,7 +256,9 @@ func findOrCreateFolder(UID string) (int64, error) {
 }
 
 func makeFolderUID(title string) string {
+	re, _ := regexp.Compile(`[^A-Za-z0-9_\-]`)
 	uid := strings.ReplaceAll(title, " ", "-")
+	uid = re.ReplaceAllString(uid, "")
 	return uid
 }
 func createFolder(UID string) (int64, error) {

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -55,7 +55,7 @@ func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.Resources, error
 			spec[k] = defaults[k]
 		}
 	}
-	spec["name"] = m.Metadata().Name()
+	spec["uid"] = m.Metadata().Name()
 	resource["spec"] = spec
 	return grizzly.Resources{resource}, nil
 }
@@ -70,6 +70,7 @@ func (h *DatasourceHandler) Unprepare(resource grizzly.Resource) *grizzly.Resour
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *DatasourceHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
 	resource.SetSpecValue("id", existing.GetSpecValue("id"))
+	resource.DeleteSpecKey("version")
 	return &resource
 }
 

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -69,7 +69,7 @@ func (h *DatasourceHandler) Unprepare(resource grizzly.Resource) *grizzly.Resour
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *DatasourceHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	resource.SetSpecString("id", existing.GetSpecString("id"))
+	resource.SetSpecValue("id", existing.GetSpecValue("id"))
 	return &resource
 }
 

--- a/pkg/grafana/datasources.go
+++ b/pkg/grafana/datasources.go
@@ -13,7 +13,7 @@ import (
 
 // getRemoteDatasource retrieves a datasource object from Grafana
 func getRemoteDatasource(uid string) (*grizzly.Resource, error) {
-	grafanaURL, err := getGrafanaURL("api/datasources/name/" + uid)
+	grafanaURL, err := getGrafanaURL("api/datasources/uid/" + uid)
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +25,7 @@ func getRemoteDatasource(uid string) (*grizzly.Resource, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
 		resp.Body.Close()
-		grafanaURL, err := getGrafanaURL("api/datasources/uid/" + uid)
+		grafanaURL, err := getGrafanaURL("api/datasources/name/" + uid)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/grafana/datasources.go
+++ b/pkg/grafana/datasources.go
@@ -23,7 +23,19 @@ func getRemoteDatasource(uid string) (*grizzly.Resource, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		grafanaURL, err := getGrafanaURL("api/datasources/uid/" + uid)
+		if err != nil {
+			return nil, err
+		}
 
+		resp, err = http.Get(grafanaURL)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+	}
 	switch resp.StatusCode {
 	case http.StatusNotFound:
 		return nil, grizzly.ErrNotFound

--- a/pkg/grafana/datasources.go
+++ b/pkg/grafana/datasources.go
@@ -96,7 +96,7 @@ func postDatasource(resource grizzly.Resource) error {
 
 func putDatasource(resource grizzly.Resource) error {
 	spec := resource.Spec()
-	id := spec["id"].(int64)
+	id := int64(spec["id"].(float64))
 	grafanaURL, err := getGrafanaURL(fmt.Sprintf("api/datasources/%d", id))
 	if err != nil {
 		return err

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -14,6 +14,5 @@ type GrizzlyOpts struct {
 
 // PreviewOpts Options to Configure a Preview
 type PreviewOpts struct {
-	GrizzlyOpts
 	ExpiresSeconds int
 }

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -1,11 +1,5 @@
 package grizzly
 
-// Config provides configuration to `grizzly`
-type Config struct {
-	Registry Registry
-	Notifier Notifier
-}
-
 // GrizzlyOpts contains options for all Grizzly commands
 type GrizzlyOpts struct {
 	JsonnetPaths []string

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -8,12 +8,6 @@ type GrizzlyOpts struct {
 	Targets      *[]string
 }
 
-func (o *GrizzlyOpts) ConsumeArguments(args []string) {
-	if len(args) > 0 {
-		o.ResourceFile = &args[0]
-	}
-}
-
 // PreviewOpts Options to Configure a Preview
 type PreviewOpts struct {
 	ExpiresSeconds int

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -2,8 +2,16 @@ package grizzly
 
 // GrizzlyOpts contains options for all Grizzly commands
 type GrizzlyOpts struct {
-	JsonnetPaths []string
-	Targets      []string
+	ConfigFile   *string
+	ResourceFile *string
+	JsonnetPaths *[]string
+	Targets      *[]string
+}
+
+func (o *GrizzlyOpts) ConsumeArguments(args []string) {
+	if len(args) > 0 {
+		o.ResourceFile = &args[0]
+	}
 }
 
 // PreviewOpts Options to Configure a Preview

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -6,7 +6,14 @@ type Config struct {
 	Notifier Notifier
 }
 
+// GrizzlyOpts contains options for all Grizzly commands
+type GrizzlyOpts struct {
+	JsonnetPaths []string
+	Targets      []string
+}
+
 // PreviewOpts Options to Configure a Preview
 type PreviewOpts struct {
+	GrizzlyOpts
 	ExpiresSeconds int
 }

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -1,0 +1,106 @@
+package grizzly
+
+import (
+	"bufio"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-jsonnet"
+	"github.com/grafana/tanka/pkg/jsonnet/native"
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/grafana/tanka/pkg/process"
+	"gopkg.in/yaml.v3"
+)
+
+func Parse(config Config, filename string, opts GrizzlyOpts) (Resources, error) {
+	if strings.HasSuffix(filename, ".yaml") ||
+		strings.HasSuffix(filename, ".yml") {
+		return ParseYAML(config, filename, opts)
+	} else if strings.HasSuffix(filename, ".jsonnet") ||
+		strings.HasSuffix(filename, ".libsonnet") ||
+		strings.HasSuffix(filename, ".json") {
+		return ParseJsonnet(config, filename, opts)
+	} else {
+		return nil, fmt.Errorf("Either a config file or a resource file is required")
+	}
+}
+
+// ParseYAML evaluates a YAML file and parses it into resources
+func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, error) {
+	f, err := os.Open(yamlFile)
+	if err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(f)
+	decoder := yaml.NewDecoder(reader)
+	manifests := map[string]manifest.Manifest{}
+	var m manifest.Manifest
+	var resources Resources
+	for i := 0; decoder.Decode(&m) == nil; i++ {
+		manifests[strconv.Itoa(i)] = m
+		handler, err := config.Registry.GetHandler(m.Kind())
+		if err != nil {
+			return nil, err
+		}
+		parsedResources, err := handler.Parse(m)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, parsedResources...)
+
+	}
+	return resources, nil
+}
+
+//go:embed grizzly.jsonnet
+var script string
+
+// ParseJsonnet evaluates a jsonnet file and parses it into an object tree
+func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
+
+	script := fmt.Sprintf(script, jsonnetFile)
+	vm := jsonnet.MakeVM()
+	vm.Importer(newExtendedImporter(opts.JsonnetPaths))
+	for _, nf := range native.Funcs() {
+		vm.NativeFunction(nf)
+	}
+
+	result, err := vm.EvaluateSnippet(jsonnetFile, script)
+	if err != nil {
+		return nil, err
+	}
+	var data interface{}
+	if err := json.Unmarshal([]byte(result), &data); err != nil {
+		return nil, err
+	}
+
+	extracted, err := process.Extract(data)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unwrap *List types
+	if err := process.Unwrap(extracted); err != nil {
+		return nil, err
+	}
+
+	resources := Resources{}
+	for _, m := range extracted {
+		handler, err := config.Registry.GetHandler(m.Kind())
+		if err != nil {
+			log.Println("Error getting handler", err)
+			continue
+		}
+		parsedResources, err := handler.Parse(m)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, parsedResources...)
+	}
+	return resources, nil
+}

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -17,21 +17,21 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func Parse(config Config, filename string, opts GrizzlyOpts) (Resources, error) {
+func Parse(registry Registry, filename string, opts GrizzlyOpts) (Resources, error) {
 	if strings.HasSuffix(filename, ".yaml") ||
 		strings.HasSuffix(filename, ".yml") {
-		return ParseYAML(config, filename, opts)
+		return ParseYAML(registry, filename, opts)
 	} else if strings.HasSuffix(filename, ".jsonnet") ||
 		strings.HasSuffix(filename, ".libsonnet") ||
 		strings.HasSuffix(filename, ".json") {
-		return ParseJsonnet(config, filename, opts)
+		return ParseJsonnet(registry, filename, opts)
 	} else {
 		return nil, fmt.Errorf("Either a config file or a resource file is required")
 	}
 }
 
 // ParseYAML evaluates a YAML file and parses it into resources
-func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, error) {
+func ParseYAML(registry Registry, yamlFile string, opts GrizzlyOpts) (Resources, error) {
 	f, err := os.Open(yamlFile)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, err
 	var resources Resources
 	for i := 0; decoder.Decode(&m) == nil; i++ {
 		manifests[strconv.Itoa(i)] = m
-		handler, err := config.Registry.GetHandler(m.Kind())
+		handler, err := registry.GetHandler(m.Kind())
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, err
 var script string
 
 // ParseJsonnet evaluates a jsonnet file and parses it into an object tree
-func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
+func ParseJsonnet(registry Registry, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
 
 	script := fmt.Sprintf(script, jsonnetFile)
 	vm := jsonnet.MakeVM()
@@ -91,7 +91,7 @@ func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resource
 
 	resources := Resources{}
 	for _, m := range extracted {
-		handler, err := config.Registry.GetHandler(m.Kind())
+		handler, err := registry.GetHandler(m.Kind())
 		if err != nil {
 			log.Println("Error getting handler", err)
 			continue

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -17,14 +17,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func Parse(registry Registry, filename string, opts GrizzlyOpts) (Resources, error) {
-	if strings.HasSuffix(filename, ".yaml") ||
-		strings.HasSuffix(filename, ".yml") {
-		return ParseYAML(registry, filename, opts)
-	} else if strings.HasSuffix(filename, ".jsonnet") ||
-		strings.HasSuffix(filename, ".libsonnet") ||
-		strings.HasSuffix(filename, ".json") {
-		return ParseJsonnet(registry, filename, opts)
+func Parse(registry Registry, opts GrizzlyOpts) (Resources, error) {
+	if strings.HasSuffix(*opts.ResourceFile, ".yaml") ||
+		strings.HasSuffix(*opts.ResourceFile, ".yml") {
+		return ParseYAML(registry, *opts.ResourceFile, opts)
+	} else if strings.HasSuffix(*opts.ResourceFile, ".jsonnet") ||
+		strings.HasSuffix(*opts.ResourceFile, ".libsonnet") ||
+		strings.HasSuffix(*opts.ResourceFile, ".json") {
+		return ParseJsonnet(registry, *opts.ResourceFile, opts)
 	} else {
 		return nil, fmt.Errorf("Either a config file or a resource file is required")
 	}
@@ -65,7 +65,7 @@ func ParseJsonnet(registry Registry, jsonnetFile string, opts GrizzlyOpts) (Reso
 
 	script := fmt.Sprintf(script, jsonnetFile)
 	vm := jsonnet.MakeVM()
-	vm.Importer(newExtendedImporter(opts.JsonnetPaths))
+	vm.Importer(newExtendedImporter(*opts.JsonnetPaths))
 	for _, nf := range native.Funcs() {
 		vm.NativeFunction(nf)
 	}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -209,3 +209,8 @@ func (r *Registry) GetHandler(path string) (Handler, error) {
 	}
 	return handler, nil
 }
+
+// Notifier returns a notifier for responding to users
+func (r *Registry) Notifier() *Notifier {
+	return &Notifier{}
+}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -177,17 +177,15 @@ type Provider interface {
 
 // Registry records providers
 type Registry struct {
-	Providers     []Provider
-	Handlers      []Handler
-	HandlerByName map[string]Handler
+	Providers []Provider
+	Handlers  map[string]Handler
 }
 
 // NewProviderRegistry returns a new registry instance
 func NewProviderRegistry() Registry {
 	registry := Registry{}
 	registry.Providers = []Provider{}
-	registry.Handlers = []Handler{}
-	registry.HandlerByName = map[string]Handler{}
+	registry.Handlers = map[string]Handler{}
 	return registry
 }
 
@@ -195,15 +193,14 @@ func NewProviderRegistry() Registry {
 func (r *Registry) RegisterProvider(provider Provider) error {
 	r.Providers = append(r.Providers, provider)
 	for _, handler := range provider.GetHandlers() {
-		r.Handlers = append(r.Handlers, handler)
-		r.HandlerByName[handler.Kind()] = handler
+		r.Handlers[handler.Kind()] = handler
 	}
 	return nil
 }
 
 // GetHandler returns a single provider based upon a JSON path
 func (r *Registry) GetHandler(path string) (Handler, error) {
-	handler, exists := r.HandlerByName[path]
+	handler, exists := r.Handlers[path]
 	if !exists {
 		return nil, fmt.Errorf("No handler registered to %s", path)
 	}

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -76,6 +76,9 @@ func Show(registry Registry, resources Resources) error {
 	var items []term.PageItem
 	for _, resource := range resources {
 		handler, err := registry.GetHandler(resource.Kind())
+		if err != nil {
+			return nil
+		}
 		resource = *(handler.Unprepare(resource))
 
 		rep, err := resource.YAML()

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -205,15 +205,15 @@ func Preview(registry Registry, resources Resources, opts *PreviewOpts) error {
 	return nil
 }
 
-// Parser encapsulates the action of parsing a resource (jsonnet or otherwise)
-type Parser interface {
+// WatchParser encapsulates the action of parsing a resource (jsonnet or otherwise)
+type WatchParser interface {
 	Name() string
 	Parse(registry Registry) (Resources, error)
 }
 
 // Watch watches a directory for changes then pushes Jsonnet resource to endpoints
 // when changes are noticed
-func Watch(registry Registry, watchDir string, parser Parser) error {
+func Watch(registry Registry, watchDir string, parser WatchParser) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return err

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -1,26 +1,18 @@
 package grizzly
 
 import (
-	"bufio"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 
-	"github.com/google/go-jsonnet"
 	"github.com/grafana/grizzly/pkg/term"
-	"github.com/grafana/tanka/pkg/jsonnet/native"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
-	"github.com/grafana/tanka/pkg/process"
 	"github.com/pmezard/go-difflib/difflib"
 	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/fsnotify.v1"
-	"gopkg.in/yaml.v3"
 )
 
 var interactive = terminal.IsTerminal(int(os.Stdout.Fd()))
@@ -76,94 +68,6 @@ func List(config Config, resources Resources) error {
 		fmt.Fprintf(w, f, handler.APIVersion(), handler.Kind(), resource.Name())
 	}
 	return w.Flush()
-}
-
-func Parse(config Config, filename string, opts GrizzlyOpts) (Resources, error) {
-	if strings.HasSuffix(filename, ".yaml") ||
-		strings.HasSuffix(filename, ".yml") {
-		return ParseYAML(config, filename, opts)
-	} else if strings.HasSuffix(filename, ".jsonnet") ||
-		strings.HasSuffix(filename, ".libsonnet") ||
-		strings.HasSuffix(filename, ".json") {
-		return ParseJsonnet(config, filename, opts)
-	} else {
-		return nil, fmt.Errorf("Either a config file or a resource file is required")
-	}
-}
-
-// ParseYAML evaluates a YAML file and parses it into resources
-func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, error) {
-	f, err := os.Open(yamlFile)
-	if err != nil {
-		return nil, err
-	}
-	reader := bufio.NewReader(f)
-	decoder := yaml.NewDecoder(reader)
-	manifests := map[string]manifest.Manifest{}
-	var m manifest.Manifest
-	var resources Resources
-	for i := 0; decoder.Decode(&m) == nil; i++ {
-		manifests[strconv.Itoa(i)] = m
-		handler, err := config.Registry.GetHandler(m.Kind())
-		if err != nil {
-			return nil, err
-		}
-		parsedResources, err := handler.Parse(m)
-		if err != nil {
-			return nil, err
-		}
-		resources = append(resources, parsedResources...)
-
-	}
-	return resources, nil
-}
-
-//go:embed grizzly.jsonnet
-var script string
-
-// ParseJsonnet evaluates a jsonnet file and parses it into an object tree
-func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
-
-	script := fmt.Sprintf(script, jsonnetFile)
-	vm := jsonnet.MakeVM()
-	vm.Importer(newExtendedImporter(opts.JsonnetPaths))
-	for _, nf := range native.Funcs() {
-		vm.NativeFunction(nf)
-	}
-
-	result, err := vm.EvaluateSnippet(jsonnetFile, script)
-	if err != nil {
-		return nil, err
-	}
-	var data interface{}
-	if err := json.Unmarshal([]byte(result), &data); err != nil {
-		return nil, err
-	}
-
-	extracted, err := process.Extract(data)
-	if err != nil {
-		return nil, err
-	}
-
-	// Unwrap *List types
-	if err := process.Unwrap(extracted); err != nil {
-		return nil, err
-	}
-
-	resources := Resources{}
-	for _, m := range extracted {
-		handler, err := config.Registry.GetHandler(m.Kind())
-		if err != nil {
-			log.Println("Error getting handler", err)
-			continue
-		}
-		parsedResources, err := handler.Parse(m)
-		if err != nil {
-			return nil, err
-		}
-		resources = append(resources, parsedResources...)
-	}
-	return resources, nil
 }
 
 // Show displays resources

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -78,21 +78,21 @@ func List(config Config, resources Resources) error {
 	return w.Flush()
 }
 
-func Parse(config Config, filename string, jsonnetPaths []string, targets []string) (Resources, error) {
+func Parse(config Config, filename string, opts GrizzlyOpts) (Resources, error) {
 	if strings.HasSuffix(filename, ".yaml") ||
 		strings.HasSuffix(filename, ".yml") {
-		return ParseYAML(config, filename, targets)
+		return ParseYAML(config, filename, opts)
 	} else if strings.HasSuffix(filename, ".jsonnet") ||
 		strings.HasSuffix(filename, ".libsonnet") ||
 		strings.HasSuffix(filename, ".json") {
-		return ParseJsonnet(config, filename, jsonnetPaths, targets)
+		return ParseJsonnet(config, filename, opts)
 	} else {
 		return nil, fmt.Errorf("Either a config file or a resource file is required")
 	}
 }
 
 // ParseYAML evaluates a YAML file and parses it into resources
-func ParseYAML(config Config, yamlFile string, targets []string) (Resources, error) {
+func ParseYAML(config Config, yamlFile string, opts GrizzlyOpts) (Resources, error) {
 	f, err := os.Open(yamlFile)
 	if err != nil {
 		return nil, err
@@ -122,11 +122,11 @@ func ParseYAML(config Config, yamlFile string, targets []string) (Resources, err
 var script string
 
 // ParseJsonnet evaluates a jsonnet file and parses it into an object tree
-func ParseJsonnet(config Config, jsonnetFile string, jsonnetPaths []string, targets []string) (Resources, error) {
+func ParseJsonnet(config Config, jsonnetFile string, opts GrizzlyOpts) (Resources, error) {
 
 	script := fmt.Sprintf(script, jsonnetFile)
 	vm := jsonnet.MakeVM()
-	vm.Importer(newExtendedImporter(jsonnetPaths))
+	vm.Importer(newExtendedImporter(opts.JsonnetPaths))
 	for _, nf := range native.Funcs() {
 		vm.NativeFunction(nf)
 	}


### PR DESCRIPTION
This PR tidies up a number of things that either make the code easier
to read/work with, or resolves issues found using Grizzly against a
large Grafana instance.

It is best reviewed one commit at a time:

- Support YAML parsing
- Switch to GrizzlyOpts
- Reduce code duplication
- Move parsing into separate file
- Remove unnecessary embedding
- Replace Config with just Registry
- Actually remove the Config struct
- Fix args(!) and prep for config file
- Rename, tidy
- add missing error check
- Support getting datasources by UID
- Treat datasource ID as an integer
- Again, ID as int not string
- Handle folders with spaces in name
- Improve dashboard folder uid generation
- Use UID for datasources first, then defer to name
