### PR TITLE
Set dashboard folder to default val when undefined

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -71,6 +71,9 @@ func (h *DashboardHandler) ResourceFilePath(resource grizzly.Resource, filetype 
 func (h *DashboardHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
 	resource := grizzly.Resource(m)
 	resource.SetSpecString("uid", resource.GetMetadata("name"))
+	if !resource.HasMetadata("folder") {
+		resource.SetMetadata("folder", dashboardFolderDefault) 
+	}
 	return grizzly.Resources{resource}, nil
 }
 


### PR DESCRIPTION
Closes https://github.com/grafana/grizzly/issues/180

Applies the existing `dashboardFolderDefault` as default when `metadata.folder` is undefined.