### PR TITLE
Add Folders as first-class citizens

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -8,15 +8,6 @@ import (
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
 
-/*
- * This DashboardHandler supports folders. Add a `folderName` to your dashboard JSON.
- * This will be removed from the JSON, and if no folder exists, a dashboard folder
- * will be created with UID and title matching your `folderName`.
- *
- * Alternatively, create a `grafanaDashboardFolder` root element in your Jsonnet. This
- * value will be used as a folder name for all of your dashboards.
- */
-
 // DashboardHandler is a Grizzly Handler for Grafana dashboards
 type DashboardHandler struct {
 	Provider Provider

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -1,0 +1,98 @@
+package grafana
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/grafana/grizzly/pkg/grizzly"
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+)
+
+// FolderHandler is a Grizzly Handler for Grafana dashboard folders
+type FolderHandler struct {
+	Provider Provider
+}
+
+// NewFolderHandler returns configuration defining a new Grafana Folder Handler
+func NewFolderHandler(provider Provider) *FolderHandler {
+	return &FolderHandler{
+		Provider: provider,
+	}
+}
+
+// Kind returns the name for this handler
+func (h *FolderHandler) Kind() string {
+	return "DashboardFolder"
+}
+
+// APIVersion returns the group and version for the provider of which this handler is a part
+func (h *FolderHandler) APIVersion() string {
+	return h.Provider.APIVersion()
+}
+
+// GetExtension returns the file name extension for a dashboard
+func (h *FolderHandler) GetExtension() string {
+	return "json"
+}
+
+const (
+	folderGlob    = "folders/folder-*"
+	folderPattern = "folders/folder-%s.%s"
+)
+
+// FindResourceFiles identifies files within a directory that this handler can process
+func (h *FolderHandler) FindResourceFiles(dir string) ([]string, error) {
+	path := filepath.Join(dir, folderGlob)
+	return filepath.Glob(path)
+}
+
+// ResourceFilePath returns the location on disk where a resource should be updated
+func (h *FolderHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {
+	return fmt.Sprintf(folderPattern, resource.Name(), filetype)
+}
+
+// Parse parses a manifest object into a struct for this resource type
+func (h *FolderHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+	resource := grizzly.Resource(m)
+	resource.SetSpecString("uid", resource.GetMetadata("name"))
+	return grizzly.Resources{resource}, nil
+}
+
+// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
+func (h *FolderHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
+	return &resource
+}
+
+// Prepare gets a resource ready for dispatch to the remote endpoint
+func (h *FolderHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
+	return &resource
+}
+
+// GetByUID retrieves JSON for a resource from an endpoint, by UID
+func (h *FolderHandler) GetByUID(UID string) (*grizzly.Resource, error) {
+	resource, err := getRemoteDashboard(UID)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving dashboard %s: %v", UID, err)
+	}
+	return resource, nil
+}
+
+// GetRemote retrieves a folder as a resource
+func (h *FolderHandler) GetRemote(resource grizzly.Resource) (*grizzly.Resource, error) {
+	return getRemoteFolder(resource.Name())
+}
+
+// ListRemote retrieves as list of UIDs of all remote resources
+func (h *FolderHandler) ListRemote() ([]string, error) {
+	return getRemoteFolderList()
+}
+
+// Add pushes a new folder to Grafana via the API
+func (h *FolderHandler) Add(resource grizzly.Resource) error {
+	return postFolder(resource)
+}
+
+// Update pushes a folder to Grafana via the API
+func (h *FolderHandler) Update(existing, resource grizzly.Resource) error {
+	return putFolder(resource)
+}

--- a/pkg/grafana/folders.go
+++ b/pkg/grafana/folders.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
-// getRemoteFolder retrieves a dashboard object from Grafana
+// getRemoteFolder retrieves a folder object from Grafana
 func getRemoteFolder(uid string) (*grizzly.Resource, error) {
 	grafanaURL, err := getGrafanaURL("api/folders/" + uid)
 	if err != nil {
@@ -114,7 +114,7 @@ func postFolder(resource grizzly.Resource) error {
 		}
 		return fmt.Errorf("Error while applying '%s' to Grafana: %s", resource.Name(), r.Message)
 	default:
-		return NewErrNon200Response("dashboard", resource.Name(), resp)
+		return NewErrNon200Response("folder", resource.Name(), resp)
 	}
 	return nil
 }
@@ -153,7 +153,7 @@ func putFolder(resource grizzly.Resource) error {
 		}
 		return fmt.Errorf("Error while applying '%s' to Grafana: %s", resource.Name(), r.Message)
 	default:
-		return NewErrNon200Response("dashboard", resource.Name(), resp)
+		return NewErrNon200Response("folder", resource.Name(), resp)
 	}
 
 	return nil

