### PR TITLE
Rename files to match contents

### DIFF
--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -1,0 +1,64 @@
+package grizzly
+
+import (
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+)
+
+// Handler describes a handler for a single API resource handled by a single provider
+type Handler interface {
+	APIVersion() string
+	Kind() string
+
+	// FindResourceFiles identifies files within a directory that this handler can process
+	FindResourceFiles(dir string) ([]string, error)
+
+	// ResourceFilePath returns the location on disk where a resource should be updated
+	ResourceFilePath(resource Resource, filetype string) string
+
+	// Parse parses a manifest object into a struct for this resource type
+	Parse(m manifest.Manifest) (Resources, error)
+
+	// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
+	Unprepare(resource Resource) *Resource
+
+	// Prepare gets a resource ready for dispatch to the remote endpoint
+	Prepare(existing, resource Resource) *Resource
+
+	// Retrieves a UID for a resource
+	GetUID(resource Resource) (string, error)
+
+	// Get retrieves JSON for a resource from an endpoint, by UID
+	GetByUID(UID string) (*Resource, error)
+
+	// GetRemote retrieves a remote equivalent of a remote resource
+	GetRemote(resource Resource) (*Resource, error)
+
+	// ListRemote retrieves as list of UIDs of all remote resources
+	ListRemote() ([]string, error)
+
+	// Add pushes a new resource to the endpoint
+	Add(resource Resource) error
+
+	// Update pushes an existing resource to the endpoint
+	Update(existing, resource Resource) error
+
+	// Validate gets or build the uid of corresponding resource
+	Validate(resource Resource) error
+
+	// Sort sorts resources as defined by the handler
+	Sort(resources Resources) Resources
+}
+
+// PreviewHandler describes a handler that has the ability to render
+// a preview of a resource
+type PreviewHandler interface {
+	// Preview renders Jsonnet then pushes them to the endpoint if previews are possible
+	Preview(resource Resource, opts *PreviewOpts) error
+}
+
+// ListenHandler describes a handler that has the ability to watch a single
+// resource for changes, and write changes to that resource to a local file
+type ListenHandler interface {
+	// Listen watches a resource and update local file on changes
+	Listen(UID, filename string) error
+}

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -27,9 +27,11 @@ var Registry registry
 
 // NewProviderRegistry returns a new registry instance
 func ConfigureProviderRegistry(providers []Provider) {
-	Registry.Providers = providers
-	Registry.Handlers = map[string]Handler{}
-	Registry.HandlerOrder = []Handler{}
+	Registry.Providers = append(Registry.Providers, providers...)
+	if Registry.Handlers == nil {
+		Registry.Handlers = map[string]Handler{}
+		Registry.HandlerOrder = []Handler{}
+	}
 	for _, provider := range providers {
 		for _, handler := range provider.GetHandlers() {
 			Registry.Handlers[handler.Kind()] = handler

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 	"gopkg.in/yaml.v3"
 )
 
@@ -157,63 +156,4 @@ func (r *Resources) Sort() Resources {
 		resources = append(resources, handler.Sort(handlerResources)...)
 	}
 	return resources
-}
-
-// Handler describes a handler for a single API resource handled by a single provider
-type Handler interface {
-	APIVersion() string
-	Kind() string
-
-	// FindResourceFiles identifies files within a directory that this handler can process
-	FindResourceFiles(dir string) ([]string, error)
-
-	// ResourceFilePath returns the location on disk where a resource should be updated
-	ResourceFilePath(resource Resource, filetype string) string
-
-	// Parse parses a manifest object into a struct for this resource type
-	Parse(m manifest.Manifest) (Resources, error)
-
-	// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
-	Unprepare(resource Resource) *Resource
-
-	// Prepare gets a resource ready for dispatch to the remote endpoint
-	Prepare(existing, resource Resource) *Resource
-
-	// Retrieves a UID for a resource
-	GetUID(resource Resource) (string, error)
-
-	// Get retrieves JSON for a resource from an endpoint, by UID
-	GetByUID(UID string) (*Resource, error)
-
-	// GetRemote retrieves a remote equivalent of a remote resource
-	GetRemote(resource Resource) (*Resource, error)
-
-	// ListRemote retrieves as list of UIDs of all remote resources
-	ListRemote() ([]string, error)
-
-	// Add pushes a new resource to the endpoint
-	Add(resource Resource) error
-
-	// Update pushes an existing resource to the endpoint
-	Update(existing, resource Resource) error
-
-	// Validate gets or build the uid of corresponding resource
-	Validate(resource Resource) error
-
-	// Sort sorts resources as defined by the handler
-	Sort(resources Resources) Resources
-}
-
-// PreviewHandler describes a handler that has the ability to render
-// a preview of a resource
-type PreviewHandler interface {
-	// Preview renders Jsonnet then pushes them to the endpoint if previews are possible
-	Preview(resource Resource, opts *PreviewOpts) error
-}
-
-// ListenHandler describes a handler that has the ability to watch a single
-// resource for changes, and write changes to that resource to a local file
-type ListenHandler interface {
-	// Listen watches a resource and update local file on changes
-	Listen(UID, filename string) error
 }


### PR DESCRIPTION
Some file names are simply confusing as they don't match the contents. This trivial PR
fixes that. Also, the `ConfigureProviderRegistry()` func assumes it will only be called
once (which is the case right now). This PR also future-proofs that by making sure it'll
work for multiple invocations.﻿
