### PR TITLE
Re-strip id and version fields

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -75,6 +75,8 @@ func (h *DashboardHandler) Parse(m manifest.Manifest) (grizzly.Resources, error)
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 func (h *DashboardHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
+	resource.DeleteSpecKey("id")
+	resource.DeleteSpecKey("version")
 	return &resource
 }
 


### PR DESCRIPTION
After merging #262, we lost the code that removed the `id` and `version` fields. These, if present, cause issues in diffs and rename/uploads. They really are internal to Grafana and not needed in the presentation of a dashboard.