### PR TITLE
Import libraries relative to execution folder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,5 +7,6 @@ This directory contains examples that use this format.
 To look at the examples in this directory, execute:
 
 ```
-grr show examples/grr.jsonnet
+cd examples
+grr show grr.jsonnet
 ```

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -100,12 +100,11 @@ func ParseJsonnet(jsonnetFile string, opts Opts) (Resources, error) {
 
 	script := fmt.Sprintf(script, jsonnetFile)
 	vm := jsonnet.MakeVM()
-	absoluteFile, err := filepath.Abs(jsonnetFile)
+	currentWorkingDirectory, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
-	path := filepath.Dir(absoluteFile)
-	vm.Importer(newExtendedImporter(path, opts.JsonnetPaths))
+	vm.Importer(newExtendedImporter(currentWorkingDirectory, opts.JsonnetPaths))
 	for _, nf := range native.Funcs() {
 		vm.NativeFunction(nf)
 	}


### PR DESCRIPTION
This is to make it consistent with jsonnet behavior. Fixes #171 