### PR TITLE
Add config "get" and "path" subcommands

### DIFF
--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -6,7 +6,23 @@ import (
 	"github.com/go-clix/cli"
 	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/grizzly"
+	"github.com/spf13/viper"
 )
+
+func configPathCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "path",
+		Short: "Print the path to the configuration file",
+		Args:  cli.ArgsExact(0),
+	}
+	var opts grizzly.LoggingOpts
+
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		fmt.Println(viper.ConfigFileUsed())
+		return nil
+	}
+	return initialiseLogging(cmd, &opts)
+}
 
 func configImportCmd() *cli.Command {
 	cmd := &cli.Command{
@@ -65,6 +81,31 @@ func getContextsCmd() *cli.Command {
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		return config.GetContexts()
+	}
+	return initialiseLogging(cmd, &opts)
+}
+
+func getConfigCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "get [path]",
+		Short: "get the whole configuration for a context or a specific attribute of the configuration",
+		Args:  cli.ArgsRange(0, 1),
+	}
+	var opts grizzly.LoggingOpts
+	var output string
+	cmd.Flags().StringVarP(&output, "output", "o", "yaml", "Output format")
+
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		path := ""
+		if len(args) > 0 {
+			path = args[0]
+		}
+		val, err := config.Get(path, output)
+		if err != nil {
+			return err
+		}
+		fmt.Println(val)
+		return nil
 	}
 	return initialiseLogging(cmd, &opts)
 }

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -272,10 +272,12 @@ func configCmd() *cli.Command {
 		Short: "Show, select or configure configuration",
 		Args:  cli.ArgsExact(0),
 	}
+	cmd.AddCommand(configPathCmd())
 	cmd.AddCommand(currentContextCmd())
 	cmd.AddCommand(useContextCmd())
 	cmd.AddCommand(getContextsCmd())
 	cmd.AddCommand(configImportCmd())
+	cmd.AddCommand(getConfigCmd())
 	cmd.AddCommand(setCmd())
 	cmd.AddCommand(createContextCmd())
 	return cmd

--- a/integration/context_test.go
+++ b/integration/context_test.go
@@ -1,20 +1,61 @@
 package integration_test
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestContexts(t *testing.T) {
-	setupContexts(t, "testdata/contexts")
+	dir := "testdata/contexts"
+	setupContexts(t, dir)
 
 	t.Run("Get contexts - success", func(t *testing.T) {
 		runTest(t, GrizzlyTest{
-			TestDir: "testdata/contexts",
+			TestDir: dir,
 			Commands: []Command{
 				{
 					Command:            "config get-contexts",
 					ExpectedCode:       0,
 					ExpectedOutputFile: "get-contexts.txt",
+				},
+			},
+		})
+	})
+
+	absConfigPath, err := filepath.Abs("testdata/contexts/settings.yaml")
+	require.NoError(t, err)
+	t.Run("Find config path", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir: dir,
+			Commands: []Command{
+				{
+					Command:        "config path",
+					ExpectedOutput: absConfigPath,
+				},
+			},
+		})
+	})
+
+	t.Run("Get context config", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir: dir,
+			Commands: []Command{
+				// Whole config
+				{
+					Command:            "config get",
+					ExpectedOutputFile: "get-context-val.yml",
+				},
+				// Whole config JSON
+				{
+					Command:            "config get -o json",
+					ExpectedOutputFile: "get-context-val.json",
+				},
+				// Specific key
+				{
+					Command:        "config get grafana.url",
+					ExpectedOutput: "http://localhost:3001",
 				},
 			},
 		})

--- a/integration/testdata/contexts/get-context-val.json
+++ b/integration/testdata/contexts/get-context-val.json
@@ -1,0 +1,6 @@
+{
+  "grafana": {
+    "url": "http://localhost:3001"
+  },
+  "name": "default"
+}

--- a/integration/testdata/contexts/get-context-val.yml
+++ b/integration/testdata/contexts/get-context-val.yml
@@ -1,0 +1,3 @@
+grafana:
+    url: http://localhost:3001
+name: default

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -54,7 +54,7 @@ func runTest(t *testing.T, test GrizzlyTest) {
 					command.ExpectedOutput = string(bytes)
 				}
 				if command.ExpectedOutput != "" {
-					require.Equal(t, command.ExpectedOutput, stdout)
+					require.Equal(t, strings.TrimSpace(command.ExpectedOutput), strings.TrimSpace(stdout))
 				}
 				if command.ExpectedOutputContains != "" {
 					require.Contains(t, stdout, command.ExpectedOutputContains)


### PR DESCRIPTION
Related to https://github.com/grafana/grizzly/issues/315

- get: Allows quickly getting the current config without going into the YAML settings file
- path: Allows actually finding the current config file. Had trouble finding the `/Users/julienduchesne/Library/Application Support/grizzly/settings.yaml` on my machine. This helps

While implementing the `config path` function, I noticed that the config logic was a bit weird. While grizzly was possibly reading (through viper) the config file from the workdir, it was writing back to the system config. Is this expected? By using `viper.ConfigFileUsed()`, we write back to the file we're reading the config from