### PR TITLE
Fix jsonnet to make UID from folder name

### DIFF
--- a/pkg/grizzly/grizzly.jsonnet
+++ b/pkg/grizzly/grizzly.jsonnet
@@ -14,7 +14,7 @@ local convert(main, apiVersion) = {
 
     folders:
       local is_alpha(x) =
-    std.setMember(x,"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_");
+    std.member("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_", x);
       local uid(folder) = std.join("", std.filter(is_alpha, std.stringChars(folder)));
      if ('grafanaDashboardFolder' in main) && main.grafanaDashboardFolder != 'General'
       then makeResource(


### PR DESCRIPTION
Without this, the jsonnet that converts hidden elements into K8s style resources for processing was erroneously stripping dashes and underscores, even though they were mentioned in the allowed string. This fixes the behaviour.