### PR TITLE
Highlight current context in get-contexts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,9 +100,14 @@ func NewConfig() {
 
 func GetContexts() error {
 	contexts := map[string]interface{}{}
+	currentContext := viper.GetString(CURRENT_CONTEXT)
 	viper.UnmarshalKey("contexts", &contexts)
 	for k := range contexts {
-		fmt.Printf("  %s\n", k)
+		if k == currentContext {
+			fmt.Printf("* %s\n", k)
+		} else {
+			fmt.Printf("  %s\n", k)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
`kubectl` does this - a single asterisk tells a lot.﻿
