### PR TITLE
Update Jsonnet examples to use grizzly lib

### DIFF
--- a/examples/dashboard-simple.libsonnet
+++ b/examples/dashboard-simple.libsonnet
@@ -1,11 +1,6 @@
-local util = import 'util.libsonnet';
-
-local dashboard = {
-  uid: 'prod-overview',
+{
   title: 'Production Overview',
   tags: ['templated'],
   timezone: 'browser',
   schemaVersion: 17,
-};
-
-util.makeResource('Dashboard', dashboard.uid, dashboard, { folder: 'sample' })
+}

--- a/examples/datasource-prometheus.libsonnet
+++ b/examples/datasource-prometheus.libsonnet
@@ -1,13 +1,9 @@
-local util = import 'util.libsonnet';
-
-local datasource = {
+{
   access: 'proxy',
   isDefault: true,
   jsonData: {
     httpMethod: 'GET',
   },
-  name: 'prometheus',
   type: 'prometheus',
   url: 'http://localhost/prometheus/',
-};
-util.makeResource('Datasource', datasource.name, datasource)
+}

--- a/examples/grr.jsonnet
+++ b/examples/grr.jsonnet
@@ -1,13 +1,25 @@
 local dashboard = import 'dashboard-simple.libsonnet';
 local datasource = import 'datasource-prometheus.libsonnet';
 local folder = import 'folder-simple.libsonnet';
+local grr = import 'grizzly/grizzly.libsonnet';
 local prometheus = import 'prometheus-rules.libsonnet';
 local sm = import 'synthetic-monitoring-simple.libsonnet';
 
 {
-  folders: [folder],
-  dashboards: [dashboard],
-  datasources: [datasource],
-  prometheus: [prometheus],
-  sm: [sm],
+  folders: [
+    grr.folder.new('sample', 'Sample'),
+  ],
+  dashboards: [
+    grr.dashboard.new('prod-overview', dashboard)
+    + grr.resource.addMetadata('folder', 'sample'),
+  ],
+  datasources: [
+    grr.datasource.new('prometheus', datasource),
+  ],
+  prometheus_rule_groups: [
+    grr.rule_group.new('first_rules', 'grizzly_alerts', prometheus),
+  ],
+  sm: [
+    grr.synthetic_monitoring_check.new('http', 'grafana-com', sm),
+  ],
 }

--- a/examples/jsonnetfile.json
+++ b/examples/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grizzly"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/examples/jsonnetfile.lock.json
+++ b/examples/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grizzly"
+        }
+      },
+      "version": "a9c2ba2ae059bdc087c7cb35a5696227adba0f17",
+      "sum": "dPeHROxEuo8PEn2EtimLTMiIgvY3w8TQKlsXtiOWWRs="
+    }
+  ],
+  "legacyImports": false
+}

--- a/examples/prometheus-rules.libsonnet
+++ b/examples/prometheus-rules.libsonnet
@@ -1,26 +1,20 @@
-local prom = import 'prom.libsonnet';
-local promRuleGroupSet = prom.v1.ruleGroupSet;
-local promRuleGroup = prom.v1.ruleGroup;
-local util = import 'util.libsonnet';
+local ruleGroup = (import 'prom.libsonnet').v1.ruleGroup;
 
