### PR TITLE
Don't panic when no overrides

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,8 +58,10 @@ func Import() error {
 	contextPath := fmt.Sprintf("contexts.%s", name)
 	ctx := viper.Sub(contextPath)
 	overrides := viper.Sub("overrides")
-	for key, value := range overrides.AllSettings() {
-		ctx.Set(key, value)
+	if overrides != nil {
+		for key, value := range overrides.AllSettings() {
+			ctx.Set(key, value)
+		}
 	}
 	err := Write()
 	return err


### PR DESCRIPTION
Overrides from environment variables go into a separate `overrides` node in the config, as
they cannot possibly know what the current context is and override the specific settings
on that variable path. However, if no overrides provided, kaboom. This PR unkabooms.﻿
