### PR TITLE
fix: update folders unconditionally

### DIFF
--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -243,14 +243,15 @@ func (h *FolderHandler) putFolder(resource grizzly.Resource) error {
 	}
 
 	body := models.UpdateFolderCommand{
-		Title: folder.Title,
+		Title:     folder.Title,
+		Overwrite: true,
 	}
 	client, err := h.Provider.(ClientProvider).Client()
 	if err != nil {
 		return err
 	}
 
-	params := folders.NewUpdateFolderParams().WithBody(&body)
+	params := folders.NewUpdateFolderParams().WithBody(&body).WithFolderUID(resource.UID())
 	_, err = client.Folders.UpdateFolder(params, nil)
 	return err
 }


### PR DESCRIPTION
This fixes an issue in the folder update logic by passing the folder ID and setting the overwrite property. Without this fix, subsequent applies of the same folder will fail.