### PR TITLE
Handle missing dashboard folder

### DIFF
--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -98,7 +98,7 @@ func postDashboard(resource grizzly.Resource) error {
 
 	folderUID := resource.GetMetadata("folder")
 	var folderID int64
-	if !(folderUID == "General" || folderUID == "general") {
+	if !(folderUID == "General" || folderUID == "general" || folderUID == "") {
 		folder, err := getRemoteFolder(folderUID)
 		if err != nil && errors.As(err, &grizzly.ErrNotFound) {
 			return fmt.Errorf("Cannot upload dashboard %s as folder %s not found", resource.GetMetadata("name"), folderUID)

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -69,7 +69,11 @@ func (r *Resource) HasMetadata(key string) bool {
 
 func (r *Resource) GetMetadata(key string) string {
 	metadata := (*r)["metadata"].(map[string]interface{})
-	return metadata[key].(string)
+	value, ok := metadata[key].(string)
+	if !ok {
+		return ""
+	}
+	return value
 }
 
 func (r *Resource) SetMetadata(key, value string) {


### PR DESCRIPTION
Currently, when no folder is provided for a dashboard, Grizzly panics
trying to convert a nil to a string. This is less than ideal.

This PR fixes the panic, and takes the assumption that a dashboard
without a folder named should go into the General folder.

Fixes #180.
