### PR TITLE
feat: add support for library elements

### DIFF
--- a/pkg/grafana/library-elements-handler.go
+++ b/pkg/grafana/library-elements-handler.go
@@ -1,0 +1,219 @@
+package grafana
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"errors"
+
+	"github.com/grafana/grizzly/pkg/grizzly"
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+
+	library "github.com/grafana/grafana-openapi-client-go/client/library_elements"
+	"github.com/grafana/grafana-openapi-client-go/models"
+)
+
+// LibraryElementHandler is a Grizzly Handler for Grafana dashboard folders
+type LibraryElementHandler struct {
+	Provider grizzly.Provider
+}
+
+var _ grizzly.Handler = &LibraryElementHandler{}
+
+// NewLibraryElementHandler returns configuration defining a new Grafana Library Element Handler
+func NewLibraryElementHandler(provider grizzly.Provider) *LibraryElementHandler {
+	return &LibraryElementHandler{
+		Provider: provider,
+	}
+}
+
+// Kind returns the name for this handler
+func (h *LibraryElementHandler) Kind() string {
+	return "LibraryElement"
+}
+
+// Validate returns the uid of resource
+func (h *LibraryElementHandler) Validate(resource grizzly.Resource) error {
+	uid, exist := resource.GetSpecString("uid")
+	if exist {
+		if uid != resource.Name() {
+			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
+		}
+	}
+
+	return nil
+}
+
+// APIVersion returns the group and version for the provider of which this handler is a part
+func (h *LibraryElementHandler) APIVersion() string {
+	return h.Provider.APIVersion()
+}
+
+// GetExtension returns the file name extension for a library element
+func (h *LibraryElementHandler) GetExtension() string {
+	return "json"
+}
+
+const (
+	libraryElementGlob    = "library-elements/*-*"
+	libraryElementPattern = "library-elements/%s-%s.%s"
+)
+
+// FindResourceFiles identifies files within a directory that this handler can process
+func (h *LibraryElementHandler) FindResourceFiles(dir string) ([]string, error) {
+	path := filepath.Join(dir, libraryElementGlob)
+	return filepath.Glob(path)
+}
+
+// ResourceFilePath returns the location on disk where a resource should be updated
+func (h *LibraryElementHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {
+	kind := "element"
+	t := resource.GetSpecValue("kind").(float64)
+
+	switch t {
+	case 1:
+		kind = "panel"
+	case 2:
+		kind = "variable"
+	}
+	return fmt.Sprintf(libraryElementPattern, kind, resource.Name(), filetype)
+}
+
+// Parse parses a manifest object into a struct for this resource type
+func (h *LibraryElementHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+	resource := grizzly.Resource(m)
+	resource.SetSpecString("uid", resource.Name())
+	return grizzly.Resources{resource}, nil
+}
+
+// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
+func (h *LibraryElementHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
+	resource.DeleteSpecKey("meta")
+	resource.DeleteSpecKey("version")
+	resource.DeleteSpecKey("id")
+	return &resource
+}
+
+// Prepare gets a resource ready for dispatch to the remote endpoint
+func (h *LibraryElementHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
+	if existing != nil {
+		val := existing.GetSpecValue("version")
+		resource.SetSpecValue("version", val)
+	}
+	resource.DeleteSpecKey("meta")
+	return &resource
+}
+
+// GetUID returns the UID for a resource
+func (h *LibraryElementHandler) GetUID(resource grizzly.Resource) (string, error) {
+	return resource.Name(), nil
+}
+
+// GetByUID retrieves JSON for a resource from an endpoint, by UID
+func (h *LibraryElementHandler) GetByUID(UID string) (*grizzly.Resource, error) {
+	resource, err := h.getRemoteLibraryElement(UID)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving library element %s: %w", UID, err)
+	}
+
+	return resource, nil
+}
+
+// GetRemote retrieves an element as a resource
+func (h *LibraryElementHandler) GetRemote(resource grizzly.Resource) (*grizzly.Resource, error) {
+	return h.getRemoteLibraryElement(resource.Name())
+}
+
+// ListRemote retrieves as list of UIDs of all remote resources
+func (h *LibraryElementHandler) ListRemote() ([]string, error) {
+	return h.listElements()
+}
+
+// Add pushes a new element to Grafana via the API
+func (h *LibraryElementHandler) Add(resource grizzly.Resource) error {
+	return h.createElement(resource)
+}
+
+// Update pushes an element to Grafana via the API
+func (h *LibraryElementHandler) Update(existing, resource grizzly.Resource) error {
+	return h.updateElement(existing, resource)
+}
+
+func (h *LibraryElementHandler) listElements() ([]string, error) {
+	params := library.NewGetLibraryElementsParams()
+	client, err := h.Provider.(ClientProvider).Client()
+	if err != nil {
+		return nil, err
+	}
+	elemsOK, err := client.LibraryElements.GetLibraryElements(params, nil)
+	if err != nil {
+		return nil, err
+	}
+	elems := elemsOK.GetPayload().Result.Elements
+	uids := make([]string, len(elems))
+	for i, e := range elems {
+		uids[i] = e.UID
+	}
+	return uids, nil
+}
+
+func (h *LibraryElementHandler) updateElement(existing, resource grizzly.Resource) error {
+	data, err := json.Marshal(resource.Spec())
+	if err != nil {
+		return err
+	}
+	var command models.PatchLibraryElementCommand
+	err = json.Unmarshal(data, &command)
+	if err != nil {
+		return err
+	}
+	client, err := h.Provider.(ClientProvider).Client()
+	if err != nil {
+		return err
+	}
+	_, err = client.LibraryElements.UpdateLibraryElement(resource.UID(), &command)
+	return err
+}
+
+func (h *LibraryElementHandler) createElement(resource grizzly.Resource) error {
+	data, err := json.Marshal(resource.Spec())
+	if err != nil {
+		return err
+	}
+	var command models.CreateLibraryElementCommand
+	err = json.Unmarshal(data, &command)
+	if err != nil {
+		return err
+	}
+	client, err := h.Provider.(ClientProvider).Client()
+	if err != nil {
+		return err
+	}
+	_, err = client.LibraryElements.CreateLibraryElement(&command, nil)
+	return err
+}
+
+func (h *LibraryElementHandler) getRemoteLibraryElement(uid string) (*grizzly.Resource, error) {
+	client, err := h.Provider.(ClientProvider).Client()
+	if err != nil {
+		return nil, err
+	}
+	libraryElementsOk, err := client.LibraryElements.GetLibraryElementByUID(uid, nil)
+	if err != nil {
+		var gErr *library.GetLibraryElementByUIDNotFound
+		if errors.As(err, &gErr) {
+			return nil, grizzly.ErrNotFound
+		}
+		return nil, err
+	}
+	libraryElement := libraryElementsOk.GetPayload()
+
+	spec, err := structToMap(libraryElement.Result)
+	if err != nil {
+		return nil, err
+	}
+
+	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	return &resource, nil
+}

