### PR TITLE
documenting the use of a proxy with grizzly

### DIFF
--- a/docs/content/authentication.md
+++ b/docs/content/authentication.md
@@ -50,3 +50,11 @@ Your stack ID is the number at the end of the url when you view your Grafana ins
 # Timeouts
 
 Grizzly has a 10 second timeout on some HTTP calls. To override this behavior, use the `GRIZZLY_HTTP_TIMEOUT=<seconds>` environment variable.
+
+## HTTP PROXY
+To use a proxy with Grizzly, you must have the following environment variable set:
+
+| Name | Description | Required |
+| --- | --- | --- |
+| `HTTPS_PROXY` | This should be the full url/port of your proxy https://proxy:8080 | true |
+

--- a/pkg/grafana/httpclient.go
+++ b/pkg/grafana/httpclient.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"net/http"
-	"net/url"
 	"os"
 	"strconv"
 	"time"
@@ -17,11 +16,5 @@ func NewHttpClient() (*http.Client, error) {
 		}
 		timeout = time.Duration(timeoutSeconds) * time.Second
 	}
-	if httpProxy := os.Getenv("HTTP_PROXY"); httpProxy != "" {
-		proxyUrl, err := url.Parse(httpProxy)
-	Transport:
-		&http.Transport{Proxy: http.ProxyURL(proxyUrl)}
-	}
-
 	return &http.Client{Timeout: timeout}, nil
 }

--- a/pkg/grafana/httpclient.go
+++ b/pkg/grafana/httpclient.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"time"
@@ -16,5 +17,11 @@ func NewHttpClient() (*http.Client, error) {
 		}
 		timeout = time.Duration(timeoutSeconds) * time.Second
 	}
+	if httpProxy := os.Getenv("HTTP_PROXY"); httpProxy != "" {
+		proxyUrl, err := url.Parse(httpProxy)
+	Transport:
+		&http.Transport{Proxy: http.ProxyURL(proxyUrl)}
+	}
+
 	return &http.Client{Timeout: timeout}, nil
 }


### PR DESCRIPTION
added the use of HTTPS_PROXY to our docs