### PR TITLE
Add ability to list (and filter) remote resources

### DIFF
--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -220,7 +220,7 @@ func (r *Registry) GetHandler(path string) (Handler, error) {
 }
 
 // HandlerMatchesTarget identifies whether a handler is in a target list
-func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string, isSilent bool) bool {
+func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string) bool {
 	if len(targets) == 0 {
 		return true
 	}
@@ -230,9 +230,6 @@ func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string, isSil
 		if strings.Contains(target, "/") && strings.Split(target, "/")[0] == key {
 			return true
 		}
-	}
-	if !isSilent {
-		r.Notifier().Info(SimpleString(key), "skipped")
 	}
 	return false
 }

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -220,7 +220,7 @@ func (r *Registry) GetHandler(path string) (Handler, error) {
 }
 
 // HandlerMatchesTarget identifies whether a handler is in a target list
-func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string) bool {
+func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string, isSilent bool) bool {
 	if len(targets) == 0 {
 		return true
 	}
@@ -231,7 +231,9 @@ func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string) bool 
 			return true
 		}
 	}
-	r.Notifier().Info(SimpleString(key), "skipped")
+	if !isSilent {
+		r.Notifier().Info(SimpleString(key), "skipped")
+	}
 	return false
 }
 

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -79,7 +79,7 @@ func ListRemote(registry Registry, opts Opts) error {
 
 	fmt.Fprintf(w, f, "API VERSION", "KIND", "UID")
 	for _, handler := range registry.Handlers {
-		if !registry.HandlerMatchesTarget(handler, opts.Targets, true) {
+		if !registry.HandlerMatchesTarget(handler, opts.Targets) {
 			continue
 		}
 		IDs, err := handler.ListRemote()
@@ -103,7 +103,8 @@ func Pull(registry Registry, resourcePath string, opts Opts) error {
 	}
 
 	for _, handler := range registry.Handlers {
-		if !registry.HandlerMatchesTarget(handler, opts.Targets, false) {
+		if !registry.HandlerMatchesTarget(handler, opts.Targets) {
+			registry.Notifier().Info(SimpleString(handler.Kind()), "skipped")
 			continue
 		}
 		UIDs, err := handler.ListRemote()


### PR DESCRIPTION
`grr list` currently tells you the resources available locally within your Jsonnet or YAML.

This PR adds the ability to list remote resources, in the same format. This was surprisingly easy to add, all the infrastructure (e.g. pulling a list of resources) was already present.