--- a/pkg/grafana/library-elements_test.go
+++ b/pkg/grafana/library-elements_test.go
@@ -1,0 +1,59 @@
+package grafana
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/grafana/grizzly/pkg/grizzly"
+	. "github.com/grafana/grizzly/pkg/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLibraryElements(t *testing.T) {
+	InitialiseTestConfig()
+	handler := NewLibraryElementHandler(NewProvider())
+
+	ticker := PingService(GetUrl())
+	defer ticker.Stop()
+
+	t.Run("create libraryElement - success", func(t *testing.T) {
+		libraryElement, err := os.ReadFile("testdata/test_json/post_library-element.json")
+		require.NoError(t, err)
+
+		var resource grizzly.Resource
+
+		err = json.Unmarshal(libraryElement, &resource)
+		require.NoError(t, err)
+
+		err = handler.Add(resource)
+		require.NoError(t, err)
+
+		remoteLibraryElement, err := handler.GetByUID("example-panel")
+		require.NoError(t, err)
+		require.NotNil(t, remoteLibraryElement)
+		require.Equal(t, remoteLibraryElement.GetSpecValue("name").(string), "Example Panel")
+	})
+
+	t.Run("get remote libraryElement - success", func(t *testing.T) {
+		resource, err := handler.GetByUID("example-panel")
+		require.NoError(t, err)
+
+		require.Equal(t, "grizzly.grafana.com/v1alpha1", resource.APIVersion())
+		require.Equal(t, "example-panel", resource.Name())
+		require.Len(t, resource.Spec(), 9)
+	})
+
+	t.Run("get remote libraryElement - not found", func(t *testing.T) {
+		_, err := handler.GetByUID("dummy")
+		require.ErrorContains(t, err, "Error retrieving library element dummy: not found")
+	})
+
+	t.Run("get libraryElements list", func(t *testing.T) {
+		resources, err := handler.ListRemote()
+		require.NoError(t, err)
+
+		require.NotNil(t, resources)
+		require.Len(t, resources, 1)
+	})
+}

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -76,9 +76,9 @@ func (p *Provider) GetHandlers() []grizzly.Handler {
 	return []grizzly.Handler{
 		NewDatasourceHandler(p),
 		NewFolderHandler(p),
+		NewLibraryElementHandler(p),
 		NewDashboardHandler(p),
 		NewRuleHandler(p),
 		NewSyntheticMonitoringHandler(p),
-		NewLibraryElementHandler(p),
 	}
 }

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -79,5 +79,6 @@ func (p *Provider) GetHandlers() []grizzly.Handler {
 		NewDashboardHandler(p),
 		NewRuleHandler(p),
 		NewSyntheticMonitoringHandler(p),
+		NewLibraryElementHandler(p),
 	}
 }

--- a/pkg/grafana/testdata/test_json/post_library-element.json
+++ b/pkg/grafana/testdata/test_json/post_library-element.json
@@ -1,0 +1,42 @@
+{
+  "apiVersion": "grizzly.grafana.com/v1alpha1",
+  "kind": "LibraryElement",
+  "metadata": {
+    "name": "example-panel"
+  },
+  "spec": {
+    "id": 3,
+    "kind": 1,
+    "model": {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Example Content",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.0-64167",
+      "title": "Example Panel",
+      "type": "text"
+    },
+    "name": "Example Panel",
+    "orgId": 1,
+    "type": "text",
+    "uid": "example-panel",
+    "version": 2
+  }
+}


### PR DESCRIPTION
This is a reimplementation/follow up to
https://github.com/grafana/grizzly/pull/218, using the openapi client to keep in line with the rest of the codebase. It allows pull & push of library panels and variables.

Tested pull & push with a simple library panel and a dashboard using this panel