### PR TITLE
modify requests to send authorization header

### DIFF
--- a/pkg/grafana/config.go
+++ b/pkg/grafana/config.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 )
 
+func getGrafanaToken() (string, error) {
+	if token, exists := os.LookupEnv("GRAFANA_TOKEN"); exists {
+			return token, nil
+	}
+	return "", fmt.Errorf("Require GRAFANA_TOKEN")
+}
+
 func getGrafanaURL(urlPath string) (string, error) {
 	if grafanaURL, exists := os.LookupEnv("GRAFANA_URL"); exists {
 		u, err := url.Parse(grafanaURL)

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -30,7 +30,6 @@ func getRemoteDashboard(uid string) (*grizzly.Resource, error) {
 	}
 	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-	//resp, err := http.Get(grafanaURL)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -84,7 +83,6 @@ func getRemoteDashboardList() ([]string, error) {
 		}
 		req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-		//resp, err := http.Get(grafanaURL)
 		resp, err := client.Do(req)
 		if err != nil {
 			return nil, err
@@ -155,7 +153,6 @@ func postDashboard(resource grizzly.Resource) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-	//resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(wrappedJSON))
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -223,7 +220,6 @@ func postSnapshot(resource grizzly.Resource, opts *grizzly.PreviewOpts) (*Snapsh
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-	//resp, err := http.Post(url, "application/json", bytes.NewBuffer(bs))
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/grafana/dashboards.go
+++ b/pkg/grafana/dashboards.go
@@ -13,12 +13,25 @@ import (
 
 // getRemoteDashboard retrieves a dashboard object from Grafana
 func getRemoteDashboard(uid string) (*grizzly.Resource, error) {
+	client := new(http.Client)
 	grafanaURL, err := getGrafanaURL("api/dashboards/uid/" + uid)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := http.Get(grafanaURL)
+	req, err := http.NewRequest("GET", grafanaURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+	//resp, err := http.Get(grafanaURL)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +65,7 @@ func getRemoteDashboard(uid string) (*grizzly.Resource, error) {
 func getRemoteDashboardList() ([]string, error) {
 	batchSize := 500
 
+	client := new(http.Client)
 	UIDs := []string{}
 	for page := 1; ; page++ {
 		grafanaURL, err := getGrafanaURL(fmt.Sprintf("/api/search?type=dash-db&limit=%d&page=%d", batchSize, page))
@@ -59,7 +73,19 @@ func getRemoteDashboardList() ([]string, error) {
 			return nil, err
 		}
 
-		resp, err := http.Get(grafanaURL)
+		req, err := http.NewRequest("GET", grafanaURL, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		grafanaToken, err := getGrafanaToken()
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+		//resp, err := http.Get(grafanaURL)
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, err
 		}
@@ -91,10 +117,12 @@ func getRemoteDashboardList() ([]string, error) {
 }
 
 func postDashboard(resource grizzly.Resource) error {
+	client := new(http.Client)
 	grafanaURL, err := getGrafanaURL("api/dashboards/db")
 	if err != nil {
 		return err
 	}
+
 
 	folderUID := resource.GetMetadata("folder")
 	var folderID int64
@@ -115,7 +143,20 @@ func postDashboard(resource grizzly.Resource) error {
 	}
 	wrappedJSON, err := wrappedBoard.toJSON()
 
-	resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(wrappedJSON))
+	req, err := http.NewRequest("POST", grafanaURL, bytes.NewBufferString(wrappedJSON))
+	if err != nil {
+		return err
+	}
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+	//resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(wrappedJSON))
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -147,7 +188,7 @@ type SnapshotResp struct {
 }
 
 func postSnapshot(resource grizzly.Resource, opts *grizzly.PreviewOpts) (*SnapshotResp, error) {
-
+	client := new(http.Client)
 	url, err := getGrafanaURL("api/snapshots")
 	if err != nil {
 		return nil, err
@@ -170,7 +211,20 @@ func postSnapshot(resource grizzly.Resource, opts *grizzly.PreviewOpts) (*Snapsh
 		return nil, err
 	}
 
-	resp, err := http.Post(url, "application/json", bytes.NewBuffer(bs))
+	req, err :=  http.NewRequest("POST", url, bytes.NewBuffer(bs))
+	if err != nil {
+		return nil, err
+	}
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+	//resp, err := http.Post(url, "application/json", bytes.NewBuffer(bs))
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grafana/datasources.go
+++ b/pkg/grafana/datasources.go
@@ -29,7 +29,6 @@ func makeDatasourceRequest(url string) ([]byte, error) {
 	}
 	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-	//resp, err := http.Get(grafanaURL)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -86,7 +85,6 @@ func getRemoteDatasourceList() ([]string, error) {
 	}
 	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-	//resp, err := http.Get(grafanaURL)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -140,7 +138,6 @@ func postDatasource(resource grizzly.Resource) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-	//resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(sourceJSON))
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/pkg/grafana/datasources.go
+++ b/pkg/grafana/datasources.go
@@ -12,12 +12,25 @@ import (
 )
 
 func makeDatasourceRequest(url string) ([]byte, error) {
+	client := new(http.Client)
 	grafanaURL, err := getGrafanaURL(url)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := http.Get(grafanaURL)
+	req, err := http.NewRequest("GET", grafanaURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+	//resp, err := http.Get(grafanaURL)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -56,12 +69,25 @@ func getRemoteDatasource(uid string) (*grizzly.Resource, error) {
 }
 
 func getRemoteDatasourceList() ([]string, error) {
+	client := new(http.Client)
 	grafanaURL, err := getGrafanaURL("api/datasources")
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := http.Get(grafanaURL)
+	req, err := http.NewRequest("GET", grafanaURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+	//resp, err := http.Get(grafanaURL)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -91,6 +117,7 @@ func getRemoteDatasourceList() ([]string, error) {
 }
 
 func postDatasource(resource grizzly.Resource) error {
+	client := new(http.Client)
 	grafanaURL, err := getGrafanaURL("api/datasources")
 	if err != nil {
 		return err
@@ -101,7 +128,20 @@ func postDatasource(resource grizzly.Resource) error {
 		return err
 	}
 
-	resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(sourceJSON))
+	req, err := http.NewRequest("POST", grafanaURL, bytes.NewBufferString(sourceJSON))
+	if err != nil {
+		return err
+	}
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+	//resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(sourceJSON))
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -144,6 +184,12 @@ func putDatasource(resource grizzly.Resource) error {
 	}
 	req, err := http.NewRequest("PUT", grafanaURL, bytes.NewBufferString(sourceJSON))
 	req.Header.Add("Content-type", "application/json")
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/grafana/folders.go
+++ b/pkg/grafana/folders.go
@@ -40,7 +40,6 @@ func getRemoteFolder(uid string) (*grizzly.Resource, error) {
 	}
 	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-	//resp, err := http.Get(grafanaURL)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -90,7 +89,6 @@ func getRemoteFolderList() ([]string, error) {
 		}
 		req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-		//resp, err := http.Get(grafanaURL)
 		resp, err := client.Do(req)
 		if err != nil {
 			return nil, err
@@ -149,7 +147,6 @@ func postFolder(resource grizzly.Resource) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-	//resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(folderJSON))
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -238,7 +235,6 @@ var getFolderById = func(folderId int64) (Folder, error) {
 	}
 	req.Header.Set("Authorization", "Bearer " + grafanaToken)
 
-	//resp, err := http.Get(grafanaURL)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/grafana/folders.go
+++ b/pkg/grafana/folders.go
@@ -13,6 +13,7 @@ import (
 
 // getRemoteFolder retrieves a folder object from Grafana
 func getRemoteFolder(uid string) (*grizzly.Resource, error) {
+	client := new(http.Client)
 	h := FolderHandler{}
 	if uid == "General" || uid == "general" {
 		folder := Folder{
@@ -28,7 +29,19 @@ func getRemoteFolder(uid string) (*grizzly.Resource, error) {
 		return nil, err
 	}
 
-	resp, err := http.Get(grafanaURL)
+	req, err := http.NewRequest("GET", grafanaURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+	//resp, err := http.Get(grafanaURL)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -57,6 +70,8 @@ func getRemoteFolder(uid string) (*grizzly.Resource, error) {
 func getRemoteFolderList() ([]string, error) {
 	batchSize := 100
 
+	client := new(http.Client)
+
 	UIDs := []string{}
 	for page := 1; ; page++ {
 		grafanaURL, err := getGrafanaURL(fmt.Sprintf("/api/search?type=dash-folder&limit=%d&page=%d", batchSize, page))
@@ -64,7 +79,19 @@ func getRemoteFolderList() ([]string, error) {
 			return nil, err
 		}
 
-		resp, err := http.Get(grafanaURL)
+		req, err := http.NewRequest("GET", grafanaURL, nil)
+	    if err != nil {
+		    return nil, err
+	    }
+	
+		grafanaToken, err := getGrafanaToken()
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+		//resp, err := http.Get(grafanaURL)
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, err
 		}
@@ -97,6 +124,7 @@ func getRemoteFolderList() ([]string, error) {
 
 func postFolder(resource grizzly.Resource) error {
 	name := resource.GetMetadata("name")
+	client := new(http.Client)
 	if name == "General" || name == "general" {
 		return nil
 	}
@@ -109,7 +137,20 @@ func postFolder(resource grizzly.Resource) error {
 	folder["uid"] = resource.GetMetadata("name")
 	folderJSON, err := folder.toJSON()
 
-	resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(folderJSON))
+	req, err := http.NewRequest("POST", grafanaURL, bytes.NewBufferString(folderJSON))
+	if err != nil {
+		return err
+	}
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+	//resp, err := http.Post(grafanaURL, "application/json", bytes.NewBufferString(folderJSON))
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -147,6 +188,13 @@ func putFolder(resource grizzly.Resource) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -173,12 +221,25 @@ func putFolder(resource grizzly.Resource) error {
 }
 
 var getFolderById = func(folderId int64) (Folder, error) {
+	client := new(http.Client)
 	grafanaURL, err := getGrafanaURL(fmt.Sprintf("folders/id/%d", folderId))
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := http.Get(grafanaURL)
+    req, err := http.NewRequest("GET", grafanaURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	grafanaToken, err := getGrafanaToken()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer " + grafanaToken)
+
+	//resp, err := http.Get(grafanaURL)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I modified the code to use header-based authentication. The following changes where made:

- **pkg/grafana/config.go** - add function "getGrafanaToken" which reads the environment variable GRAFANA_TOKEN and returns the token
- **pkg/grafana/dashboards.go** - modified all requests to send the API token in the request header (Authorization)
- **pkg/grafana/datasources.go** - modified all requests to send the API token in the request header (Authorization)
- **pkg/grafana/folders.go** - modified all requests to send the API token in the request header (Authorization)

With this changes, Grizzly can be used even if the basic authentication method cannot be used e.g. because Grafana sits behind a reverse proxy with automatic authentication such as OpenID or similar. 

Not sure if all requests are modified or if there are other requests where the Authentication header musst be added. Especially for the rules further modification can be neccesarry. 