### PR TITLE
Use absolute import paths

### DIFF
--- a/pkg/grizzly/jsonnet.go
+++ b/pkg/grizzly/jsonnet.go
@@ -1,6 +1,8 @@
 package grizzly
 
 import (
+	"path/filepath"
+
 	"github.com/google/go-jsonnet"
 )
 
@@ -26,11 +28,16 @@ func newFileLoader(fi *jsonnet.FileImporter) importLoader {
 	}
 }
 
-func newExtendedImporter(jpath []string) *ExtendedImporter {
+func newExtendedImporter(path string, jpath []string) *ExtendedImporter {
+	absolutePaths := make([]string, len(jpath)+1)
+	absolutePaths = append(absolutePaths, path)
+	for _, p := range jpath {
+		absolutePaths = append(absolutePaths, filepath.Join(path, p))
+	}
 	return &ExtendedImporter{
 		loaders: []importLoader{
 			newFileLoader(&jsonnet.FileImporter{
-				JPaths: jpath,
+				JPaths: absolutePaths,
 			})},
 		processors: []importProcessor{},
 	}

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -98,7 +98,12 @@ func ParseJsonnet(jsonnetFile string, opts Opts) (Resources, error) {
 
 	script := fmt.Sprintf(script, jsonnetFile)
 	vm := jsonnet.MakeVM()
-	vm.Importer(newExtendedImporter(opts.JsonnetPaths))
+	absoluteFile, err := filepath.Abs(jsonnetFile)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Dir(absoluteFile)
+	vm.Importer(newExtendedImporter(path, opts.JsonnetPaths))
 	for _, nf := range native.Funcs() {
 		vm.NativeFunction(nf)
 	}


### PR DESCRIPTION
Due to legacy support for hidden fields, Grizzly does not load Jsonnet files directly - it loads its own Jsonnet, which imports the referenced jsonnet.

This means that the path to the `lib` and `vendor` directories will actually be the current directory, not the directory in which the loaded jsonnet file resides.

This PR makes those paths absolute and relative to the jsonnet file's directory, and fixes this issue.