### PR TITLE
Add support for Grafana Library Panels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-jsonnet v0.18.0
 	github.com/grafana/cortex-tools v0.10.2
+	github.com/grafana/grafana-api-golang-client v0.7.0 // indirect
 	github.com/grafana/synthetic-monitoring-agent v0.0.23
 	github.com/grafana/synthetic-monitoring-api-go-client v0.0.2
 	github.com/grafana/tanka v0.14.0
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/rivo/tview v0.0.0-20200818120338-53d50e499bf9
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -803,6 +803,7 @@ github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr6
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-zookeeper/zk v1.0.2 h1:4mx0EYENAdX/B/rbunjlt5+4RTA/a9SMHBRuSKdGxPM=
 github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
+github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b/go.mod h1:Xo4aNUOrJnVruqWQJBtW6+bTBDTniY8yZum5rF3b5jw=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=
@@ -1030,6 +1031,8 @@ github.com/grafana-tools/sdk v0.0.0-20210310213032-c3f3511b3e9b/go.mod h1:uby+6h
 github.com/grafana/cortex-tools v0.10.2 h1:dRER28YbQgDhlq8ZuTGIf8W2ib4Ups041SngMDq3QVE=
 github.com/grafana/cortex-tools v0.10.2/go.mod h1:L2J3x8sA130Witmg9UxUSbhpyV4M7E4o9exrA+EYfMU=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85/go.mod h1:crI9WX6p0IhrqB+DqIUHulRW853PaNFf7o4UprV//3I=
+github.com/grafana/grafana-api-golang-client v0.7.0 h1:MEkWVbM1acmfHiyxzKqhoiQtoV7S7taUSrT0OXXKTmw=
+github.com/grafana/grafana-api-golang-client v0.7.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/loki v1.6.1/go.mod h1:X+GvtCzAf2ok/xRLLvGB8kuWP1R+75nXnvjCEnenP0s=
 github.com/grafana/loki v1.6.2-0.20210604065612-c3af249fe0f7 h1:16LlsuzNYj/9MligC1xm9y+APHvjW+2438JWJFw/1eA=
 github.com/grafana/loki v1.6.2-0.20210604065612-c3af249fe0f7/go.mod h1:4dNziJ4fSOHOUwFmJzwJDIhEmQKXLuj3n9LvFqL6yPA=
@@ -1089,6 +1092,8 @@ github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de/go.mod h1:
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-connlimit v0.2.0/go.mod h1:OUj9FGL1tPIhl/2RCfzYHrIiWj+VVPGNyVPnUX8AqS0=
 github.com/hashicorp/go-discover v0.0.0-20200501174627-ad1e96bde088/go.mod h1:vZu6Opqf49xX5lsFAu7iFNewkcVF1sn/wyapZh5ytlg=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
@@ -1429,6 +1434,8 @@ github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/pointerstructure v1.0.0/go.mod h1:k4XwG94++jLVsSiTxo7qdIfXA9pj9EAeo0QsNNJOLZ8=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/pkg/grafana/client.go
+++ b/pkg/grafana/client.go
@@ -1,0 +1,27 @@
+package grafana
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	grafana "github.com/grafana/grafana-api-golang-client"
+)
+
+func getClient() (*grafana.Client, error) {
+	grafanaURL, exists := os.LookupEnv("GRAFANA_URL")
+	if !exists {
+		return nil, fmt.Errorf("require GRAFANA_URL (optionally GRAFANA_TOKEN & GRAFANA_USER")
+	}
+	cfg := grafana.Config{}
+
+	if token, exists := os.LookupEnv("GRAFANA_TOKEN"); exists {
+		if user, exists := os.LookupEnv("GRAFANA_USER"); exists {
+			cfg.BasicAuth = url.UserPassword(user, token)
+		} else {
+			cfg.APIKey = token
+		}
+	}
+
+	return grafana.New(grafanaURL, cfg)
+}

