### PR TITLE
Always apply handlers in order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,4 @@ drone:
 	drone jsonnet --source .drone/drone.jsonnet --target .drone/drone.yml --stream --format
 	# Sign the config
 	drone --server https://drone.grafana.net sign --save grafana/grizzly .drone/drone.yml
+

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -27,9 +27,9 @@ func (p *Provider) APIVersion() string {
 // GetHandlers identifies the handlers for the Grafana provider
 func (p *Provider) GetHandlers() []grizzly.Handler {
 	return []grizzly.Handler{
+		NewDatasourceHandler(*p),
 		NewFolderHandler(*p),
 		NewDashboardHandler(*p),
-		NewDatasourceHandler(*p),
 		NewRuleHandler(*p),
 		NewSyntheticMonitoringHandler(*p),
 	}

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -30,7 +30,7 @@ func (p *Provider) GetHandlers() []grizzly.Handler {
 		NewFolderHandler(*p),
 		NewDashboardHandler(*p),
 		NewDatasourceHandler(*p),
-		NewSyntheticMonitoringHandler(*p),
 		NewRuleHandler(*p),
+		NewSyntheticMonitoringHandler(*p),
 	}
 }

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 
 	"github.com/google/go-jsonnet"
@@ -87,6 +88,7 @@ func ParseYAML(yamlFile string, opts Opts) (Resources, error) {
 			}
 		}
 	}
+	sort.Sort(resources)
 	return resources, nil
 }
 
@@ -144,6 +146,7 @@ func ParseJsonnet(jsonnetFile string, opts Opts) (Resources, error) {
 			}
 		}
 	}
+	sort.Sort(resources)
 	return resources, nil
 }
 

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -144,6 +144,22 @@ func (r *Resource) MatchesTarget(targets []string) bool {
 // Resources represents a set of resources
 type Resources []Resource
 
+func (r Resources) Len() int {
+	return len(r)
+}
+
+func (r Resources) Less(i, j int) bool {
+	iKind := r[i].Kind()
+	jKind := r[j].Kind()
+	iPos := Registry.HandlerOrder[iKind]
+	jPos := Registry.HandlerOrder[jKind]
+	return iPos < jPos
+}
+
+func (r Resources) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
 // Handler describes a handler for a single API resource handled by a single provider
 type Handler interface {
 	APIVersion() string

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -17,8 +17,9 @@ type Provider interface {
 
 // ProviderSet records providers
 type registry struct {
-	Providers []Provider
-	Handlers  map[string]Handler
+	Providers    []Provider
+	Handlers     map[string]Handler
+	HandlerOrder map[string]int
 }
 
 // Global Handler registry
@@ -28,9 +29,13 @@ var Registry registry
 func ConfigureProviderRegistry(providers []Provider) {
 	Registry.Providers = providers
 	Registry.Handlers = map[string]Handler{}
+	Registry.HandlerOrder = map[string]int{}
+	position := 0
 	for _, provider := range providers {
 		for _, handler := range provider.GetHandlers() {
 			Registry.Handlers[handler.Kind()] = handler
+			Registry.HandlerOrder[handler.Kind()] = position
+			position++
 		}
 	}
 }


### PR DESCRIPTION
Grizzly consumes code from Tanka that extracts "manifests" from a
JSON tree (i.e. output from Jsonnet script). This is returned as a
`map[string]manifest.Manifest`. As this is a map, it is unordered,
meaning resources are returned in a different order each time.

This can cause problems when ordering matters, notably when a
dashboard is applied before its folder.

This PR creates a consistent ordering for resources, they will
always be processed in consistent handler order.

Note, ordering within a handler will not (yet) be consistent, but
this shouldn't cause issues.
