### PR TITLE
Set datasource spec.name to metadata.name

### DIFF
--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -86,6 +86,7 @@ func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.Resources, error
 		}
 	}
 	spec["uid"] = m.Metadata().Name()
+	spec["name"] = m.Metadata().Name()
 	resource["spec"] = spec
 	return grizzly.Resources{resource}, nil
 }


### PR DESCRIPTION
Closes https://github.com/grafana/grizzly/issues/181

Resolves the following error when doing `grr apply grr.jsonnet` in the example folder:  
`Non-200 response from Grafana while applying datasource prometheus: 422 Unprocessable Entity [{"fieldNames":["Name"],"classification":"RequiredError","message":"Required"}]`

`spec.name` seems to be a required datasource field. I think it makes sense to copy the name from metadata, as done with `spec.uid`.