### PR TITLE
Add new context and make integration tests stricter

### DIFF
--- a/integration/testdata/contexts/get-contexts.txt
+++ b/integration/testdata/contexts/get-contexts.txt
@@ -1,3 +1,4 @@
   another
 * default
   other
+  subpath

--- a/integration/testdata/contexts/settings.yaml
+++ b/integration/testdata/contexts/settings.yaml
@@ -3,6 +3,10 @@ contexts:
     name: default
     grafana:
       url: http://localhost:3001
+  subpath:
+    name: subpath
+    grafana:
+      url: http://localhost:3003/grafana
   other:
     name: other
   another:

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,14 +32,14 @@ func RunTests(t *testing.T, tests []GrizzlyTest) {
 				cwd, _ := os.Getwd()
 				cmd := exec.Command(filepath.Join(cwd, "../grr"), args...)
 				cmd.Dir = test.TestDir
-				output, err := cmd.CombinedOutput()
+				output, err := cmd.Output()
 				if command.ExpectedError != nil {
 					require.Error(t, err, command.ExpectedError)
 				}
 				if command.ExpectedOutput != "" {
 					data, err := os.ReadFile(filepath.Join(test.TestDir, command.ExpectedOutput))
-					require.NoError(t, err, fmt.Sprintf(""))
-					require.Contains(t, string(output), string(data))
+					require.NoError(t, err)
+					require.Equal(t, string(output), string(data))
 				}
 				exitCode := cmd.ProcessState.ExitCode()
 				require.Equal(t, command.ExpectedCode, exitCode, "Exited with %d (%d expected)", exitCode, command.ExpectedCode)

--- a/test-docker-compose/docker-compose.yml
+++ b/test-docker-compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   grafana:
-    image: grafana/grafana:10.2.0
+    image: &image grafana/grafana:10.2.0
     ports:
       - "3001:3001"
     environment:
@@ -16,3 +16,34 @@ services:
       interval: 1s
       retries: 30
       start_period: 10s
+
+  # Grafana instance served from a subpath (Grafana on port 3002, nginx on port 3003, and the subpath is /grafana)
+  # It's important to use nginx to serve the subpath, otherwise, it doesn't really test the real-world scenario
+  # Grafana will redirect all subpaths to the root URL if that's the correct path, while an nginx will fail if the subpath is not correct
+  grafana_subpath:
+    image: *image
+    ports:
+      - "3002:3002"
+    environment:
+      - GF_SERVER_HTTP_PORT=3002
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_PATHS=/etc/grafana/provisioning
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      - GF_SERVER_ROOT_URL=http://localhost:3003/grafana # This is the URL that nginx will use to proxy to the subpath
+    volumes:
+      - ./provisioning:/etc/grafana/provisioning
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3002/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
+      interval: 1s
+      retries: 30
+      start_period: 10s
+  nginx:
+    depends_on:
+      grafana_subpath:
+        condition: service_healthy
+    image: nginx:latest
+    ports:
+      - 3003:3003
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf

--- a/test-docker-compose/nginx.conf
+++ b/test-docker-compose/nginx.conf
@@ -1,0 +1,34 @@
+events{}
+
+http {
+    # this is required to proxy Grafana Live WebSocket connections.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    upstream grafana {
+        server grafana_subpath:3002;
+    }
+
+    server {
+        listen 3003;
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        server_name  0.0.0.0;
+
+        location /grafana/ {
+            proxy_set_header Host $host;
+            proxy_pass http://grafana;
+        }
+
+        # Proxy Grafana Live WebSocket connections.
+        location /api/live/ {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_pass http://grafana;
+        }
+    }
+}


### PR DESCRIPTION
I added a new context and I noticed that the tests were still passing (incorrectly)
Turns out the `.Contains` condition on the output was still matching. I changed to a strict `Equal` and removed the stderr output from there. We're not trying to match log lines here

The subpath context is unused so far, but it will be in a future PR