### PR TITLE
Don't use local when adding to global registry

### DIFF
--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -26,12 +26,11 @@ var Registry registry
 
 // NewProviderRegistry returns a new registry instance
 func ConfigureProviderRegistry(providers []Provider) {
-	registry := registry{}
-	registry.Providers = providers
-	registry.Handlers = map[string]Handler{}
+	Registry.Providers = providers
+	Registry.Handlers = map[string]Handler{}
 	for _, provider := range providers {
 		for _, handler := range provider.GetHandlers() {
-			registry.Handlers[handler.Kind()] = handler
+			Registry.Handlers[handler.Kind()] = handler
 		}
 	}
 }


### PR DESCRIPTION
Silly mistake when adding global registry. Without this we get "handler not found" everywhere.