### PR TITLE
Set name metadata correctly for prom rules

### DIFF
--- a/pkg/grafana/rules.go
+++ b/pkg/grafana/rules.go
@@ -52,7 +52,7 @@ func getRemoteRuleGroup(uid string) (*grizzly.Resource, error) {
 						"rules": group.Rules,
 					}
 					handler := RuleHandler{}
-					resource := grizzly.NewResource(handler.APIVersion(), handler.Kind(), uid, spec)
+					resource := grizzly.NewResource(handler.APIVersion(), handler.Kind(), group.Name, spec)
 					resource.SetMetadata("namespace", namespace)
 					return &resource, nil
 				}


### PR DESCRIPTION
Here, `uid` is `$NAMESPACE.$NAME`. We should not set the `name` to that.

Currently, if we re-render a UID we will get `$NAMESPACE.$NAMESPACE.$NAME`.

This PR corrects this error by setting the name to just `group.name`. The
namespace is set in metadata in the next line.
