### PR TITLE
Improve jsonnet parser for rules

### DIFF
--- a/docs/content/hidden-elements.md
+++ b/docs/content/hidden-elements.md
@@ -1,5 +1,5 @@
 ---
-date: "2021-06-28T00:00:00+00:00"
+date: "2022-04-17T00:00:00+00:00"
 title: "Hidden Elements"
 ---
 
@@ -82,9 +82,52 @@ Prometheus alerts and recording rules can be defined too, for example:
   },
 }
 ```
-Here, we first create an alert rule element (`grizzly_alert`), which we then add to `prometheusAlerts`. `PrometheusAlerts` is where Grizzly expects to find alerts for Prometheus configured when using 'hidden
+Here, we first create an alert rule element (`grizzly_alert`), which we then add to namespace `grizzly_rules` inside `prometheusAlerts`. `PrometheusAlerts` is where Grizzly expects to find alerts for Prometheus configured when using 'hidden
 elements.
 
 Likewise, we then create a recording rule element (`grizzly_record`), which we then add to
-`prometheusRules`, which is where Grizzly expects to find Prometheus recording rules configured, again
+namespace `grizzly_rules` inside `prometheusRules`, which is where Grizzly expects to find Prometheus recording rules configured, again
 when using hidden elements.
+
+It also possible to load rules without specifying a namespace at all. In that case `grizzly_rules` namespace would be used. This is useful when loading alerts from monitoring-mixins:
+
+```
+{
+  grizzly_alert:: {
+    alert: 'PromScrapeFailed',
+    expr: 'up != 1',
+    'for': '1m',
+    labels: {
+      severity: 'critical',
+    },
+    annotations: {
+      message: 'Prometheus failed to scrape a target {{ $labels.job }}  / {{ $labels.instance }}',
+    },
+  },
+
+  prometheusAlerts+:: {
+      // namespace removed
+      groups: [{
+        name: 'grizzly_alert_rules',
+        rules: [
+          $.grizzly_alert,
+        ],
+      }],
+  },
+
+  grizzly_record:: {
+    record: 'job:up:sum',
+    expr: 'sum by(job) (up)',
+  },
+
+  prometheusRules+:: {
+      // namespace removed
+      groups: [{
+        name: 'grizzly_recording_rules',
+        rules: [
+          $.grizzly_record,
+        ],
+      }],
+  },
+}
+```

--- a/docs/content/hidden-elements.md
+++ b/docs/content/hidden-elements.md
@@ -83,7 +83,7 @@ Prometheus alerts and recording rules can be defined too, for example:
 }
 ```
 Here, we first create an alert rule element (`grizzly_alert`), which we then add to namespace `grizzly_rules` inside `prometheusAlerts`. `PrometheusAlerts` is where Grizzly expects to find alerts for Prometheus configured when using 'hidden
-elements.
+elements'.
 
 Likewise, we then create a recording rule element (`grizzly_record`), which we then add to
 namespace `grizzly_rules` inside `prometheusRules`, which is where Grizzly expects to find Prometheus recording rules configured, again

--- a/pkg/grizzly/grizzly.jsonnet
+++ b/pkg/grizzly/grizzly.jsonnet
@@ -65,21 +65,32 @@ local convert(main, apiVersion) = {
   },
 
   prometheus:
-    local groupNamespace(key) = std.objectFields(main[key])[0];
-    local groupName(key) = main[key][groupNamespace(key)].groups[0].name;
+    local forceNamespace(contents) =
+      // if rulesGroup isn't namespaced (monitoring-mixins), then put them into default namespace
+      if std.objectHas(contents, 'groups') then
+        // no namespace, wrap into default namespace
+        { 'grizzly_rules': contents }
+      else
+        // already has namespace
+        contents
+    ;
     local fromMap(key) =
-      if key in main
-      then [
-              makeResource(
-                'PrometheusRuleGroup',
-                groupName(key),
-                spec={
-                  rules: main[key][groupNamespace(key)].groups[0].rules,
-                },
-                metadata={ namespace: groupNamespace(key)})
-              for k in std.objectFields(main[key])
-           ]
-      else [];
+      if key in main then
+        local allNamespaced = forceNamespace(main[key]);
+        [
+          [
+            makeResource(
+              'PrometheusRuleGroup',
+              g.name,
+              spec={
+                rules: g.rules,
+              },
+              metadata={ namespace: ns }
+            )
+            for g in allNamespaced[ns].groups
+          ]
+          for ns in std.objectFields(allNamespaced)
+        ] else [];
     fromMap('prometheusRules')
     + fromMap('prometheusAlerts'),
 

