### PR TITLE
Improve Jpath handling

### DIFF
--- a/pkg/grizzly/jsonnet.go
+++ b/pkg/grizzly/jsonnet.go
@@ -28,9 +28,16 @@ func newFileLoader(fi *jsonnet.FileImporter) importLoader {
 	}
 }
 
-func newExtendedImporter(path string, jpath []string) *ExtendedImporter {
-	absolutePaths := make([]string, len(jpath)+1)
+func newExtendedImporter(jsonnetFile, path string, jpath []string) *ExtendedImporter {
+	absolutePaths := make([]string, len(jpath)*2+1)
 	absolutePaths = append(absolutePaths, path)
+	jsonnetDir := filepath.Dir(jsonnetFile)
+	for _, p := range jpath {
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(jsonnetDir, p)
+		}
+		absolutePaths = append(absolutePaths, p)
+	}
 	for _, p := range jpath {
 		if !filepath.IsAbs(p) {
 			p = filepath.Join(path, p)

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -107,7 +107,7 @@ func ParseJsonnet(jsonnetFile string, opts Opts) (Resources, error) {
 	if err != nil {
 		return nil, err
 	}
-	vm.Importer(newExtendedImporter(currentWorkingDirectory, opts.JsonnetPaths))
+	vm.Importer(newExtendedImporter(jsonnetFile, currentWorkingDirectory, opts.JsonnetPaths))
 	for _, nf := range native.Funcs() {
 		vm.NativeFunction(nf)
 	}


### PR DESCRIPTION
Ideally, we would have a way to track down the root of a project, and from there
identify where the default jsonnet paths of `lib` and `vendor` should be found.

In place of this, we need two forms:

 * Look in the directory of the jsonnet file. This has the benefit of allowing
   local overrides of other imports
 * Look in the current directory where Grizzly was invoked. This allows for
   running Grizzly in the midst of other larger jsonnet codebases.

Without this fix, the Grizzly/Jsonnet examples don't work.
