### PR TITLE
Run tests on port 3001

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ build-test-image:
 
 run-test-image: build-test-image
 	docker rm -f grizzly-grafana
-	docker run --net $$DRONE_DOCKER_NETWORK_ID --name grizzly-grafana -p 3000:3000 --rm grizzly-grafana-test:latest
+	docker run --net $$DRONE_DOCKER_NETWORK_ID --name grizzly-grafana -p 3001:3000 --rm grizzly-grafana-test:latest
 
 run-test-image-locally: build-test-image test-clean
 	docker rm -f grizzly-grafana
-	docker run -d --name grizzly-grafana -p 3000:3000 --rm grizzly-grafana-test:latest
+	docker run -d --name grizzly-grafana -p 3001:3000 --rm grizzly-grafana-test:latest
 
 test-clean:
 	go clean -testcache

--- a/pkg/internal/testutil/testutil.go
+++ b/pkg/internal/testutil/testutil.go
@@ -11,7 +11,7 @@ func GetUrl() string {
 	if os.Getenv("CI") != "" {
 		return "http://grizzly-grafana:3000/"
 	} else {
-		return "http://localhost:3000/"
+		return "http://localhost:3001/"
 	}
 }
 


### PR DESCRIPTION
Running tests on the standard port for Grafana, port 3000 makes it conflict with existing Grafana installs. It makes sense to at least slightly nudge it to avoid the most obvious port conflict.