### PR TITLE
Stop offering a delete link for expiring previews

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -129,9 +129,10 @@ func (h *DashboardHandler) Preview(resource grizzly.Resource, opts *grizzly.Prev
 		return err
 	}
 	notifier.Info(resource, "view: "+s.URL)
-	notifier.Error(resource, "delete: "+s.DeleteURL)
 	if opts.ExpiresSeconds > 0 {
 		notifier.Warn(resource, fmt.Sprintf("Previews will expire and be deleted automatically in %d seconds\n", opts.ExpiresSeconds))
+	} else {
+		notifier.Error(resource, "delete: "+s.DeleteURL)
 	}
 	return nil
 }


### PR DESCRIPTION
Only display a link to delete previews if they aren't set to expire.

It seems unnecessary to offer a manual delete link if the user has requested automatic deletion after an expiry time.

This should result in less UI clutter and fewer unintentional deletions from hitting the wrong link by accident.