### PR TITLE
Remove `PingService` test util

### DIFF
--- a/integration/context_test.go
+++ b/integration/context_test.go
@@ -2,14 +2,9 @@ package integration_test
 
 import (
 	"testing"
-
-	"github.com/grafana/grizzly/pkg/testutil"
 )
 
 func TestContexts(t *testing.T) {
-	ticker := testutil.PingService(testutil.GetUrl())
-	defer ticker.Stop()
-
 	tests := []GrizzlyTest{
 		{
 			Name:    "Get contexts - success",

--- a/integration/dashboard_test.go
+++ b/integration/dashboard_test.go
@@ -2,13 +2,9 @@ package integration_test
 
 import (
 	"testing"
-
-	"github.com/grafana/grizzly/pkg/testutil"
 )
 
 func TestDashboard(t *testing.T) {
-	ticker := testutil.PingService(testutil.GetUrl())
-	defer ticker.Stop()
 	dir := "testdata/dashboards"
 	setupContexts(t, dir)
 

--- a/pkg/grafana/dashboards_test.go
+++ b/pkg/grafana/dashboards_test.go
@@ -14,9 +14,6 @@ func TestDashboard(t *testing.T) {
 	InitialiseTestConfig()
 	handler := NewDashboardHandler(NewProvider())
 
-	ticker := PingService(GetUrl())
-	defer ticker.Stop()
-
 	t.Run("get remote dashboard - success", func(t *testing.T) {
 		resource, err := handler.GetByUID("ReciqtgGk")
 		require.NoError(t, err)

--- a/pkg/grafana/datasource_test.go
+++ b/pkg/grafana/datasource_test.go
@@ -14,9 +14,6 @@ func TestDatasources(t *testing.T) {
 	InitialiseTestConfig()
 	handler := NewDatasourceHandler(NewProvider())
 
-	ticker := PingService(GetUrl())
-	defer ticker.Stop()
-
 	t.Run("get remote datasource - success", func(t *testing.T) {
 		resource, err := handler.GetByUID("AppDynamics")
 		require.NoError(t, err)

--- a/pkg/grafana/folders_test.go
+++ b/pkg/grafana/folders_test.go
@@ -15,9 +15,6 @@ func TestFolders(t *testing.T) {
 	InitialiseTestConfig()
 	handler := NewFolderHandler(NewProvider())
 
-	ticker := PingService(GetUrl())
-	defer ticker.Stop()
-
 	t.Run("get remote folder - success", func(t *testing.T) {
 		resource, err := handler.GetByUID("abcdefghi")
 		require.NoError(t, err)

--- a/pkg/grafana/library-elements_test.go
+++ b/pkg/grafana/library-elements_test.go
@@ -14,9 +14,6 @@ func TestLibraryElements(t *testing.T) {
 	InitialiseTestConfig()
 	handler := NewLibraryElementHandler(NewProvider())
 
-	ticker := PingService(GetUrl())
-	defer ticker.Stop()
-
 	t.Run("create libraryElement - success", func(t *testing.T) {
 		libraryElement, err := os.ReadFile("testdata/test_json/post_library-element.json")
 		require.NoError(t, err)

--- a/pkg/grizzly/workflow_test.go
+++ b/pkg/grizzly/workflow_test.go
@@ -20,9 +20,6 @@ func TestPull(t *testing.T) {
 			provider,
 		})
 
-	ticker := PingService(GetUrl())
-	defer ticker.Stop()
-
 	opts := grizzly.Opts{
 		Targets: []string{
 			"Datasource/392IktgGk",

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -1,10 +1,6 @@
 package testutil
 
 import (
-	"fmt"
-	"net/http"
-	"time"
-
 	"github.com/grafana/grizzly/pkg/config"
 	"github.com/spf13/viper"
 )
@@ -17,25 +13,4 @@ func InitialiseTestConfig() {
 	viper.Set(config.CURRENT_CONTEXT, "test")
 	viper.Set("contexts.test.grafana.name", "test")
 	viper.Set("contexts.test.grafana.url", GetUrl())
-}
-
-// PingService checks whether a URL is available before tests begin
-func PingService(url string) *time.Ticker {
-	ticker := time.NewTicker(1 * time.Second)
-	timeoutExceeded := time.After(120 * time.Second)
-
-	success := false
-	for !success {
-		select {
-		case <-timeoutExceeded:
-			panic(fmt.Sprintf("Unable to connect to %s", url))
-
-		case <-ticker.C:
-			resp, _ := http.Get(url)
-			if resp != nil {
-				success = true
-			}
-		}
-	}
-	return ticker
 }

--- a/test-docker-compose/docker-compose.yml
+++ b/test-docker-compose/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   grafana:
     image: &image grafana/grafana:10.2.0
+    restart: on-failure
     ports:
       - "3001:3001"
     environment:
@@ -22,6 +23,7 @@ services:
   # Grafana will redirect all subpaths to the root URL if that's the correct path, while an nginx will fail if the subpath is not correct
   grafana_subpath:
     image: *image
+    restart: on-failure
     ports:
       - "3002:3002"
     environment:


### PR DESCRIPTION
It's no longer useful since docker-compose waits until the instances are healthy