### PR TITLE
Add 'push' as alias for 'apply'

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -119,9 +119,10 @@ func diffCmd() *cli.Command {
 
 func applyCmd() *cli.Command {
 	cmd := &cli.Command{
-		Use:   "apply <resource-path>",
-		Short: "apply local resources to remote endpoints",
-		Args:  cli.ArgsExact(1),
+		Use:     "apply <resource-path>",
+		Aliases: []string{"push"},
+		Short:   "apply local resources to remote endpoints",
+		Args:    cli.ArgsExact(1),
 	}
 	var opts grizzly.Opts
 


### PR DESCRIPTION
It has long bugged me that, having followed `kubectl` and `tanka`, we have an `apply`
command. Yet, we now also have `pull`. Why then do we use `apply` rather than `push`?

This PR simply adds `push` as an alias for `apply`, as a more intuitive option.﻿