--- a/pkg/grafana/library-panel-handler.go
+++ b/pkg/grafana/library-panel-handler.go
@@ -1,0 +1,168 @@
+package grafana
+
+import (
+	"fmt"
+	"path/filepath"
+
+	grafana "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grizzly/pkg/grizzly"
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+)
+
+// LibraryPanelHandler is a Grizzly Handler for Grafana library panel
+type LibraryPanelHandler struct {
+	Provider Provider
+}
+
+// NewLibraryPanelHandler returns a new Grizzly Handler for Grafana library panel resources
+func NewLibraryPanelHandler(provider Provider) *LibraryPanelHandler {
+	return &LibraryPanelHandler{
+		Provider: provider,
+	}
+}
+
+// Kind returns the kind for this handler
+func (h *LibraryPanelHandler) Kind() string {
+	return "LibraryPanel"
+}
+
+// Validate returns the uid of resource
+func (h *LibraryPanelHandler) Validate(resource grizzly.Resource) error {
+	uid, exist := resource.GetSpecString("uid")
+	if exist {
+		if uid != resource.Name() {
+			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
+		}
+	}
+	return nil
+}
+
+// APIVersion returns group and version of the provider of this resource
+func (h *LibraryPanelHandler) APIVersion() string {
+	return h.Provider.APIVersion()
+}
+
+// GetExtension returns the file name extension for a library panel
+func (h *LibraryPanelHandler) GetExtension() string {
+	return "json"
+}
+
+const (
+	libraryPanelGlob    = "library-panel/library-panel-*"
+	libraryPanelPattern = "library-panel/library-panel-%s.%s"
+)
+
+// FindResourceFiles identifies files within a directory that this handler can process
+func (h *LibraryPanelHandler) FindResourceFiles(dir string) ([]string, error) {
+	path := filepath.Join(dir, libraryPanelGlob)
+	return filepath.Glob(path)
+}
+
+// ResourceFilePath returns the location on disk where a resource should be updated
+func (h *LibraryPanelHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {
+	return fmt.Sprintf(libraryPanelPattern, resource.Name(), filetype)
+}
+
+// Parse parses a manifest object into a struct for this resource type
+func (h *LibraryPanelHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+	resource := grizzly.Resource(m)
+	return grizzly.Resources{resource}, nil
+}
+
+// Unprepare removes unnecessary panels from a remote resource ready for presentation/comparison
+func (h *LibraryPanelHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
+	resource.DeleteSpecKey("id")
+	return &resource
+}
+
+// Prepare gets a resource ready for dispatch to the remote endpoint
+func (h *LibraryPanelHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
+	return &resource
+}
+
+// GetUID returns the UID for a resource
+func (h *LibraryPanelHandler) GetUID(resource grizzly.Resource) (string, error) {
+	return resource.Name(), nil
+}
+
+// GetByUID retrieves JSON for a resource from an endpoint, by UID
+func (h *LibraryPanelHandler) GetByUID(UID string) (*grizzly.Resource, error) {
+	client, err := getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	panel, err := client.LibraryPanelByUID(UID)
+	if err != nil {
+		return nil, err
+	}
+
+	msi := map[string]interface{}{}
+	err = decode(panel, msi)
+	if err != nil {
+		return nil, err
+	}
+
+	handler := LibraryPanelHandler{}
+	resource := grizzly.NewResource(handler.APIVersion(), handler.Kind(), UID, msi)
+	resource.SetMetadata("folder", panel.Meta.FolderUID)
+	return &resource, nil
+}
+
+// GetRemote retrieves a datasource as a Resource
+func (h *LibraryPanelHandler) GetRemote(resource grizzly.Resource) (*grizzly.Resource, error) {
+	return h.GetByUID(resource.Name())
+}
+
+// ListRemote retrieves as list of UIDs of all remote resources
+func (h *LibraryPanelHandler) ListRemote() ([]string, error) {
+	client, err := getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	panels, err := client.LibraryPanels()
+	if err != nil {
+		return nil, err
+	}
+
+	UIDs := []string{}
+	for _, panel := range panels {
+		UIDs = append(UIDs, panel.UID)
+	}
+	return UIDs, nil
+}
+
+// Add pushes a library panel to Grafana via the API
+func (h *LibraryPanelHandler) Add(resource grizzly.Resource) error {
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	panel := grafana.LibraryPanel{}
+	err = decode(resource.Spec(), &panel)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.NewLibraryPanel(panel)
+	return err
+}
+
+// Update pushes a library panel to Grafana via the API
+func (h *LibraryPanelHandler) Update(existing, resource grizzly.Resource) error {
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	panel := grafana.LibraryPanel{}
+	err = decode(resource.Spec(), &panel)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.PatchLibraryPanel(resource.Name(), panel)
+	return err
+}

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -30,6 +30,7 @@ func (p *Provider) GetHandlers() []grizzly.Handler {
 		NewDatasourceHandler(*p),
 		NewFolderHandler(*p),
 		NewDashboardHandler(*p),
+		NewLibraryPanelHandler(*p),
 		NewRuleHandler(*p),
 		NewSyntheticMonitoringHandler(*p),
 	}

--- a/pkg/grafana/utils.go
+++ b/pkg/grafana/utils.go
@@ -2,6 +2,8 @@ package grafana
 
 import (
 	"regexp"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 var folderURLRegex = regexp.MustCompile("/dashboards/f/([^/]+)")
@@ -26,4 +28,14 @@ func extractFolderUID(d DashboardWrapper) string {
 		folderUid = urlPaths[1]
 	}
 	return folderUid
+}
+
+func decode(input, output interface{}) error {
+	cfg := &mapstructure.DecoderConfig{
+		Metadata: nil,
+		Result:   &output,
+		TagName:  "json",
+	}
+	decoder, _ := mapstructure.NewDecoder(cfg)
+	return decoder.Decode(input)
 }


### PR DESCRIPTION
Adds support for Grafana library panels to Grizzly.

Also starts a transition to using the Golang client for Grafana. When
Grizzly was started, this was not sufficiently mature. This is no longer
the case. A transition to the golang client should reduce the amount
of code required in Grizzly.
