### PR TITLE
Allow non-glob and lower case targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test static install uninstall cross build-test-image run-test-image run-test-image-locally test-clean
+.PHONY: dev lint test static install uninstall cross build-test-image run-test-image run-test-image-locally test-clean
 VERSION := $(shell git describe --tags --dirty --always)
 BIN_DIR := $(GOPATH)/bin
 GOX := $(BIN_DIR)/gox

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -185,7 +185,7 @@ func ParseYAML(yamlFile string, opts Opts) (Resources, error) {
 		}
 		targets := currentContext.GetTargets(opts.Targets)
 		for _, parsedResource := range parsedResources {
-			if parsedResource.MatchesTarget(targets) {
+			if Registry.ResourceMatchesTarget(handler, parsedResource.UID(), targets) {
 				resources = append(resources, parsedResource)
 			}
 		}
@@ -249,7 +249,7 @@ func ParseJsonnet(jsonnetFile string, opts Opts) (Resources, error) {
 			return nil, err
 		}
 		for _, parsedResource := range parsedResources {
-			if parsedResource.MatchesTarget(targets) {
+			if Registry.ResourceMatchesTarget(handler, parsedResource.UID(), targets) {
 				resources = append(resources, parsedResource)
 			}
 		}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -3,6 +3,7 @@ package grizzly
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/gobwas/glob"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
@@ -139,13 +140,18 @@ func (r *Resource) MatchesTarget(targets []string) bool {
 	UID := r.UID()
 	dotKey := r.Key()
 	slashKey := fmt.Sprintf("%s/%s", r.Kind(), UID)
+	kind := strings.ToLower(r.Kind())
 	for _, target := range targets {
-		g, err := glob.Compile(target)
-		if err != nil {
-			continue
-		}
+		if strings.Contains(target, ".") {
+			g, err := glob.Compile(target)
+			if err != nil {
+				continue
+			}
 
-		if g.Match(slashKey) || g.Match(dotKey) {
+			if g.Match(slashKey) || g.Match(dotKey) {
+				return true
+			}
+		} else if strings.ToLower(target) == kind {
 			return true
 		}
 	}

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -3,9 +3,7 @@ package grizzly
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
-	"github.com/gobwas/glob"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 	"gopkg.in/yaml.v3"
 )
@@ -130,32 +128,6 @@ func (r *Resource) YAML() (string, error) {
 		return "", err
 	}
 	return string(y), nil
-}
-
-// MatchesTarget identifies whether a resource is in a target list
-func (r *Resource) MatchesTarget(targets []string) bool {
-	if len(targets) == 0 {
-		return true
-	}
-	UID := r.UID()
-	dotKey := r.Key()
-	slashKey := fmt.Sprintf("%s/%s", r.Kind(), UID)
-	kind := strings.ToLower(r.Kind())
-	for _, target := range targets {
-		if strings.Contains(target, ".") {
-			g, err := glob.Compile(target)
-			if err != nil {
-				continue
-			}
-
-			if g.Match(slashKey) || g.Match(dotKey) {
-				return true
-			}
-		} else if strings.ToLower(target) == kind {
-			return true
-		}
-	}
-	return false
 }
 
 // Resources represents a set of resources

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -60,6 +60,8 @@ func (r *registry) HandlerMatchesTarget(handler Handler, targets []string) bool 
 		if (strings.Contains(target, "/") && strings.Split(target, "/")[0] == key) ||
 			(strings.Contains(target, ".") && strings.Split(target, ".")[0] == key) {
 			return true
+		} else if strings.ToLower(target) == strings.ToLower(key) {
+			return true
 		}
 	}
 	return false
@@ -70,17 +72,22 @@ func (r *registry) ResourceMatchesTarget(handler Handler, UID string, targets []
 	if len(targets) == 0 {
 		return true
 	}
+	kind := handler.Kind()
 	// I mistakenly assumed 'dot' was a special character for globs, so opted for '/' as separator.
 	// This keeps back-compat
-	slashKey := fmt.Sprintf("%s/%s", handler.Kind(), UID)
-	dotKey := fmt.Sprintf("%s.%s", handler.Kind(), UID)
+	slashKey := fmt.Sprintf("%s/%s", kind, UID)
+	dotKey := fmt.Sprintf("%s.%s", kind, UID)
 	for _, target := range targets {
-		g, err := glob.Compile(target)
-		if err != nil {
-			continue
-		}
+		if strings.Contains(target, ".") {
+			g, err := glob.Compile(target)
+			if err != nil {
+				continue
+			}
 
-		if g.Match(slashKey) || g.Match(dotKey) {
+			if g.Match(slashKey) || g.Match(dotKey) {
+				return true
+			}
+		} else if strings.ToLower(target) == strings.ToLower(kind) {
 			return true
 		}
 	}

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -78,7 +78,7 @@ func (r *registry) ResourceMatchesTarget(handler Handler, UID string, targets []
 	slashKey := fmt.Sprintf("%s/%s", kind, UID)
 	dotKey := fmt.Sprintf("%s.%s", kind, UID)
 	for _, target := range targets {
-		if strings.Contains(target, ".") {
+		if strings.Contains(target, ".") || strings.Contains(target, "/") {
 			g, err := glob.Compile(target)
 			if err != nil {
 				continue


### PR DESCRIPTION
The syntax for targets is currently:

    grr <cmd> -t Dashboard.*

This is powerful, in that it allows a user to pick out specific targets by UID
pattern.

However, I've never actually used, nor seen it used, for anything other than matching
by kind.

Therefore, this is simpler and likely to lead to less confusion:

    grr <cmd> -t Dashboard

For that matter, while the kind follows a capitalised pattern (as does Kubernetes),
it adds nothing here, other than risk for confusion. Thus this will now work too:

    grr <cmd> -t dashboard
﻿
