### PR TITLE
Add GetUID function to resource object

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -84,6 +84,11 @@ func (h *DashboardHandler) Prepare(existing, resource grizzly.Resource) *grizzly
 	return &resource
 }
 
+// GetUID returns the UID for a resource
+func (h *DashboardHandler) GetUID(resource grizzly.Resource) (string, error) {
+	return resource.Name(), nil
+}
+
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *DashboardHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 	resource, err := getRemoteDashboard(UID)

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -104,6 +104,11 @@ func (h *DatasourceHandler) Prepare(existing, resource grizzly.Resource) *grizzl
 	return &resource
 }
 
+// GetUID returns the UID for a resource
+func (h *DatasourceHandler) GetUID(resource grizzly.Resource) (string, error) {
+	return resource.Name(), nil
+}
+
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *DatasourceHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 	return getRemoteDatasource(UID)

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -80,6 +80,11 @@ func (h *FolderHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Re
 	return &resource
 }
 
+// GetUID returns the UID for a resource
+func (h *FolderHandler) GetUID(resource grizzly.Resource) (string, error) {
+	return resource.Name(), nil
+}
+
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *FolderHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 	resource, err := getRemoteFolder(UID)

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -78,6 +78,14 @@ func (h *RuleHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Reso
 	return &resource
 }
 
+// GetUID returns the UID for a resource
+func (h *RuleHandler) GetUID(resource grizzly.Resource) (string, error) {
+	if !resource.HasMetadata("namespace") {
+		return "", fmt.Errorf("%s %s requires a namespace metadata entry", h.Kind(), resource.Name())
+	}
+	return fmt.Sprintf("%s.%s", resource.GetMetadata("namespace"), resource.Name()), nil
+}
+
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *RuleHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 	return getRemoteRuleGroup(UID)

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -101,6 +101,14 @@ func (h *SyntheticMonitoringHandler) Prepare(existing, resource grizzly.Resource
 	return &resource
 }
 
+// GetUID returns the UID for a resource
+func (h *SyntheticMonitoringHandler) GetUID(resource grizzly.Resource) (string, error) {
+	if !resource.HasMetadata("type") {
+		return "", fmt.Errorf("%s %s lacks a type metadata element", h.Kind(), resource.Name())
+	}
+	return fmt.Sprintf("%s.%s", resource.GetMetadata("type"), resource.Name()), nil
+}
+
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *SyntheticMonitoringHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 	return getRemoteCheck(UID)

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -48,6 +48,12 @@ func (r *Resource) Key() string {
 	return fmt.Sprintf("%s/%s", r.Kind(), r.Name())
 }
 
+func (r *Resource) HasMetadata(key string) bool {
+	metadata := (*r)["metadata"].(map[string]interface{})
+	_, ok := metadata[key]
+	return ok
+}
+
 func (r *Resource) GetMetadata(key string) string {
 	metadata := (*r)["metadata"].(map[string]interface{})
 	return metadata[key].(string)
@@ -150,6 +156,9 @@ type Handler interface {
 
 	// Prepare gets a resource ready for dispatch to the remote endpoint
 	Prepare(existing, resource Resource) *Resource
+
+	// Retrieves a UID for a resource
+	GetUID(resource Resource) (string, error)
 
 	// Get retrieves JSON for a resource from an endpoint, by UID
 	GetByUID(UID string) (*Resource, error)


### PR DESCRIPTION
The new tests have shown up some naming issues.

We have `resource.Name()`, which extracts `metadata.name`, but this is *not*
the resource's UID, which in some cases needs to be a compound element, e.g.
`$NAMESPACE.$NAME` for a `PrometheusRuleGroup` or `$TYPE.$JOB` for a
`SyntheticMonitoringCheck`.

This PR adds a `GetUID()` function that correctly returns a UID across all
resource types.
