### PR TITLE
Allow configuration of pull path

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -65,9 +65,11 @@ func pullCmd() *cli.Command {
 		Args:  cli.ArgsExact(1),
 	}
 	var opts grizzly.Opts
+	var pathFormat string
+	cmd.Flags().StringVarP(&pathFormat, "format", "f", "", "path format for written files")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		return grizzly.Pull(args[0], opts)
+		return grizzly.Pull(args[0], opts, pathFormat)
 	}
 	return initialiseCmd(cmd, &opts)
 }

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -3,6 +3,8 @@ package grafana
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/grizzly/pkg/grizzly/notifier"
@@ -79,11 +81,22 @@ func (h *DashboardHandler) Parse(m manifest.Manifest) (grizzly.Resources, error)
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 func (h *DashboardHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
+	title, _ := resource.GetSpecString("title")
+	slug := title
+	if slug != "" {
+		reReplace, _ := regexp.Compile(`[-_/\s]+`)
+		reStrip, _ := regexp.Compile(`[^a-zA-Z0-9\-]+`)
+		slug = reReplace.ReplaceAllString(slug, "-")
+		slug = reStrip.ReplaceAllString(slug, "")
+		slug = strings.ToLower(slug)
+		resource.SetAnnotation("slug", slug)
+	}
 	return &resource
 }
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *DashboardHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
+	resource.DeleteAnnotation("slug")
 	return &resource
 }
 

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -78,6 +78,31 @@ func (r *Resource) SetMetadata(key, value string) {
 	(*r)["metadata"] = metadata
 }
 
+func (r *Resource) SetAnnotation(key, value string) {
+	metadata := (*r)["metadata"].(map[string]interface{})
+	annotationsObj, ok := metadata["annotations"]
+	var annotations map[string]string
+	if !ok {
+		annotations = map[string]string{}
+	} else {
+		annotations = annotationsObj.(map[string]string)
+	}
+	annotations[key] = value
+	metadata["annotations"] = annotations
+	(*r)["metadata"] = metadata
+}
+
+func (r *Resource) DeleteAnnotation(key string) {
+	metadata := (*r)["metadata"].(map[string]interface{})
+	annotationsObj, ok := metadata["annotations"]
+	if ok {
+		annotations := annotationsObj.(map[string]string)
+		delete(annotations, key)
+		metadata["annotations"] = annotations
+		(*r)["metadata"] = metadata
+	}
+}
+
 func (r *Resource) GetSpecString(key string) (string, bool) {
 	spec := (*r)["spec"].(map[string]interface{})
 	if val, ok := spec[key]; ok {


### PR DESCRIPTION
At present, Grizzly hardwires the directories to which it writes files when pulling. For some use-cases, this means that every file must be introspected in order to establish its purpose. If, instead, it were possible to include additional information from the resource (likely a dashboard) into the filename, decisions could be made without requiring introspection of the file.

This PR adds two features:
* `grr pull -f "{{.metadata.folder}}-{{.metadata.name}}.yaml"` formatting of the path that pull writes to
* adds a `.metadata.annotations.slug` annotation to dashboards that is derived from the title. This can make the meaning of the file more evident.