### PR TITLE
Add support for watching directories recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,12 @@ $ grr apply my-lib.libsonnet
 
 ### grr watch
 Watches a directory for changes. When changes are identified, the
-jsonnet is executed and changes are pushed to remote systems. This
-example watches the current directory for changes, then executes
+jsonnet is executed and changes are pushed to remote systems.
+The directory is watched recursively (i.e. all subdirectories are watched too),
+but if new subdirectories are added, watch command needs to be re-started,
+as new directories will not be picked up automatically.
+
+This example watches the current directory for changes, then executes
 `my-lib.libsonnet` when changes are noticed:
 
 ```sh

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -139,15 +139,12 @@ func (p *jsonnetWatchParser) Parse(registry grizzly.Registry) (grizzly.Resources
 func watchCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "watch <dir-to-watch> <resource-path>",
-		Short: "watch for file changes and apply",
+		Short: "watch dir recursively for file changes and apply selected resource path",
 		Args:  cli.ArgsExact(2),
 	}
 
 	var opts grizzly.Opts
 	defaultGrizzlyFlags(&opts, cmd.Flags())
-
-	var wopts grizzly.WatchOpts
-	cmd.Flags().BoolVarP(&wopts.Recursive, "recursive", "r", false, "watch the directory recursively")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		parser := &jsonnetWatchParser{
@@ -157,7 +154,7 @@ func watchCmd(registry grizzly.Registry) *cli.Command {
 
 		watchDir := args[0]
 
-		return grizzly.Watch(registry, watchDir, parser, wopts)
+		return grizzly.Watch(registry, watchDir, parser)
 	}
 	return cmd
 }

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -142,16 +142,22 @@ func watchCmd(registry grizzly.Registry) *cli.Command {
 		Short: "watch for file changes and apply",
 		Args:  cli.ArgsExact(2),
 	}
+
 	var opts grizzly.Opts
 	defaultGrizzlyFlags(&opts, cmd.Flags())
+
+	var wopts grizzly.WatchOpts
+	cmd.Flags().BoolVarP(&wopts.Recursive, "recursive", "r", false, "watch the directory recursively")
+
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		parser := &jsonnetWatchParser{
 			resourcePath: args[1],
 			opts:         opts,
 		}
+
 		watchDir := args[0]
 
-		return grizzly.Watch(registry, watchDir, parser)
+		return grizzly.Watch(registry, watchDir, parser, wopts)
 	}
 	return cmd
 }

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -11,3 +11,8 @@ type Opts struct {
 type PreviewOpts struct {
 	ExpiresSeconds int
 }
+
+// WatchOpts Options to configure watch command.
+type WatchOpts struct {
+	Recursive bool
+}

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -11,8 +11,3 @@ type Opts struct {
 type PreviewOpts struct {
 	ExpiresSeconds int
 }
-
-// WatchOpts Options to configure watch command.
-type WatchOpts struct {
-	Recursive bool
-}


### PR DESCRIPTION
Closes #121 

This PR adds ability to watch directories recursively, by using `filepath.WalkDir` to list subdirectories and adding them to fsnotify Watcher.

The functionality is hidden behind a flag, which is wired using custom options, similar to how preview command options are implemented.

The functionality is disabled by default.

Signed-off-by: Igor Suleymanov <igor.suleymanov@grafana.com>