--- a/pkg/grizzly/grizzly.jsonnet
+++ b/pkg/grizzly/grizzly.jsonnet
@@ -78,19 +78,20 @@ local convert(main, apiVersion) = {
       if key in main then
         local allNamespaced = forceNamespace(main[key]);
         [
-          [
-            makeResource(
-              'PrometheusRuleGroup',
-              g.name,
-              spec={
-                rules: g.rules,
-              },
-              metadata={ namespace: ns }
-            )
-            for g in allNamespaced[ns].groups
-          ]
+
+          makeResource(
+            'PrometheusRuleGroup',
+            g.name,
+            spec={
+              rules: g.rules,
+            },
+            metadata={ namespace: ns }
+          )
+
           for ns in std.objectFields(allNamespaced)
-        ] else [];
+          for g in allNamespaced[ns].groups
+        ]
+      else [];
     fromMap('prometheusRules')
     + fromMap('prometheusAlerts'),
 


### PR DESCRIPTION
Hi! Even though it says deprecated for using hidden fields, we still using it extensively for monitoring-mixins development, especially in `grr watch` mode. 

It works great for 'dashboards only' mixins that way, but unfortunately, it stops working when rules are present, error is recevied:

```
2022-04-17 02:34:04.863636 I | 02:34:04 Error:  RUNTIME ERROR: Unexpected type string, expected number
        mixin.libsonnet:69:28-65
        mixin.libsonnet:75:17-31        thunk from <thunk from <function <fromMap>>>
        mixin.libsonnet:8:58-62 thunk from <thunk from <thunk from <object <anonymous>>>>
        mixin.libsonnet:8:43-76 thunk from <thunk from <object <anonymous>>>
        mixin.libsonnet:8:28-90 thunk from <object <anonymous>>
        mixin.libsonnet:8:13-103        object <anonymous>
        During manifestation
``` 


This is due grizzly.jsonnet [expects](https://grafana.github.io/grizzly/hidden-elements/) rules to be wrapped in the namespace:

```
  prometheusAlerts+:: {
    grizzly_rules: { <--namespace
      groups: [{
        name: 'my_rules_group',
        rules: [
          $.alert,
        ],
      }],
    },
  },
````

while monitoring-mixins by convention have alerts defined without one:

```
  _config+:: {
  ...
  },
  grafanaDashboards+:: {
  ...
  },
  prometheusRules+:: {
  ...
  },
  prometheusAlerts+:: {
      groups: [{
        name: 'my_rules_group',
        rules: [
          $.alert,
        ],
      }],
  },
```

(some examples: 
https://github.com/prometheus/node_exporter/blob/master/docs/node-mixin/alerts/alerts.libsonnet
https://github.com/prometheus/prometheus/blob/main/documentation/prometheus-mixin/alerts.libsonnet
)

So here is the suggested improvement for jsonnet rule parser that:


- Parses rule groups even if they are not wrapped into namespace. This is extremely useful when working with monitoring-mixins. 'grizzly_rules' namespace is added
- Loads all rule groups instead of the first one.


This fix not only allows loading of monitoring-mixins dashboards inside grafana **without any grizzly specific changes to original mixin**, but also can load monitoring-mixins alerts into cortex as well:



```
user@vzhuravl-mac node-mixin % ../../../grizzly/cmd/grr/grr  watch .  mixin.libsonnet 
INFO[0000] Watching for changes                         
INFO[0001] Changes detected. Applyingmixin.libsonnet    
INFO[0001] Applying 8 resources                         
Dashboard.node-rsrc-use updated
Dashboard.nodes-darwin updated
Dashboard.nodes updated
Dashboard.node-multicluster-rsrc-use updated
PrometheusRuleGroup.grizzly_rules.node-exporter.rules no differences
PrometheusRuleGroup.abc.node-exporter-small no differences
PrometheusRuleGroup.zzz.node-exporter-small2 no differences
PrometheusRuleGroup.zzz.node-exporter no differences
```

![image](https://user-images.githubusercontent.com/14870891/163693967-87b931f1-1814-4b50-801e-84552956e63b.png)
