### PR TITLE
Refactor and improve folder missing error

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -93,10 +93,7 @@ func (h *DashboardHandler) ListRemote() ([]string, error) {
 
 // Add pushes a new dashboard to Grafana via the API
 func (h *DashboardHandler) Add(resource grizzly.Resource) error {
-	if err := postDashboard(resource); err != nil {
-		return err
-	}
-	return nil
+	return postDashboard(resource)
 }
 
 // Update pushes a dashboard to Grafana via the API

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -97,8 +97,8 @@ func postDashboard(resource grizzly.Resource) error {
 
 	folderUID := resource.GetMetadata("folder")
 	folder, err := getRemoteFolder(folderUID)
-	if err != nil {
-		return err
+	if err != nil && errors.As(err, &grizzly.ErrNotFound) {
+		return fmt.Errorf("Cannot upload dashboard %s as folder %s not found", resource.GetMetadata("name"), folderUID)
 	}
 	folderID := int64(folder.GetSpecValue("id").(float64))
 
@@ -116,7 +116,7 @@ func postDashboard(resource grizzly.Resource) error {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		break
+		return nil
 	case http.StatusPreconditionFailed:
 		d := json.NewDecoder(resp.Body)
 		var r struct {
@@ -130,8 +130,6 @@ func postDashboard(resource grizzly.Resource) error {
 	default:
 		return NewErrNon200Response("dashboard", resource.Name(), resp)
 	}
-
-	return nil
 }
 
 // SnapshotResp encapsulates the response to a snapshot request


### PR DESCRIPTION
1) Simple refactorings
2) Currently Grizzly will report "not found" if the *folder* is not present when uploading a dashboard. This PR changes the error message to be clearer.