### PR TITLE
Allow targets to be set in contexts

### DIFF
--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -24,4 +24,5 @@ type Context struct {
 	Grafana             GrafanaConfig             `yaml:"grafana"`
 	Mimir               MimirConfig               `yaml:"mimir"`
 	SyntheticMonitoring SyntheticMonitoringConfig `yaml:"synthetic-monitoring"`
+	Targets             []string                  `yaml:"targets"`
 }


### PR DESCRIPTION
Typically, targets must be set every time on the command line. This is tedious, and
error prone. This allows us to set targets once and for all, in a context.

You can still provide targets on the command line - they will be additive.﻿
