### PR TITLE
Doc Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ are:
 It is designed to work with existing [monitoring mixins](https://github.com/monitoring-mixins/docs).
 
 > **Status: Alpha**. This is a proof of concept. It will have many holes. PRs welcome.
-> **Release / Install** Please see the release page https://github.com/grafana/grizzly/releases/ 
+> **Release / Install** Please see the release page https://github.com/grafana/grizzly/releases/
 
 ## Authentication and Configuration
 
@@ -139,7 +139,7 @@ Grafana snapshots by default do not expire. Expiration can be set via the
 
 ### `-t, --target strings`
 
-It allows the targeting of resources by key, where key is in the form `<type>.<uid>`.
+It allows the targeting of resources by key, where key is in the form `<type>/<uid>`.
 
 Run `grr list` to get a list of resource keys in your code.
 

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -219,7 +219,7 @@ func (r *Registry) GetHandler(path string) (Handler, error) {
 	return handler, nil
 }
 
-// HandlerMatchesTarget identifies whether a resource is in a target list
+// HandlerMatchesTarget identifies whether a handler is in a target list
 func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string) bool {
 	if len(targets) == 0 {
 		return true
@@ -235,7 +235,7 @@ func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string) bool 
 	return false
 }
 
-// HandlerMatchesTarget identifies whether a resource is in a target list
+// ResourceMatchesTarget identifies whether a resource is in a target list
 func (r *Registry) ResourceMatchesTarget(handler Handler, UID string, targets []string) bool {
 	if len(targets) == 0 {
 		return true


### PR DESCRIPTION
* `--target` flag type, uid delimiter is `/`, not `.`.
* Fix c/p errors in Go docs.