### PR TITLE
fix: Synthetic monitoring UIDs are wrong

### DIFF
--- a/pkg/grafana/synthetic-monitoring.go
+++ b/pkg/grafana/synthetic-monitoring.go
@@ -266,5 +266,5 @@ func getType(check synthetic_monitoring.Check) string {
 }
 
 func getUID(check synthetic_monitoring.Check) string {
-	return fmt.Sprintf("%s-%s", getType(check), check.Job)
+	return fmt.Sprintf("%s.%s", getType(check), check.Job)
 }

--- a/pkg/grafana/synthetic-monitoring_test.go
+++ b/pkg/grafana/synthetic-monitoring_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
+	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,4 +28,59 @@ func TestSyntheticMonitoring(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uid, "http.test")
 	})
+}
+
+func TestSyntheticMonitoringCheckUID(t *testing.T) {
+	testCases := []struct {
+		name        string
+		check       synthetic_monitoring.Check
+		expectedUID string
+	}{
+		{
+			name: "http check",
+			check: synthetic_monitoring.Check{
+				Job: "https://website.com",
+				Settings: synthetic_monitoring.CheckSettings{
+					Http: &synthetic_monitoring.HttpSettings{},
+				},
+			},
+			expectedUID: "http.https://website.com",
+		},
+		{
+			name: "ping check",
+			check: synthetic_monitoring.Check{
+				Job: "10.1.2.3",
+				Settings: synthetic_monitoring.CheckSettings{
+					Ping: &synthetic_monitoring.PingSettings{},
+				},
+			},
+			expectedUID: "ping.10.1.2.3",
+		},
+		{
+			name: "dns check",
+			check: synthetic_monitoring.Check{
+				Job: "website.com",
+				Settings: synthetic_monitoring.CheckSettings{
+					Dns: &synthetic_monitoring.DnsSettings{},
+				},
+			},
+			expectedUID: "dns.website.com",
+		},
+		{
+			name: "tcp check",
+			check: synthetic_monitoring.Check{
+				Job: "website.com",
+				Settings: synthetic_monitoring.CheckSettings{
+					Tcp: &synthetic_monitoring.TcpSettings{},
+				},
+			},
+			expectedUID: "tcp.website.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedUID, getUID(tc.check))
+		})
+	}
 }


### PR DESCRIPTION
The UID computed from the jsonnet definition uses a `.` as a separator while the one computed from the remote checks uses `-` as a separator
This means that they never match and Grizzly always tries to create checks even if they already exists
This fails with a `409 Conflict` error