-local prometheus_metamon =
-  promRuleGroup.new('grizzly_alerts')
-  + promRuleGroup.rule.newAlert(
-    'PromScrapeFailed', {
-      expr: 'up != 1',
-      'for': '1m',
-      labels: {
-        severity: 'critical',
-      },
-      annotations: {
-        message: 'Prometheus failed to scrape a target {{ $labels.job }}  / {{ $labels.instance }}',
-      },
-    }
-  )
-  + promRuleGroup.rule.newRecording(
-    'job:up:sum', {
-      expr: 'sum by(job) (up)',
+ruleGroup.new('grizzly_alerts')
++ ruleGroup.rule.newAlert(
+  'PromScrapeFailed', {
+    expr: 'up != 1',
+    'for': '1m',
+    labels: {
+      severity: 'critical',
     },
-  );
-
-util.makeResource('PrometheusRuleGroup', prometheus_metamon.name, prometheus_metamon, metadata={ namespace: 'first_rules' })
+    annotations: {
+      message: 'Prometheus failed to scrape a target {{ $labels.job }}  / {{ $labels.instance }}',
+    },
+  }
+)
++ ruleGroup.rule.newRecording(
+  'job:up:sum', {
+    expr: 'sum by(job) (up)',
+  },
+)

--- a/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/README.md
+++ b/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/README.md
@@ -1,0 +1,23 @@
+# Grizzly Library
+
+This library provides utilities for [Grizzly](https://github.com/grafana/grizzly),
+a utility for managing observability resources on Grafana and hosted Prometheus
+installations.
+
+## Kubernetes Style Observability Objects
+It provides functions to render Kubernetes style objects from Monitoring Mixins.
+
+If deploying dashboards structured to be consumed by [prometheus-ksonnet](https://github.com/grafana/jsonnet-libs/prometheus-ksonnet)
+or associated libraries, where other resources are using Tanka, place a file
+named `grr.jsonnet` next to your `main.jsonnet`, and give it this content:
+
+```
+local main = (import 'main.jsonnet');
+local grizzly = (import 'grizzly/grizzly.libsonnet');
+
+grizzly.fromPrometheusKsonnet(main)
+```
+
+Then, you can invoke this from Grizzly like so:
+
+`grr show -r environments/<my-environment>/grr.libsonnet`

--- a/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/check.libsonnet
+++ b/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/check.libsonnet
@@ -1,0 +1,7 @@
+local resource = import 'resource.libsonnet';
+{
+  new(type, name, check)::
+    resource.new('SyntheticMonitoringCheck', name)
+    + resource.addMetadata('type', type)
+    + resource.withSpec(check),
+}

--- a/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/grafana.libsonnet
+++ b/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/grafana.libsonnet
@@ -1,0 +1,42 @@
+local resource = import 'resource.libsonnet';
+local util = import 'util.libsonnet';
+
+{
+  getFolder(main):: util.get(main, 'grafanaDashboardFolder', 'General'),
+
+  fromMap(dashboards, folder):: {
+    [k]: util.makeResource('Dashboard', k, dashboards[k], { folder: folder })
+    for k in std.objectFields(dashboards)
+  },
+
+  fromMixins(mixins):: {
+    [key]:
+      local mixin = mixins[key];
+      {
+        local folder = util.get(mixin, 'grafanaDashboardFolder', 'General'),
+        [k]: util.makeResource('Dashboard', k, mixin.grafanaDashboards[k], { folder: folder })
+        for k in std.objectFieldsAll(util.get(mixin, 'grafanaDashboards', {}))
+      }
+    for key in std.objectFields(mixins)
+  },
+
+  dashboard: {
+    new(name, dashboard_json)::
+      resource.new('Dashboard', name)
+      + resource.withSpec(dashboard_json),
+  },
+
+  folder: {
+    new(name, title)::
+      resource.new('DashboardFolder', name)
+      + resource.withSpec({
+        title: title,
+      }),
+  },
+
+  datasource: {
+    new(name, datasource_json)::
+      resource.new('Datasource', name)
+      + resource.withSpec(datasource_json),
+  },
+}

--- a/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/grizzly.libsonnet
+++ b/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/grizzly.libsonnet
@@ -1,0 +1,26 @@
+local grafana = import 'grafana.libsonnet';
+local prometheus = import 'prometheus.libsonnet';
+{
+  grafana: grafana,
+  prometheus: prometheus,
+
+  fromPrometheusKsonnet(main):: {
+    local dashboardFolder = grafana.getFolder(main),
+    local mixinRules = prometheus.getMixinRuleNames(main.mixins),
+
+    grafana: grafana.fromMap(main.grafanaDashboards, dashboardFolder)
+             + grafana.fromMixins(main.mixins),
+
+    prometheus: prometheus.fromMapsFiltered(main.prometheusAlerts, mixinRules)
+                + prometheus.fromMapsFiltered(main.prometheusRules, mixinRules)
+                + prometheus.fromMixins(main.mixins),
+  },
+
+  resource: (import 'resource.libsonnet'),
+  dashboard: grafana.dashboard,
+  folder: grafana.folder,
+  datasource: grafana.datasource,
+  rule_group: prometheus.rule_group,
+  synthetic_monitoring_check: (import 'check.libsonnet'),
+
+}

--- a/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/prometheus.libsonnet
+++ b/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/prometheus.libsonnet
@@ -1,0 +1,39 @@
+local util = import 'util.libsonnet';
+local kind = 'PrometheusRuleGroup';
+local recordingRules = 'prometheusRules';
+local alertRules = 'prometheusAlerts';
+local resource = import 'resource.libsonnet';
+
+{
+  getMixinRuleNames(mixins)::
+    local flatMixins = [mixins[key] for key in std.objectFieldsAll(mixins)];
+    local mixinRules = std.flattenArrays([mixin.prometheusRules.groups for mixin in flatMixins if std.objectHasAll(mixin, recordingRules)]);
+    local mixinAlerts = std.flattenArrays([mixin.prometheusAlerts.groups for mixin in flatMixins if std.objectHasAll(mixin, alertRules)]);
+    [group.name for group in mixinAlerts] + [group.name for group in mixinRules],
+
+  fromMaps(rules):: { [k]: util.makeResource(kind, k, { groups: rules }, {}) for k in std.objectFields(rules) },
+
+  fromMapsFiltered(rules, excludes):: {
+    local filterRules(rules, exclude_list) = [rule for rule in rules.groups if !std.member(exclude_list, rule.name)],
+    [k]: util.makeResource(kind, k, { groups: filterRules(rules, excludes) }, {})
+    for k in std.objectFields(rules)
+  },
+
+  fromMixins(mixins):: {
+    [if std.objectHasAll(mixins[key], alertRules) || std.objectHasAll(mixins[key], recordingRules) then key else null]:
+      util.makeResource(
+        kind,
+        key,
+        (if std.objectHasAll(mixins[key], alertRules) then mixins[key].prometheusAlerts else {})
+        + (if std.objectHasAll(mixins[key], recordingRules) then mixins[key].prometheusRules else {})
+      )
+    for key in std.objectFields(mixins)
+  },
+
+  rule_group: {
+    new(namespace, name, group)::
+      resource.new('PrometheusRuleGroup', name)
+      + resource.addMetadata('namespace', namespace)
+      + resource.withSpec(group),
+  },
+}

--- a/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/resource.libsonnet
+++ b/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/resource.libsonnet
@@ -1,0 +1,22 @@
+{
+  defaultApiVersion:: 'grizzly.grafana.com/v1alpha1',
+  new(kind, name):: {
+    apiVersion: $.defaultApiVersion,
+    kind: kind,
+    metadata: {
+      name: name,
+    },
+  },
+  withApiVersion(apiVersion):: {
+    defaultApiVersion:: apiVersion,
+    apiVersion: apiVersion,
+  },
+  addMetadata(name, value):: {
+    metadata+: {
+      [name]: value,
+    },
+  },
+  withSpec(spec):: {
+    spec: spec,
+  },
+}

--- a/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/util.libsonnet
+++ b/examples/vendor/github.com/grafana/jsonnet-libs/grizzly/util.libsonnet
@@ -1,0 +1,13 @@
+{
+  grizzlyAPI:: 'grizzly.grafana.com/v1alpha1',
+  get(obj, key, default):: if std.objectHasAll(obj, key) then obj[key] else default,
+
+  makeResource(kind, name, resource, metadata={}):: {
+    apiVersion: $.grizzlyAPI,
+    kind: kind,
+    metadata: {
+      name: name,
+    } + metadata,
+    spec: resource,
+  },
+}

--- a/examples/vendor/grizzly
+++ b/examples/vendor/grizzly
@@ -1,0 +1,1 @@
+github.com/grafana/jsonnet-libs/grizzly


### PR DESCRIPTION
There's now a sensible lib for Grizzly in the github.com/grafana/jsonnet-libs
repo. It offers simple constructors for each type of resource. With the
creation of this lib, we can now stop discouraging the use of hidden
elements in Grizzly, as it is easy now to expose them as Kubernetes-style
objects.
