### PR TITLE
Invalid target (-t) should not panic

### DIFF
--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -140,7 +140,11 @@ func (r *Resource) MatchesTarget(targets []string) bool {
 	dotKey := r.Key()
 	slashKey := fmt.Sprintf("%s/%s", r.Kind(), UID)
 	for _, target := range targets {
-		g := glob.MustCompile(target)
+		g, err := glob.Compile(target)
+		if err != nil {
+			continue
+		}
+
 		if g.Match(slashKey) || g.Match(dotKey) {
 			return true
 		}

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -75,7 +75,11 @@ func (r *registry) ResourceMatchesTarget(handler Handler, UID string, targets []
 	slashKey := fmt.Sprintf("%s/%s", handler.Kind(), UID)
 	dotKey := fmt.Sprintf("%s.%s", handler.Kind(), UID)
 	for _, target := range targets {
-		g := glob.MustCompile(target)
+		g, err := glob.Compile(target)
+		if err != nil {
+			continue
+		}
+
 		if g.Match(slashKey) || g.Match(dotKey) {
 			return true
 		}


### PR DESCRIPTION
A user input like target (`-t`) should not cause any panic, thus I think Grizzly should handle the error, in such case.

As an initial suggestion, I'm just skipping the target in case of error, cause if the glob cannot be compiled, there's no possible match. But we could want to give back some feedback to the user, either in form of a warning message, or interrupting the execution (in a controlled way, not panicking). What do you suggest?

Thanks!