### PR TITLE
Switch priority for targets

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -196,6 +196,9 @@ func Write() error {
 	return err
 }
 
-func (c *Context) GetTargets(extraTargets []string) []string {
-	return append(c.Targets, extraTargets...)
+func (c *Context) GetTargets(overrides []string) []string {
+	if len(overrides) > 0 {
+		return overrides
+	}
+	return c.Targets
 }


### PR DESCRIPTION
Currently, targets on the command line are appended to targets in the context.
Actually using the tool however, this is confusing.

This PR changes the behaviour: now a `-t` target on the command line will
**override** any targets in the context config. This feels more natural.﻿
