### PR TITLE
Switch to dot as resource separator

### DIFF
--- a/pkg/grafana/rules_test.go
+++ b/pkg/grafana/rules_test.go
@@ -36,7 +36,7 @@ func TestRules(t *testing.T) {
 		require.Equal(t, "PrometheusRuleGroup", res.Kind())
 		key := res.Key()
 		require.NoError(t, err)
-		require.Equal(t, "PrometheusRuleGroup/first_rules.grizzly_alerts", key)
+		require.Equal(t, "PrometheusRuleGroup.first_rules.grizzly_alerts", key)
 	})
 
 	t.Run("get remote rule group - error from cortextool client", func(t *testing.T) {

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -136,10 +136,12 @@ func (r *Resource) MatchesTarget(targets []string) bool {
 	if len(targets) == 0 {
 		return true
 	}
-	key := r.Key()
+	UID := r.UID()
+	slashKey := fmt.Sprintf("%s/%s", r.Kind(), UID)
+	dotKey := fmt.Sprintf("%s.%s", r.Kind(), UID)
 	for _, target := range targets {
 		g := glob.MustCompile(target)
-		if g.Match(key) {
+		if g.Match(slashKey) || g.Match(dotKey) {
 			return true
 		}
 	}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -43,6 +43,12 @@ func (r Resource) String() string {
 	return r.Key()
 }
 
+// Key returns a key that combines kind and uid
+func (r *Resource) Key() string {
+	uid := r.UID()
+	return fmt.Sprintf("%s.%s", r.Kind(), uid)
+}
+
 func (r Resource) UID() string {
 	handler, err := Registry.GetHandler(r.Kind())
 	if err != nil {
@@ -53,12 +59,6 @@ func (r Resource) UID() string {
 		return "error:" + err.Error()
 	}
 	return uid
-}
-
-// Key returns a key that combines kind and uid
-func (r *Resource) Key() string {
-	uid := r.UID()
-	return fmt.Sprintf("%s.%s", r.Kind(), uid)
 }
 
 func (r *Resource) HasMetadata(key string) bool {
@@ -137,8 +137,8 @@ func (r *Resource) MatchesTarget(targets []string) bool {
 		return true
 	}
 	UID := r.UID()
+	dotKey := r.Key()
 	slashKey := fmt.Sprintf("%s/%s", r.Kind(), UID)
-	dotKey := fmt.Sprintf("%s.%s", r.Kind(), UID)
 	for _, target := range targets {
 		g := glob.MustCompile(target)
 		if g.Match(slashKey) || g.Match(dotKey) {

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -43,17 +43,22 @@ func (r Resource) String() string {
 	return r.Key()
 }
 
-// Key returns a key that combines kind and uid
-func (r *Resource) Key() string {
+func (r Resource) UID() string {
 	handler, err := Registry.GetHandler(r.Kind())
 	if err != nil {
 		return "Unknown-handler:" + r.Kind()
 	}
-	uid, err := handler.GetUID(*r)
+	uid, err := handler.GetUID(r)
 	if err != nil {
 		return "error:" + err.Error()
 	}
-	return fmt.Sprintf("%s/%s", r.Kind(), uid)
+	return uid
+}
+
+// Key returns a key that combines kind and uid
+func (r *Resource) Key() string {
+	uid := r.UID()
+	return fmt.Sprintf("%s.%s", r.Kind(), uid)
 }
 
 func (r *Resource) HasMetadata(key string) bool {

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -52,7 +52,8 @@ func (r *registry) HandlerMatchesTarget(handler Handler, targets []string) bool 
 	key := handler.Kind()
 
 	for _, target := range targets {
-		if strings.Contains(target, "/") && strings.Split(target, "/")[0] == key {
+		if (strings.Contains(target, "/") && strings.Split(target, "/")[0] == key) ||
+			(strings.Contains(target, ".") && strings.Split(target, ".")[0] == key) {
 			return true
 		}
 	}
@@ -64,10 +65,13 @@ func (r *registry) ResourceMatchesTarget(handler Handler, UID string, targets []
 	if len(targets) == 0 {
 		return true
 	}
-	key := fmt.Sprintf("%s/%s", handler.Kind(), UID)
+	// I mistakenly assumed 'dot' was a special character for globs, so opted for '/' as separator.
+	// This keeps back-compat
+	slashKey := fmt.Sprintf("%s/%s", handler.Kind(), UID)
+	dotKey := fmt.Sprintf("%s.%s", handler.Kind(), UID)
 	for _, target := range targets {
 		g := glob.MustCompile(target)
-		if g.Match(key) {
+		if g.Match(slashKey) || g.Match(dotKey) {
 			return true
 		}
 	}

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -158,11 +158,11 @@ func Show(resources Resources) error {
 		}
 		if interactive {
 			items = append(items, term.PageItem{
-				Name:    fmt.Sprintf("%s/%s", resource.Kind(), resource.Name()),
+				Name:    fmt.Sprintf("%s.%s", resource.Kind(), resource.Name()),
 				Content: rep,
 			})
 		} else {
-			fmt.Printf("%s/%s:\n", resource.Kind(), resource.Name())
+			fmt.Printf("%s.%s:\n", resource.Kind(), resource.Name())
 			fmt.Println(rep)
 		}
 	}


### PR DESCRIPTION
I mistakenly assumed that a dot was a special character in globs. It isn't - a single character glob is a question mark.

Therefore, we can revert to using dots as separators everywhere. This PR does that, but it also keeps slash separators working for command line targets.