### PR TITLE
Support output formats

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -20,13 +20,13 @@ func getCmd() *cli.Command {
 		Short: "retrieve resource",
 		Args:  cli.ArgsExact(1),
 	}
-	var opts grizzly.LoggingOpts
+	var opts grizzly.Opts
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		uid := args[0]
-		return grizzly.Get(uid)
+		return grizzly.Get(uid, opts)
 	}
-	return initialiseLogging(cmd, &opts)
+	return initialiseCmd(cmd, &opts)
 }
 
 func listCmd() *cli.Command {
@@ -94,7 +94,7 @@ func showCmd() *cli.Command {
 		if err != nil {
 			return err
 		}
-		return grizzly.Show(resources)
+		return grizzly.Show(resources, opts)
 	}
 	return initialiseCmd(cmd, &opts)
 }
@@ -112,7 +112,7 @@ func diffCmd() *cli.Command {
 		if err != nil {
 			return err
 		}
-		return grizzly.Diff(resources)
+		return grizzly.Diff(resources, opts)
 	}
 	return initialiseCmd(cmd, &opts)
 }
@@ -236,7 +236,7 @@ func exportCmd() *cli.Command {
 		if err != nil {
 			return err
 		}
-		return grizzly.Export(dashboardDir, resources)
+		return grizzly.Export(dashboardDir, resources, opts)
 	}
 	return initialiseCmd(cmd, &opts)
 }
