### PR TITLE
Fix Synthetic Monitoring Example

### DIFF
--- a/examples/synthetic-monitoring-simple.libsonnet
+++ b/examples/synthetic-monitoring-simple.libsonnet
@@ -1,6 +1,4 @@
-local util = import 'util.libsonnet';
-
-local check = {
+{
   frequency: 60000,
   offset: 0,
   timeout: 2500,
@@ -42,6 +40,4 @@ local check = {
   job: 'grafana-com',
   alertSensitivity: '',
   basicMetricsOnly: true,
-};
-
-util.makeResource('SyntheticMonitoringCheck', check.job, check, { type: std.objectFields(check.settings)[0] })
+}


### PR DESCRIPTION
Currently we are creating a resource then creating a resource, i.e. getting
double nesting of Synthetic Monitoring checks in the Jsonnet example. This
PR fixes that.
