### PR TITLE
Ensure 'grr preview' processes all previewable resources

### DIFF
--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -285,7 +285,7 @@ func Preview(resources Resources, opts *PreviewOpts) error {
 		previewHandler, ok := handler.(PreviewHandler)
 		if !ok {
 			notifier.NotSupported(resource, "preview")
-			return nil
+			continue
 		}
 		err = previewHandler.Preview(resource, opts)
 		if err != nil {


### PR DESCRIPTION
Instead of stopping when we encounter a resource which doesn't support previewing (e.g. a DashboardFolder), just skip it with a warning.

Fixes #139