### PR TITLE
Make Registry global and use notifier package

### DIFF
--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -1,0 +1,86 @@
+package grizzly
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+// Provider describes a single Endpoint Provider
+type Provider interface {
+	Group() string
+	Version() string
+	APIVersion() string
+	GetHandlers() []Handler
+}
+
+// Registry records providers
+type Registry struct {
+	Providers []Provider
+	Handlers  map[string]Handler
+}
+
+// Global Handler registry
+var registry Registry
+
+// NewProviderRegistry returns a new registry instance
+func NewProviderRegistry() Registry {
+	registry := Registry{}
+	registry.Providers = []Provider{}
+	registry.Handlers = map[string]Handler{}
+	return registry
+}
+
+// RegisterProvider will register a new provider
+func (r *Registry) RegisterProvider(provider Provider) error {
+	r.Providers = append(r.Providers, provider)
+	for _, handler := range provider.GetHandlers() {
+		r.Handlers[handler.Kind()] = handler
+	}
+	return nil
+}
+
+// GetHandler returns a single provider based upon a JSON path
+func (r *Registry) GetHandler(path string) (Handler, error) {
+	handler, exists := r.Handlers[path]
+	if !exists {
+		return nil, fmt.Errorf("couldn't find a handler for %s: %w", path, ErrHandlerNotFound)
+	}
+	return handler, nil
+}
+
+// HandlerMatchesTarget identifies whether a handler is in a target list
+func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string) bool {
+	if len(targets) == 0 {
+		return true
+	}
+	key := handler.Kind()
+
+	for _, target := range targets {
+		if strings.Contains(target, "/") && strings.Split(target, "/")[0] == key {
+			return true
+		}
+	}
+	return false
+}
+
+// ResourceMatchesTarget identifies whether a resource is in a target list
+func (r *Registry) ResourceMatchesTarget(handler Handler, UID string, targets []string) bool {
+	if len(targets) == 0 {
+		return true
+	}
+	key := fmt.Sprintf("%s/%s", handler.Kind(), UID)
+	for _, target := range targets {
+		g := glob.MustCompile(target)
+		if g.Match(key) {
+			return true
+		}
+	}
+	return false
+}
+
+// Notifier returns a notifier for responding to users
+func (r *Registry) Notifier() *Notifier {
+	return &Notifier{}
+}


### PR DESCRIPTION
Currently, we create a `Registry` at startup, then hand it around everywhere. As
a configuration that does not change during the life of the app, this is an
unnecessary overhead that complicates matters.

The immediate trigger for this change is the need for a function on the
`Resource` type to be able to identify its handler. This would be a pain to
have a `Resource` object have access to the `Registry` - it would make the
code unnecessarily complex. This change, on the other hand, makes the code
significantly simpler, reducing the unnecessary handing around of static
configuration

Likewise, `registry.Notifier` is a reference to a type that only has
functions. These functions are better off as functions within a package.
This again is much simpler.
