### PR TITLE
Fix Jsonnet link in Getting Started section

### DIFF
--- a/docs/content/what-is-grizzly.md
+++ b/docs/content/what-is-grizzly.md
@@ -14,7 +14,7 @@ whenever you deploy your application, your observability is updated too.
 ## Getting Started
 The simplest way to achieve this is using YAML resource
 descriptions. (Programmatic description is explained in the section on 
-[Jsonnet](/jsonnet/)).
+[Jsonnet](../jsonnet/)).
 
 We will first explore how to use Grizzly with Grafana.
 


### PR DESCRIPTION
The link to Jsonnet in https://grafana.github.io/grizzly/what-is-grizzly/#getting-started results in a 404.

I copied the new link from https://github.com/grafana/grizzly/blob/master/docs/content/workflows.md?plain=1#L42, as it seems to work correctly in https://grafana.github.io/grizzly/workflows/#jsonnet