### PR TITLE
Use create-context not create

### DIFF
--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -85,7 +85,7 @@ func setCmd() *cli.Command {
 
 func createContextCmd() *cli.Command {
 	cmd := &cli.Command{
-		Use:   "create context",
+		Use:   "create-context",
 		Short: "Create a configuration context",
 		Args:  cli.ArgsExact(1),
 	}

--- a/docs/content/authentication.md
+++ b/docs/content/authentication.md
@@ -72,7 +72,7 @@ grr config import
 
 Create a new context with:
 ```sh
-grr config create production
+grr config create-context production
 ```
 
 To list existing contexts:


### PR DESCRIPTION
Every other `grr config` command relating to contexts uses the `context` word. This makes `create` consistent with this.﻿
