### PR TITLE
Do not modify paths that are already absolute.

### DIFF
--- a/pkg/grizzly/jsonnet.go
+++ b/pkg/grizzly/jsonnet.go
@@ -32,7 +32,10 @@ func newExtendedImporter(path string, jpath []string) *ExtendedImporter {
 	absolutePaths := make([]string, len(jpath)+1)
 	absolutePaths = append(absolutePaths, path)
 	for _, p := range jpath {
-		absolutePaths = append(absolutePaths, filepath.Join(path, p))
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(path, p)
+		}
+		absolutePaths = append(absolutePaths, p)
 	}
 	return &ExtendedImporter{
 		loaders: []importLoader{


### PR DESCRIPTION
Fix for a bug introduced in #154, which caused already-absolute paths to have the cwd prepended to them.