--- a/pkg/grafana/folders.go
+++ b/pkg/grafana/folders.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
@@ -14,7 +13,6 @@ import (
 
 // getRemoteFolder retrieves a dashboard object from Grafana
 func getRemoteFolder(uid string) (*grizzly.Resource, error) {
-	log.Println("GET")
 	grafanaURL, err := getGrafanaURL("api/folders/" + uid)
 	if err != nil {
 		return nil, err
@@ -28,10 +26,8 @@ func getRemoteFolder(uid string) (*grizzly.Resource, error) {
 
 	switch {
 	case resp.StatusCode == http.StatusNotFound:
-		log.Println("NOT FOUND")
 		return nil, grizzly.ErrNotFound
 	case resp.StatusCode >= 400:
-		log.Println(">400")
 		return nil, errors.New(resp.Status)
 	}
 
@@ -91,7 +87,6 @@ func getRemoteFolderList() ([]string, error) {
 }
 
 func postFolder(resource grizzly.Resource) error {
-	log.Println("POST")
 	grafanaURL, err := getGrafanaURL("api/folders")
 	if err != nil {
 		return err
@@ -100,7 +95,6 @@ func postFolder(resource grizzly.Resource) error {
 	folder := Folder(resource["spec"].(map[string]interface{}))
 	folder["uid"] = resource.GetMetadata("name")
 	folderJSON, err := folder.toJSON()
-	log.Println("JSON", folderJSON)
 
 	resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(folderJSON))
 	if err != nil {
@@ -126,7 +120,6 @@ func postFolder(resource grizzly.Resource) error {
 }
 
 func putFolder(resource grizzly.Resource) error {
-	log.Println("PUT")
 	uid := resource.GetMetadata("name")
 	grafanaURL, err := getGrafanaURL("api/folders/" + uid)
 	if err != nil {
@@ -136,7 +129,6 @@ func putFolder(resource grizzly.Resource) error {
 	folder := Folder(resource["spec"].(map[string]interface{}))
 	folder["overwrite"] = true
 	folderJSON, err := folder.toJSON()
-	log.Println("PUT", grafanaURL)
 	req, err := http.NewRequest(http.MethodPut, grafanaURL, bytes.NewBufferString(folderJSON))
 	if err != nil {
 		return err

--- a/pkg/grafana/folders.go
+++ b/pkg/grafana/folders.go
@@ -1,0 +1,187 @@
+package grafana
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/grafana/grizzly/pkg/grizzly"
+)
+
+// getRemoteFolder retrieves a dashboard object from Grafana
+func getRemoteFolder(uid string) (*grizzly.Resource, error) {
+	log.Println("GET")
+	grafanaURL, err := getGrafanaURL("api/folders/" + uid)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Get(grafanaURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		log.Println("NOT FOUND")
+		return nil, grizzly.ErrNotFound
+	case resp.StatusCode >= 400:
+		log.Println(">400")
+		return nil, errors.New(resp.Status)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var f Folder
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, grizzly.APIErr{Err: err, Body: data}
+	}
+	h := FolderHandler{}
+	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, f)
+	return &resource, nil
+}
+
+func getRemoteFolderList() ([]string, error) {
+	batchSize := 100
+
+	UIDs := []string{}
+	for page := 1; ; page++ {
+		grafanaURL, err := getGrafanaURL(fmt.Sprintf("/api/search?type=dash-folder&limit=%d&page=%d", batchSize, page))
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := http.Get(grafanaURL)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		switch {
+		case resp.StatusCode == http.StatusNotFound:
+			return nil, grizzly.ErrNotFound
+		case resp.StatusCode >= 400:
+			return nil, errors.New(resp.Status)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		var folders []Folder
+		if err := json.Unmarshal([]byte(string(body)), &folders); err != nil {
+			return nil, grizzly.APIErr{Err: err, Body: body}
+		}
+		for _, folder := range folders {
+			UIDs = append(UIDs, folder.UID())
+		}
+		if len(folders) < batchSize {
+			break
+		}
+	}
+	return UIDs, nil
+
+}
+
+func postFolder(resource grizzly.Resource) error {
+	log.Println("POST")
+	grafanaURL, err := getGrafanaURL("api/folders")
+	if err != nil {
+		return err
+	}
+
+	folder := Folder(resource["spec"].(map[string]interface{}))
+	folder["uid"] = resource.GetMetadata("name")
+	folderJSON, err := folder.toJSON()
+	log.Println("JSON", folderJSON)
+
+	resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(folderJSON))
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		break
+	case http.StatusPreconditionFailed:
+		d := json.NewDecoder(resp.Body)
+		var r struct {
+			Message string `json:"message"`
+		}
+		if err := d.Decode(&r); err != nil {
+			return fmt.Errorf("Failed to decode actual error (412 Precondition failed): %s", err)
+		}
+		return fmt.Errorf("Error while applying '%s' to Grafana: %s", resource.Name(), r.Message)
+	default:
+		return NewErrNon200Response("dashboard", resource.Name(), resp)
+	}
+	return nil
+}
+
+func putFolder(resource grizzly.Resource) error {
+	log.Println("PUT")
+	uid := resource.GetMetadata("name")
+	grafanaURL, err := getGrafanaURL("api/folders/" + uid)
+	if err != nil {
+		return err
+	}
+
+	folder := Folder(resource["spec"].(map[string]interface{}))
+	folder["overwrite"] = true
+	folderJSON, err := folder.toJSON()
+	log.Println("PUT", grafanaURL)
+	req, err := http.NewRequest(http.MethodPut, grafanaURL, bytes.NewBufferString(folderJSON))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		break
+	case http.StatusPreconditionFailed:
+		d := json.NewDecoder(resp.Body)
+		var r struct {
+			Message string `json:"message"`
+		}
+		if err := d.Decode(&r); err != nil {
+			return fmt.Errorf("Failed to decode actual error (412 Precondition failed): %s", err)
+		}
+		return fmt.Errorf("Error while applying '%s' to Grafana: %s", resource.Name(), r.Message)
+	default:
+		return NewErrNon200Response("dashboard", resource.Name(), resp)
+	}
+
+	return nil
+}
+
+type Folder map[string]interface{}
+
+func (f *Folder) UID() string {
+	return (*f)["uid"].(string)
+}
+
+func (f *Folder) ID() float64 {
+	return (*f)["id"].(float64)
+}
+
+// toJSON returns JSON expected by Grafana API
+func (f *Folder) toJSON() (string, error) {
+	j, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(j), nil
+}

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -27,6 +27,7 @@ func (p *Provider) APIVersion() string {
 // GetHandlers identifies the handlers for the Grafana provider
 func (p *Provider) GetHandlers() []grizzly.Handler {
 	return []grizzly.Handler{
+		NewFolderHandler(*p),
 		NewDashboardHandler(*p),
 		NewDatasourceHandler(*p),
 		NewSyntheticMonitoringHandler(*p),

--- a/pkg/grizzly/grizzly.jsonnet
+++ b/pkg/grizzly/grizzly.jsonnet
@@ -11,6 +11,18 @@ local convert(main, apiVersion) = {
   },
 
   grafana: {
+
+    folders:
+      local is_alpha(x) =
+    std.setMember(x,"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_");
+      local uid(folder) = std.join("", std.filter(is_alpha, std.stringChars(folder)));
+     if ('grafanaDashboardFolder' in main) && main.grafanaDashboardFolder != 'General'
+      then makeResource(
+        'DashboardFolder',
+        uid(main.grafanaDashboardFolder),
+        spec={
+          title: main.grafanaDashboardFolder,
+        }),
     dashboards:
       local uid(k, dashboard) =
         if std.objectHasAll(dashboard, "uid")

--- a/testdata/folder-simple.libsonnet
+++ b/testdata/folder-simple.libsonnet
@@ -1,0 +1,7 @@
+local util = import 'util.libsonnet';
+
+local folder = {
+  title: 'Sample',
+};
+
+util.makeResource('DashboardFolder', 'sample', folder, {})

--- a/testdata/grr.jsonnet
+++ b/testdata/grr.jsonnet
@@ -1,9 +1,11 @@
 local dashboard = import 'dashboard-simple.libsonnet';
 local datasource = import 'datasource-prometheus.libsonnet';
+local folder = import 'folder-simple.libsonnet';
 local prometheus = import 'prometheus-rules.libsonnet';
 local sm = import 'synthetic-monitoring-simple.libsonnet';
 
 {
+  folders: [folder],
   dashboards: [dashboard],
   datasources: [datasource],
   prometheus: [prometheus],

--- a/testdata/yaml/folders/folder-sample.yaml
+++ b/testdata/yaml/folders/folder-sample.yaml
@@ -1,0 +1,6 @@
+apiVersion: grizzly.grafana.com/v1alpha1
+kind: DashboardFolder
+metadata:
+  name: sample
+spec:
+  title: Special Sample Folder


### PR DESCRIPTION
When Grizzly was first created, it only handled dashboards. Dashboards need folders, so Grizzly automagically created the folders.

Given Grizzly now supports multiple resource types, this magic isn't required anymore, in fact, it is an unnecessary complexity and a hindrance (you can't have a different UID and name for your folder, for example).

With this PR, folders become first-class citizens. There's not much you can set beyond UID and title, but that's a whole lot more than you could do before!