@@ -287,6 +287,7 @@ func initialiseCmd(cmd *cli.Command, opts *grizzly.Opts) *cli.Command {
 
 	cmd.Flags().StringSliceVarP(&opts.Targets, "target", "t", nil, "resources to target")
 	cmd.Flags().StringSliceVarP(&opts.JsonnetPaths, "jpath", "J", getDefaultJsonnetFolders(), "Specify an additional library search dir (right-most wins)")
+	cmd.Flags().StringVarP(&opts.OutputFormat, "output", "o", "", "Output format")
 
 	return initialiseLogging(cmd, &opts.LoggingOpts)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,6 +155,7 @@ var acceptableKeys = map[string]string{
 	"synthetic-monitoring.metrics-id": "string",
 	"synthetic-monitoring.logs-id":    "string",
 	"targets":                         "[]string",
+	"output-format":                   "string",
 }
 
 func Set(path string, value string) error {
@@ -201,4 +202,18 @@ func (c *Context) GetTargets(overrides []string) []string {
 		return overrides
 	}
 	return c.Targets
+}
+
+func GetOutputFormat(override string) (string, error) {
+	context, err := CurrentContext()
+	if err != nil {
+		return "", err
+	}
+	if override != "" {
+		return override, nil
+	}
+	if context.OutputFormat != "" {
+		return context.OutputFormat, nil
+	}
+	return "yaml", nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,6 +156,7 @@ var acceptableKeys = map[string]string{
 	"synthetic-monitoring.logs-id":    "string",
 	"targets":                         "[]string",
 	"output-format":                   "string",
+	"only-spec":                       "bool",
 }
 
 func Set(path string, value string) error {
@@ -169,6 +170,10 @@ func Set(path string, value string) error {
 				val = value
 			case "[]string":
 				val = strings.Split(value, ",")
+			case "bool":
+				val = strings.ToLower(value) == "true"
+			default:
+				return fmt.Errorf("Unknown config key type %s for key %s", typ, key)
 			}
 			viper.Set(fullPath, val)
 			return Write()
@@ -202,18 +207,4 @@ func (c *Context) GetTargets(overrides []string) []string {
 		return overrides
 	}
 	return c.Targets
-}
-
-func GetOutputFormat(override string) (string, error) {
-	context, err := CurrentContext()
-	if err != nil {
-		return "", err
-	}
-	if override != "" {
-		return override, nil
-	}
-	if context.OutputFormat != "" {
-		return context.OutputFormat, nil
-	}
-	return "yaml", nil
 }

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -1,28 +1,29 @@
 package config
 
 type GrafanaConfig struct {
-	URL   string `yaml:"url"`
-	User  string `yaml:"user"`
-	Token string `yaml:"token"`
+	URL   string `yaml:"url" mapstructure:"url"`
+	User  string `yaml:"user" mapstructure:"user"`
+	Token string `yaml:"token" mapstructure:"token"`
 }
 
 type MimirConfig struct {
-	Address  string `yaml:"address"`
-	TenantID int64  `yaml:"tenant-id"`
-	ApiKey   string `yaml:"api-key"`
+	Address  string `yaml:"address" mapstructure:"address"`
+	TenantID int64  `yaml:"tenant-id" mapstructure:"tenant-id"`
+	ApiKey   string `yaml:"api-key" mapstructure:"api-key"`
 }
 
 type SyntheticMonitoringConfig struct {
-	Token     string `yaml:"token"`
-	StackID   int64  `yaml:"stack-id"`
-	LogsID    int64  `yaml:"logs-id"`
-	MetricsID int64  `yaml:"metrics-id"`
+	Token     string `yaml:"token" mapstructure:"token"`
+	StackID   int64  `yaml:"stack-id" mapstructure:"stack-id"`
+	LogsID    int64  `yaml:"logs-id" mapstructure:"logs-id"`
+	MetricsID int64  `yaml:"metrics-id" mapstructure:"metrics-id"`
 }
 
 type Context struct {
-	Name                string                    `yaml:"name"`
-	Grafana             GrafanaConfig             `yaml:"grafana"`
-	Mimir               MimirConfig               `yaml:"mimir"`
-	SyntheticMonitoring SyntheticMonitoringConfig `yaml:"synthetic-monitoring"`
-	Targets             []string                  `yaml:"targets"`
+	Name                string                    `yaml:"name" mapstructure:"name"`
+	Grafana             GrafanaConfig             `yaml:"grafana" mapstructure:"grafana"`
+	Mimir               MimirConfig               `yaml:"mimir" mapstructure:"mimir"`
+	SyntheticMonitoring SyntheticMonitoringConfig `yaml:"synthetic-monitoring" mapstructure:"synthetic-monitoring"`
+	Targets             []string                  `yaml:"targets" mapstructure:"targets"`
+	OutputFormat        string                    `yaml:"output-format" mapstructure:"output-format"`
 }

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -26,4 +26,5 @@ type Context struct {
 	SyntheticMonitoring SyntheticMonitoringConfig `yaml:"synthetic-monitoring" mapstructure:"synthetic-monitoring"`
 	Targets             []string                  `yaml:"targets" mapstructure:"targets"`
 	OutputFormat        string                    `yaml:"output-format" mapstructure:"output-format"`
+	OnlySpec            bool                      `yaml:"only-spec" mapstructure:"only-spec"`
 }

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -55,11 +55,6 @@ func (h *AlertRuleGroupHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-// GetExtension returns the file name extension for a alertRuleGroup
-func (h *AlertRuleGroupHandler) GetExtension() string {
-	return "json"
-}
-
 const (
 	alertRuleGroupGlob    = "alert-rules/alertRuleGroup-*"
 	alertRuleGroupPattern = "alert-rules/alertRuleGroup-%s.%s"

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -46,11 +46,6 @@ func (h *AlertContactPointHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-// GetExtension returns the file name extension for a contactPoint
-func (h *AlertContactPointHandler) GetExtension() string {
-	return "json"
-}
-
 const (
 	contactPointGlob    = "alert-contact-points/contactPoint-*"
 	contactPointPattern = "alert-contact-points/contactPoint-%s.%s"

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -52,11 +52,6 @@ func (h *DashboardHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-// GetExtension returns the file name extension for a dashboard
-func (h *DashboardHandler) GetExtension() string {
-	return "json"
-}
-
 const (
 	dashboardGlob    = "dashboards/*/dashboard-*"
 	dashboardPattern = "dashboards/%s/dashboard-%s.%s"

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -50,11 +50,6 @@ func (h *DatasourceHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-// GetExtension returns the file name extension for a datasource
-func (h *DatasourceHandler) GetExtension() string {
-	return "json"
-}
-
 const (
 	datasourceGlob    = "datasources/datasource-*"
 	datasourcePattern = "datasources/datasource-%s.%s"

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -49,11 +49,6 @@ func (h *FolderHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-// GetExtension returns the file name extension for a dashboard
-func (h *FolderHandler) GetExtension() string {
-	return "json"
-}
-
 const (
 	folderGlob    = "folders/folder-*"
 	folderPattern = "folders/folder-%s.%s"

--- a/pkg/grafana/library-elements-handler.go
+++ b/pkg/grafana/library-elements-handler.go
@@ -50,11 +50,6 @@ func (h *LibraryElementHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-// GetExtension returns the file name extension for a library element
-func (h *LibraryElementHandler) GetExtension() string {
-	return "json"
-}
-
 const (
 	libraryElementGlob    = "library-elements/*-*"
 	libraryElementPattern = "library-elements/%s-%s.%s"

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -48,11 +48,6 @@ func (h *AlertNotificationPolicyHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-// GetExtension returns the file name extension for a alertNotificationPolicy
-func (h *AlertNotificationPolicyHandler) GetExtension() string {
-	return "json"
-}
-
 const (
 	alertNotificationPolicyFile = "alertNotificationPolicy.yaml"
 )

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -48,11 +48,6 @@ func (h *RuleHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-// GetExtension returns the file name extension for a rule grouping
-func (h *RuleHandler) GetExtension() string {
-	return "yaml"
-}
-
 const (
 	prometheusRuleGroupGlob    = "prometheus/rules-*"
 	prometheusRuleGroupPattern = "prometheus/rules-%s.%s"

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -60,11 +60,6 @@ func (h *SyntheticMonitoringHandler) APIVersion() string {
 	return h.Provider.APIVersion()
 }
 
-// GetExtension returns the file name extension for a check
-func (h *SyntheticMonitoringHandler) GetExtension() string {
-	return "json"
-}
-
 const (
 	syntheticMonitoringCheckGlob = "synthetic-monitoring/check-*"
 	syntheticMonitoringPattern   = "synthetic-monitoring/check-%s.%s"

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -14,8 +14,9 @@ type Opts struct {
 	OutputFormat string
 
 	// Used for supporting commands that output dashboard JSON
-	FolderUID string
-	JSONSpec  bool
+	FolderUID   string
+	OnlySpec    bool
+	HasOnlySpec bool
 }
 
 // PreviewOpts contains options to configure a preview

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -11,6 +11,7 @@ type Opts struct {
 	Directory    bool // Deprecated: now is gathered with os.Stat(<resource-path>)
 	JsonnetPaths []string
 	Targets      []string
+	OutputFormat string
 
 	// Used for supporting commands that output dashboard JSON
 	FolderUID string

--- a/pkg/grizzly/formatting.go
+++ b/pkg/grizzly/formatting.go
@@ -1,0 +1,66 @@
+package grizzly
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func Format(resourcePath string, resource *Resource, format string) ([]byte, string, string, error) {
+	var content string
+	var filename string
+	var extension string
+	var err error
+
+	switch format {
+	case "yaml":
+		extension = "yaml"
+		filename, err = getFilename(resourcePath, resource, extension)
+		if err != nil {
+			return nil, "", "", err
+		}
+		content, err = resource.YAML()
+	case "json":
+		extension = "json"
+		filename, err = getFilename(resourcePath, resource, extension)
+		if err != nil {
+			return nil, "", "", err
+		}
+		content, err = resource.JSON()
+	case "legacy-json":
+		extension = "json"
+		filename, err = getFilename(resourcePath, resource, extension)
+		if err != nil {
+			return nil, "", "", err
+		}
+		content, err = resource.SpecAsJSON()
+	default:
+		extension = "yaml"
+		filename, err = getFilename(resourcePath, resource, extension)
+		if err != nil {
+			return nil, "", "", err
+		}
+		content, err = resource.YAML()
+	}
+	return []byte(content), filename, extension, err
+}
+
+func getFilename(resourcePath string, resource *Resource, extension string) (string, error) {
+	handler, err := Registry.GetHandler(resource.Kind())
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resourcePath, handler.ResourceFilePath(*resource, extension)), nil
+}
+
+func WriteFile(filename string, content []byte) error {
+	dir := filepath.Dir(filename)
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(filename, content, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/grizzly/formatting.go
+++ b/pkg/grizzly/formatting.go
@@ -5,11 +5,17 @@ import (
 	"path/filepath"
 )
 
-func Format(resourcePath string, resource *Resource, format string) ([]byte, string, string, error) {
+func Format(resourcePath string, resource *Resource, format string, onlySpec bool) ([]byte, string, string, error) {
 	var content string
 	var filename string
 	var extension string
 	var err error
+
+	spec := resource
+	if onlySpec {
+		s := Resource(resource.Spec())
+		spec = &s
+	}
 
 	switch format {
 	case "yaml":
@@ -18,28 +24,21 @@ func Format(resourcePath string, resource *Resource, format string) ([]byte, str
 		if err != nil {
 			return nil, "", "", err
 		}
-		content, err = resource.YAML()
+		content, err = spec.YAML()
 	case "json":
 		extension = "json"
 		filename, err = getFilename(resourcePath, resource, extension)
 		if err != nil {
 			return nil, "", "", err
 		}
-		content, err = resource.JSON()
-	case "legacy-json":
-		extension = "json"
-		filename, err = getFilename(resourcePath, resource, extension)
-		if err != nil {
-			return nil, "", "", err
-		}
-		content, err = resource.SpecAsJSON()
+		content, err = spec.JSON()
 	default:
 		extension = "yaml"
 		filename, err = getFilename(resourcePath, resource, extension)
 		if err != nil {
 			return nil, "", "", err
 		}
-		content, err = resource.YAML()
+		content, err = spec.YAML()
 	}
 	return []byte(content), filename, extension, err
 }

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -60,7 +60,7 @@ func FindResourceFiles(resourcePath string) ([]string, error) {
 }
 
 func ParseFile(opts Opts, resourceFile string) (Resources, error) {
-	if opts.JSONSpec && filepath.Ext(resourceFile) != ".json" {
+	if opts.OnlySpec && filepath.Ext(resourceFile) != ".json" {
 		return nil, fmt.Errorf("when -s flag is passed, command expects only json files as resources")
 	}
 
@@ -102,7 +102,7 @@ func manifestFile(resourceFile string) (bool, error) {
 
 // ParseJSON evaluates a JSON file and parses it into resources
 func ParseJSON(resourceFile string, opts Opts) (Resources, error) {
-	if opts.JSONSpec {
+	if opts.OnlySpec {
 		return ParseDashboardJSON(resourceFile, opts)
 	}
 
@@ -256,34 +256,4 @@ func ParseJsonnet(jsonnetFile string, opts Opts) (Resources, error) {
 	}
 	sort.Sort(resources)
 	return resources, nil
-}
-
-// MarshalYAML takes a resource and renders it to a source file as a YAML string
-func MarshalYAML(resource Resource, filename string) error {
-	y, err := resource.YAML()
-	if err != nil {
-		return err
-	}
-	return writeFile(filename, []byte(y))
-}
-
-func MarshalSpecToJSON(resource Resource, filename string) error {
-	j, err := json.MarshalIndent(resource.Spec(), "", "  ")
-	if err != nil {
-		return err
-	}
-	return writeFile(filename, j)
-}
-
-func writeFile(filename string, content []byte) error {
-	dir := filepath.Dir(filename)
-	err := os.MkdirAll(dir, 0755)
-	if err != nil {
-		return err
-	}
-	err = os.WriteFile(filename, content, 0644)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/pkg/grizzly/providers.go
+++ b/pkg/grizzly/providers.go
@@ -113,7 +113,7 @@ func (r *Resource) Spec() map[string]interface{} {
 }
 
 func (r *Resource) SpecAsJSON() (string, error) {
-	j, err := json.Marshal(r.Spec())
+	j, err := json.MarshalIndent(r.Spec(), "", "  ")
 	if err != nil {
 		return "", err
 	}
@@ -128,6 +128,15 @@ func (r *Resource) YAML() (string, error) {
 		return "", err
 	}
 	return string(y), nil
+}
+
+// JSON Gets the string representation for this resource
+func (r *Resource) JSON() (string, error) {
+	j, err := json.MarshalIndent(*r, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(j), nil
 }
 
 // Resources represents a set of resources
@@ -153,7 +162,6 @@ func (r Resources) Swap(i, j int) {
 type Handler interface {
 	APIVersion() string
 	Kind() string
-	GetExtension() string
 
 	// FindResourceFiles identifies files within a directory that this handler can process
 	FindResourceFiles(dir string) ([]string, error)


### PR DESCRIPTION
Currently, Grizzly mostly exports as YAML. It would be useful if the user could
specify the format that they want their content in, e.g. JSON or YAML.

Apart from anything, this would provide a workaround for #301.

Also, the `--only-spec` parameter allows the user to specify whether to show
raw JSON without the envelope. This currently assumes JSON, because, well,
a raw dashboard has always been JSON. This justification makes no actual
sense.

Therefore, this PR adds a `--output` flag to relevant commands, allowing the
user to choose either `yaml` or `json` outputs. These can also be set in the
context with `grr config set output-format json` for example.

The `--only-spec` arg now works with any format (YAML or JSON at present).
It can also be set in the context with `grr config set only-spec true`.

