### PR TITLE
fix: unprepare dashboard on create

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -126,6 +126,7 @@ func (h *DashboardHandler) ListRemote() ([]string, error) {
 
 // Add pushes a new dashboard to Grafana via the API
 func (h *DashboardHandler) Add(resource grizzly.Resource) error {
+	resource = *h.Unprepare(resource)
 	return h.postDashboard(resource)
 }
 

--- a/pkg/grafana/dashboards_test.go
+++ b/pkg/grafana/dashboards_test.go
@@ -64,6 +64,7 @@ func TestDashboard(t *testing.T) {
 				"folder": "dummy",
 				"name":   "dummy",
 			},
+			"spec": map[string]interface{}{},
 		}
 
 		err := handler.Add(resource)


### PR DESCRIPTION
Since the dashboard API uses the same request for create and update, we need to make sure the create request does not contain the "id" property as this results in a 404 response.