### PR TITLE
Gracefully fail if the `spec` is not a map

### DIFF
--- a/integration/dashboard_test.go
+++ b/integration/dashboard_test.go
@@ -52,6 +52,21 @@ func TestDashboard(t *testing.T) {
 		})
 	})
 
+	// Check that the spec must be a map
+	t.Run("Apply dashboard - spec as string", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir:       dir,
+			RunOnContexts: allContexts,
+			Commands: []Command{
+				{
+					Command:             "apply spec-as-string-post.yml",
+					ExpectedCode:        1,
+					ExpectedLogsContain: "resource spec-as-string has an invalid spec. Expected a map, got a value of type string",
+				},
+			},
+		})
+	})
+
 	t.Run("Diff dashboard - success", func(t *testing.T) {
 		runTest(t, GrizzlyTest{
 			TestDir:       dir,

--- a/integration/testdata/dashboards/spec-as-string-get.yml
+++ b/integration/testdata/dashboards/spec-as-string-get.yml
@@ -1,9 +1,0 @@
-apiVersion: grizzly.grafana.com/v1alpha1
-kind: Dashboard
-metadata:
-    folder: general
-    name: spec-as-string
-spec:
-    timezone: utc
-    title: Spec as String
-    uid: spec-as-string

--- a/integration/testdata/dashboards/spec-as-string-get.yml
+++ b/integration/testdata/dashboards/spec-as-string-get.yml
@@ -1,0 +1,9 @@
+apiVersion: grizzly.grafana.com/v1alpha1
+kind: Dashboard
+metadata:
+    folder: general
+    name: spec-as-string
+spec:
+    timezone: utc
+    title: Spec as String
+    uid: spec-as-string

--- a/integration/testdata/dashboards/spec-as-string-post.yml
+++ b/integration/testdata/dashboards/spec-as-string-post.yml
@@ -1,0 +1,12 @@
+apiVersion: grizzly.grafana.com/v1alpha1
+kind: Dashboard
+metadata:
+  name: spec-as-string
+spec: |
+  {
+    "id": 4000,
+    "timezone": "utc",
+    "title": "Spec as String",
+    "uid": "spec-as-string",
+    "version": 10
+  }

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -73,7 +73,10 @@ func (h *AlertRuleGroupHandler) ResourceFilePath(resource grizzly.Resource, file
 
 // Parse parses a manifest object into a struct for this resource type
 func (h *AlertRuleGroupHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
-	resource := grizzly.Resource(m)
+	resource, err := grizzly.ResourceFromMap(m)
+	if err != nil {
+		return nil, err
+	}
 	return grizzly.Resources{resource}, nil
 }
 

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -64,7 +64,10 @@ func (h *AlertContactPointHandler) ResourceFilePath(resource grizzly.Resource, f
 
 // Parse parses a manifest object into a struct for this resource type
 func (h *AlertContactPointHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
-	resource := grizzly.Resource(m)
+	resource, err := grizzly.ResourceFromMap(m)
+	if err != nil {
+		return nil, err
+	}
 	resource.SetSpecString("uid", resource.Name())
 	return grizzly.Resources{resource}, nil
 }

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -70,7 +70,10 @@ func (h *DashboardHandler) ResourceFilePath(resource grizzly.Resource, filetype 
 
 // Parse parses a manifest object into a struct for this resource type
 func (h *DashboardHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
-	resource := grizzly.Resource(m)
+	resource, err := grizzly.ResourceFromMap(m)
+	if err != nil {
+		return nil, err
+	}
 	resource.SetSpecString("uid", resource.Name())
 	if !resource.HasMetadata("folder") {
 		resource.SetMetadata("folder", generalFolderUID)

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -68,7 +68,10 @@ func (h *DatasourceHandler) ResourceFilePath(resource grizzly.Resource, filetype
 
 // Parse parses a manifest object into a struct for this resource type
 func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
-	resource := grizzly.Resource(m)
+	resource, err := grizzly.ResourceFromMap(m)
+	if err != nil {
+		return nil, err
+	}
 	defaults := map[string]interface{}{
 		"basicAuth":         false,
 		"basicAuthPassword": "",

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -68,7 +68,10 @@ func (h *FolderHandler) ResourceFilePath(resource grizzly.Resource, filetype str
 
 // Parse parses a manifest object into a struct for this resource type
 func (h *FolderHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
-	resource := grizzly.Resource(m)
+	resource, err := grizzly.ResourceFromMap(m)
+	if err != nil {
+		return nil, err
+	}
 	resource.SetSpecString("uid", resource.Name())
 	return grizzly.Resources{resource}, nil
 }

--- a/pkg/grafana/library-elements-handler.go
+++ b/pkg/grafana/library-elements-handler.go
@@ -77,7 +77,10 @@ func (h *LibraryElementHandler) ResourceFilePath(resource grizzly.Resource, file
 
 // Parse parses a manifest object into a struct for this resource type
 func (h *LibraryElementHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
-	resource := grizzly.Resource(m)
+	resource, err := grizzly.ResourceFromMap(m)
+	if err != nil {
+		return nil, err
+	}
 	resource.SetSpecString("uid", resource.Name())
 	return grizzly.Resources{resource}, nil
 }

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -70,7 +70,10 @@ func (h *AlertNotificationPolicyHandler) ResourceFilePath(resource grizzly.Resou
 
 // Parse parses a manifest object into a struct for this resource type
 func (h *AlertNotificationPolicyHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
-	resource := grizzly.Resource(m)
+	resource, err := grizzly.ResourceFromMap(m)
+	if err != nil {
+		return nil, err
+	}
 	return grizzly.Resources{resource}, h.Validate(resource)
 }
 

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -66,7 +66,10 @@ func (h *RuleHandler) ResourceFilePath(resource grizzly.Resource, filetype strin
 
 // Parse parses a manifest object into a struct for this resource type
 func (h *RuleHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
-	resource := grizzly.Resource(m)
+	resource, err := grizzly.ResourceFromMap(m)
+	if err != nil {
+		return nil, err
+	}
 	return grizzly.Resources{resource}, nil
 }
 

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -93,7 +93,10 @@ func (h *SyntheticMonitoringHandler) ResourceFilePath(resource grizzly.Resource,
 
 // Parse parses a manifest object into a struct for this resource type
 func (h *SyntheticMonitoringHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
-	resource := grizzly.Resource(m)
+	resource, err := grizzly.ResourceFromMap(m)
+	if err != nil {
+		return nil, err
+	}
 	resource.SetSpecString("job", resource.GetMetadata("name"))
 	return grizzly.Resources{resource}, nil
 }

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -19,15 +19,7 @@ func ResourceFromMap(data map[string]interface{}) (Resource, error) {
 		return nil, fmt.Errorf("resource %s has no spec", r.Name())
 	}
 	if _, isMap := spec.(map[string]interface{}); !isMap {
-		specStr, isString := spec.(string)
-		if !isString {
-			return nil, fmt.Errorf("resource %s has an invalid spec. Expected either a map or a JSON string", r.Name())
-		}
-		var specMap map[string]interface{}
-		if err := json.Unmarshal([]byte(specStr), &specMap); err != nil {
-			return nil, fmt.Errorf("resource %s has an invalid spec. Expected either a map or a JSON string. JSON parse error: %w", r.Name(), err)
-		}
-		r["spec"] = specMap
+		return nil, fmt.Errorf("resource %s has an invalid spec. Expected a map, got a value of type %T", r.Name(), spec)
 	}
 
 	return r, nil

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -10,6 +10,29 @@ import (
 // Resource represents a single Resource destined for a single endpoint
 type Resource map[string]interface{}
 
+func ResourceFromMap(data map[string]interface{}) (Resource, error) {
+	r := Resource(data)
+
+	// Ensure that the spec is a map
+	spec := r["spec"]
+	if spec == nil {
+		return nil, fmt.Errorf("resource %s has no spec", r.Name())
+	}
+	if _, isMap := spec.(map[string]interface{}); !isMap {
+		specStr, isString := spec.(string)
+		if !isString {
+			return nil, fmt.Errorf("resource %s has an invalid spec. Expected either a map or a JSON string", r.Name())
+		}
+		var specMap map[string]interface{}
+		if err := json.Unmarshal([]byte(specStr), &specMap); err != nil {
+			return nil, fmt.Errorf("resource %s has an invalid spec. Expected either a map or a JSON string. JSON parse error: %w", r.Name(), err)
+		}
+		r["spec"] = specMap
+	}
+
+	return r, nil
+}
+
 // NewResource returns a new Resource object
 func NewResource(apiVersion, kind, name string, spec map[string]interface{}) Resource {
 	resource := Resource{


### PR DESCRIPTION
Based on https://github.com/grafana/grizzly/pull/325 (I needed the `ExpectedLogsContain` util)

Closes https://github.com/grafana/grizzly/issues/208

Currently, it panics when the `Resource` struct tries to interact with the spec as if it were a map. We should make sure that the spec actually is a map when we're casting as a `Resource`