### PR TITLE
Fix apply errors when using folder name with spaces

### DIFF
--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -70,10 +70,11 @@ func (h *FolderHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Re
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *FolderHandler) GetByUID(UID string) (*grizzly.Resource, error) {
-	resource, err := getRemoteDashboard(UID)
+	resource, err := getRemoteFolder(UID)
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving dashboard %s: %v", UID, err)
+		return nil, fmt.Errorf("Error retrieving dashboard folder %s: %v", UID, err)
 	}
+
 	return resource, nil
 }
 

--- a/pkg/grafana/folders.go
+++ b/pkg/grafana/folders.go
@@ -26,7 +26,7 @@ func getRemoteFolder(uid string) (*grizzly.Resource, error) {
 
 	switch {
 	case resp.StatusCode == http.StatusNotFound:
-		return nil, grizzly.ErrNotFound
+		return nil, fmt.Errorf("couldn't fetch folder '%s' from remote: %w", uid, grizzly.ErrNotFound)
 	case resp.StatusCode >= 400:
 		return nil, errors.New(resp.Status)
 	}
@@ -63,7 +63,7 @@ func getRemoteFolderList() ([]string, error) {
 
 		switch {
 		case resp.StatusCode == http.StatusNotFound:
-			return nil, grizzly.ErrNotFound
+			return nil, fmt.Errorf("couldn't fetch folder list from remote: %w", grizzly.ErrNotFound)
 		case resp.StatusCode >= 400:
 			return nil, errors.New(resp.Status)
 		}

--- a/pkg/grizzly/errors.go
+++ b/pkg/grizzly/errors.go
@@ -5,11 +5,16 @@ import (
 	"fmt"
 )
 
-// ErrNotFound is used to signal a missing resource
-var ErrNotFound = errors.New("not found")
+var (
+	// ErrNotFound is used to signal a missing resource
+	ErrNotFound = errors.New("not found")
 
-// ErrNotImplemented signals a feature that is not supported by a provider
-var ErrNotImplemented = errors.New("not implemented")
+	// ErrNotImplemented signals a feature that is not supported by a provider
+	ErrNotImplemented = errors.New("not implemented")
+
+	// ErrHandlerNotFound indicates that no handler was found for a particular resource Kind.
+	ErrHandlerNotFound = errors.New("handler not found")
+)
 
 // APIErr encapsulates an error from the Grafana API
 type APIErr struct {

--- a/pkg/grizzly/grizzly.jsonnet
+++ b/pkg/grizzly/grizzly.jsonnet
@@ -1,4 +1,5 @@
 local main = import '%s';
+
 local convert(main, apiVersion) = {
   local makeResource(kind, name, spec=null, data=null, metadata={}) = {
     apiVersion: apiVersion,
@@ -10,16 +11,16 @@ local convert(main, apiVersion) = {
     [if data != null then 'data']: std.manifestJsonEx(data, '  '),
   },
 
-  grafana: {
+  local formatUID(name) =
+      local is_alpha(x) = std.member("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_", x);
+      std.join("", std.filter(is_alpha, std.stringChars(name))),
 
+  grafana: {
     folders:
-      local is_alpha(x) =
-    std.member("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_", x);
-      local uid(folder) = std.join("", std.filter(is_alpha, std.stringChars(folder)));
      if ('grafanaDashboardFolder' in main) && main.grafanaDashboardFolder != 'General'
       then makeResource(
         'DashboardFolder',
-        uid(main.grafanaDashboardFolder),
+        formatUID(main.grafanaDashboardFolder),
         spec={
           title: main.grafanaDashboardFolder,
         }),
@@ -30,7 +31,7 @@ local convert(main, apiVersion) = {
         else k;
       local folder =
         if 'grafanaDashboardFolder' in main
-        then main.grafanaDashboardFolder
+        then formatUID(main.grafanaDashboardFolder)
         else 'General';
       local fromMap(dashboards, folder) = [
         makeResource(

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -214,7 +214,7 @@ func (r *Registry) RegisterProvider(provider Provider) error {
 func (r *Registry) GetHandler(path string) (Handler, error) {
 	handler, exists := r.Handlers[path]
 	if !exists {
-		return nil, fmt.Errorf("No handler registered to %s", path)
+		return nil, fmt.Errorf("couldn't find a handler for %s: %w", path, ErrHandlerNotFound)
 	}
 	return handler, nil
 }

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -146,7 +146,7 @@ func Show(registry Registry, resources Resources) error {
 	for _, resource := range resources {
 		handler, err := registry.GetHandler(resource.Kind())
 		if err != nil {
-			return nil
+			return err
 		}
 		resource = *(handler.Unprepare(resource))
 
@@ -175,12 +175,12 @@ func Diff(registry Registry, resources Resources) error {
 	for _, resource := range resources {
 		handler, err := registry.GetHandler(resource.Kind())
 		if err != nil {
-			return nil
+			return err
 		}
 
 		local, err := resource.YAML()
 		if err != nil {
-			return nil
+			return err
 		}
 
 		resource = *handler.Unprepare(resource)
@@ -225,8 +225,7 @@ func Apply(registry Registry, resources Resources) error {
 	for _, resource := range resources {
 		handler, err := registry.GetHandler(resource.Kind())
 		if err != nil {
-			// Why?
-			return nil
+			return err
 		}
 
 		existingResource, err := handler.GetRemote(resource)
@@ -251,8 +250,7 @@ func Apply(registry Registry, resources Resources) error {
 		existingResource = handler.Unprepare(*existingResource)
 		existingResourceRepresentation, err := existingResource.YAML()
 		if err != nil {
-			// Why?
-			return nil
+			return err
 		}
 
 		if resourceRepresentation == existingResourceRepresentation {
@@ -275,7 +273,7 @@ func Preview(registry Registry, resources Resources, opts *PreviewOpts) error {
 	for _, resource := range resources {
 		handler, err := registry.GetHandler(resource.Kind())
 		if err != nil {
-			return nil
+			return err
 		}
 		previewHandler, ok := handler.(PreviewHandler)
 		if !ok {
@@ -384,7 +382,7 @@ func Export(registry Registry, exportDir string, resources Resources) error {
 	for _, resource := range resources {
 		handler, err := registry.GetHandler(resource.Kind())
 		if err != nil {
-			return nil
+			return err
 		}
 		updatedResource, err := resource.YAML()
 		if err != nil {


### PR DESCRIPTION
This PR fixes an issue that happens when a mixin is using a dashboard folder name which contains spaces, e.g.:

```jsonnet
{
  grafanaDashboardFolder:: 'My Awesome Folder',

  grafanaDashboards+:: {
    'some-dashboard': (import './dashboards/some-dashboard.libsonnet'),
  },
}
```

The root cause is the fact that spaces are removed from the name when preparing the Folder resource in Jsonnet, but the name is used as-is when preparing Dashboard resources.

I took the liberty of fixing what looks to be a bug in `FolderHandler.GetByUID` and improving error messages and error handling in the folder handler.
