### PR TITLE
Clearer dashboard validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test-clean:
 	go clean -testcache
 
 test: run-test-image-locally
-	go test -v ./cmd/... ./pkg/... || ( status=$$?; docker logs grizzly-grafana ; exit $$status )
+	go test -v ./cmd/... ./pkg/...
 	make stop-test-image-locally
 
 integration: run-test-image-locally dev

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -32,24 +32,6 @@ func (h *AlertRuleGroupHandler) Kind() string {
 	return "AlertRuleGroup"
 }
 
-// Validate checks that the uid format is valid
-func (h *AlertRuleGroupHandler) Validate(resource grizzly.Resource) error {
-	data, err := json.Marshal(resource.Spec())
-	if err != nil {
-		return err
-	}
-	var group models.AlertRuleGroup
-	err = json.Unmarshal(data, &group)
-	if err != nil {
-		return err
-	}
-	uid := h.getUID(group)
-	if uid != resource.Name() {
-		return fmt.Errorf("title/folder combination '%s' and name '%s', don't match", uid, resource.Name())
-	}
-	return nil
-}
-
 // APIVersion returns group and version of the provider of this resource
 func (h *AlertRuleGroupHandler) APIVersion() string {
 	return h.Provider.APIVersion()
@@ -88,6 +70,24 @@ func (h *AlertRuleGroupHandler) Unprepare(resource grizzly.Resource) *grizzly.Re
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *AlertRuleGroupHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
 	return &resource
+}
+
+// Validate checks that the uid format is valid
+func (h *AlertRuleGroupHandler) Validate(resource grizzly.Resource) error {
+	data, err := json.Marshal(resource.Spec())
+	if err != nil {
+		return err
+	}
+	var group models.AlertRuleGroup
+	err = json.Unmarshal(data, &group)
+	if err != nil {
+		return err
+	}
+	uid := h.getUID(group)
+	if uid != resource.Name() {
+		return fmt.Errorf("title/folder combination '%s' and name '%s', don't match", uid, resource.Name())
+	}
+	return nil
 }
 
 // GetUID returns the UID for a resource

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -30,17 +30,6 @@ func (h *AlertContactPointHandler) Kind() string {
 	return "AlertContactPoint"
 }
 
-// Validate returns the uid of resource
-func (h *AlertContactPointHandler) Validate(resource grizzly.Resource) error {
-	uid, exist := resource.GetSpecString("uid")
-	if exist {
-		if uid != resource.Name() {
-			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
-		}
-	}
-	return nil
-}
-
 // APIVersion returns group and version of the provider of this resource
 func (h *AlertContactPointHandler) APIVersion() string {
 	return h.Provider.APIVersion()
@@ -80,6 +69,17 @@ func (h *AlertContactPointHandler) Unprepare(resource grizzly.Resource) *grizzly
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *AlertContactPointHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
 	return &resource
+}
+
+// Validate returns the uid of resource
+func (h *AlertContactPointHandler) Validate(resource grizzly.Resource) error {
+	uid, exist := resource.GetSpecString("uid")
+	if exist {
+		if uid != resource.Name() {
+			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
+		}
+	}
+	return nil
 }
 
 // GetUID returns the UID for a resource

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -89,11 +89,11 @@ func (h *DashboardHandler) Prepare(existing, resource grizzly.Resource) *grizzly
 // Validate returns the uid of resource
 func (h *DashboardHandler) Validate(resource grizzly.Resource) error {
 	uid, exist := resource.GetSpecString("uid")
+	if resource.Name() == "" {
+		return fmt.Errorf("name cannot be blank")
+	}
 	if resource.Name() != uid && exist {
 		return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
-	}
-	if resource.Name() == "" && (!exist || uid == "") {
-		return fmt.Errorf("uid and name cannot be blank")
 	}
 	return nil
 }

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -89,9 +89,6 @@ func (h *DashboardHandler) Prepare(existing, resource grizzly.Resource) *grizzly
 // Validate returns the uid of resource
 func (h *DashboardHandler) Validate(resource grizzly.Resource) error {
 	uid, exist := resource.GetSpecString("uid")
-	if resource.Name() == "" {
-		return fmt.Errorf("name cannot be blank")
-	}
 	if resource.Name() != uid && exist {
 		return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
 	}

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -31,17 +31,6 @@ func NewDashboardHandler(provider grizzly.Provider) *DashboardHandler {
 	}
 }
 
-// Validate returns the uid of resource
-func (h *DashboardHandler) Validate(resource grizzly.Resource) error {
-	uid, exist := resource.GetSpecString("uid")
-	if exist {
-		if uid != resource.Name() {
-			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
-		}
-	}
-	return nil
-}
-
 // Kind returns the name for this handler
 func (h *DashboardHandler) Kind() string {
 	return "Dashboard"
@@ -90,7 +79,23 @@ func (h *DashboardHandler) Unprepare(resource grizzly.Resource) *grizzly.Resourc
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *DashboardHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
+	uid, _ := resource.GetSpecString("uid")
+	if uid == "" {
+		resource.SetSpecString("uid", resource.Name())
+	}
 	return &resource
+}
+
+// Validate returns the uid of resource
+func (h *DashboardHandler) Validate(resource grizzly.Resource) error {
+	uid, exist := resource.GetSpecString("uid")
+	if resource.Name() != uid && exist {
+		return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
+	}
+	if resource.Name() == "" && (!exist || uid == "") {
+		return fmt.Errorf("uid and name cannot be blank")
+	}
+	return nil
 }
 
 // GetUID returns the UID for a resource

--- a/pkg/grafana/dashboard_test.go
+++ b/pkg/grafana/dashboard_test.go
@@ -83,56 +83,70 @@ func TestDashboard(t *testing.T) {
 	_ = os.Unsetenv("GRAFANA_URL")
 
 	t.Run("Validate/Prepare", func(t *testing.T) {
+		grizzly.ConfigureProviderRegistry(
+			[]grizzly.Provider{
+				NewProvider(),
+			})
+
 		handler := DashboardHandler{}
 		tests := []struct {
 			Name                string
+			Kind                string
 			Resource            grizzly.Resource
 			ValidateErrorString string
 			ExpectedUID         string
 		}{
 			{
 				Name:                "name and UID match",
+				Kind:                "Dashboard",
 				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{"uid": "name1"}),
 				ValidateErrorString: "",
 				ExpectedUID:         "name1",
 			},
 			{
 				Name:                "no UID provided",
-				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{}),
+				Kind:                "Dashboard",
+				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{"title": "something"}),
 				ValidateErrorString: "",
 				ExpectedUID:         "name1",
 			},
 			{
 				Name:                "name and UID differ",
+				Kind:                "Dashboard",
 				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{"uid": "name2"}),
 				ValidateErrorString: "uid 'name2' and name 'name1', don't match",
 			},
 			{
 				Name:                "no name provided",
+				Kind:                "Dashboard",
 				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "", map[string]any{"uid": "name1"}),
-				ValidateErrorString: "name cannot be blank",
+				ValidateErrorString: "Resource lacks name",
+			},
+			{
+				Name:                "no spec provided",
+				Kind:                "Dashboard",
+				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{}),
+				ValidateErrorString: "Resource name1 lacks spec",
 			},
 			{
 				Name:                "neither name nor UID provided",
-				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "", map[string]any{}),
-				ValidateErrorString: "name cannot be blank",
+				Kind:                "Dashboard",
+				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "", map[string]any{"title": "something"}),
+				ValidateErrorString: "Resource lacks name",
 			},
 		}
 		for _, test := range tests {
 			t.Run(test.Name, func(t *testing.T) {
-				err := handler.Validate(test.Resource)
-				if err != nil {
-					if test.ValidateErrorString == "" {
-						require.NoError(t, err)
-					} else {
-						require.Contains(t, err.Error(), test.ValidateErrorString)
-					}
-				} else {
-					require.NoError(t, err)
-					newResource := handler.Prepare(nil, test.Resource)
-					uid, _ := handler.GetUID(*newResource)
-					require.Equal(t, uid, test.ExpectedUID)
+				err := test.Resource.Validate()
+				if test.ValidateErrorString != "" {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), test.ValidateErrorString)
+					return
 				}
+				require.NoError(t, err)
+				newResource := handler.Prepare(nil, test.Resource)
+				uid, _ := handler.GetUID(*newResource)
+				require.Equal(t, uid, test.ExpectedUID)
 			})
 		}
 	})

--- a/pkg/grafana/dashboard_test.go
+++ b/pkg/grafana/dashboard_test.go
@@ -81,4 +81,59 @@ func TestDashboard(t *testing.T) {
 	})
 
 	_ = os.Unsetenv("GRAFANA_URL")
+
+	t.Run("Validate/Prepare", func(t *testing.T) {
+		handler := DashboardHandler{}
+		tests := []struct {
+			Name                string
+			Resource            grizzly.Resource
+			ValidateErrorString string
+			ExpectedUID         string
+		}{
+			{
+				Name:                "name and UID match",
+				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{"uid": "name1"}),
+				ValidateErrorString: "",
+				ExpectedUID:         "name1",
+			},
+			{
+				Name:                "no UID provided",
+				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{}),
+				ValidateErrorString: "",
+				ExpectedUID:         "name1",
+			},
+			{
+				Name:                "name and UID differ",
+				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{"uid": "name2"}),
+				ValidateErrorString: "uid 'name2' and name 'name1', don't match",
+			},
+			{
+				Name:                "no name provided",
+				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "", map[string]any{"uid": "name1"}),
+				ValidateErrorString: "name cannot be blank",
+			},
+			{
+				Name:                "neither name nor UID provided",
+				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "", map[string]any{}),
+				ValidateErrorString: "name cannot be blank",
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.Name, func(t *testing.T) {
+				err := handler.Validate(test.Resource)
+				if err != nil {
+					if test.ValidateErrorString == "" {
+						require.NoError(t, err)
+					} else {
+						require.Contains(t, err.Error(), test.ValidateErrorString)
+					}
+				} else {
+					require.NoError(t, err)
+					newResource := handler.Prepare(nil, test.Resource)
+					uid, _ := handler.GetUID(*newResource)
+					require.Equal(t, uid, test.ExpectedUID)
+				}
+			})
+		}
+	})
 }

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -34,17 +34,6 @@ func (h *DatasourceHandler) Kind() string {
 	return "Datasource"
 }
 
-// Validate returns the uid of resource
-func (h *DatasourceHandler) Validate(resource grizzly.Resource) error {
-	uid, exist := resource.GetSpecString("uid")
-	if exist {
-		if uid != resource.Name() {
-			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
-		}
-	}
-	return nil
-}
-
 // APIVersion returns group and version of the provider of this resource
 func (h *DatasourceHandler) APIVersion() string {
 	return h.Provider.APIVersion()
@@ -109,6 +98,17 @@ func (h *DatasourceHandler) Prepare(existing, resource grizzly.Resource) *grizzl
 	resource.SetSpecValue("id", existing.GetSpecValue("id"))
 	resource.DeleteSpecKey("version")
 	return &resource
+}
+
+// Validate returns the uid of resource
+func (h *DatasourceHandler) Validate(resource grizzly.Resource) error {
+	uid, exist := resource.GetSpecString("uid")
+	if exist {
+		if uid != resource.Name() {
+			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
+		}
+	}
+	return nil
 }
 
 // GetUID returns the UID for a resource

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -33,18 +33,6 @@ func (h *FolderHandler) Kind() string {
 	return "DashboardFolder"
 }
 
-// Validate returns the uid of resource
-func (h *FolderHandler) Validate(resource grizzly.Resource) error {
-	uid, exist := resource.GetSpecString("uid")
-	if exist {
-		if uid != resource.Name() {
-			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
-		}
-	}
-
-	return nil
-}
-
 // APIVersion returns the group and version for the provider of which this handler is a part
 func (h *FolderHandler) APIVersion() string {
 	return h.Provider.APIVersion()
@@ -84,6 +72,18 @@ func (h *FolderHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *FolderHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
 	return &resource
+}
+
+// Validate returns the uid of resource
+func (h *FolderHandler) Validate(resource grizzly.Resource) error {
+	uid, exist := resource.GetSpecString("uid")
+	if exist {
+		if uid != resource.Name() {
+			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
+		}
+	}
+
+	return nil
 }
 
 // GetUID returns the UID for a resource

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -33,18 +33,6 @@ func (h *LibraryElementHandler) Kind() string {
 	return "LibraryElement"
 }
 
-// Validate returns the uid of resource
-func (h *LibraryElementHandler) Validate(resource grizzly.Resource) error {
-	uid, exist := resource.GetSpecString("uid")
-	if exist {
-		if uid != resource.Name() {
-			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
-		}
-	}
-
-	return nil
-}
-
 // APIVersion returns the group and version for the provider of which this handler is a part
 func (h *LibraryElementHandler) APIVersion() string {
 	return h.Provider.APIVersion()
@@ -101,6 +89,18 @@ func (h *LibraryElementHandler) Prepare(existing, resource grizzly.Resource) *gr
 	}
 	resource.DeleteSpecKey("meta")
 	return &resource
+}
+
+// Validate returns the uid of resource
+func (h *LibraryElementHandler) Validate(resource grizzly.Resource) error {
+	uid, exist := resource.GetSpecString("uid")
+	if exist {
+		if uid != resource.Name() {
+			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
+		}
+	}
+
+	return nil
 }
 
 // GetUID returns the UID for a resource

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -35,14 +35,6 @@ func (h *AlertNotificationPolicyHandler) Kind() string {
 	return "AlertNotificationPolicy"
 }
 
-// Validate returns the uid of resource
-func (h *AlertNotificationPolicyHandler) Validate(resource grizzly.Resource) error {
-	if resource.Name() != GlobalAlertNotificationPolicyName {
-		return fmt.Errorf("name of notification policy must be '%s', got '%s'", GlobalAlertNotificationPolicyName, resource.Name())
-	}
-	return nil
-}
-
 // APIVersion returns group and version of the provider of this resource
 func (h *AlertNotificationPolicyHandler) APIVersion() string {
 	return h.Provider.APIVersion()
@@ -85,6 +77,14 @@ func (h *AlertNotificationPolicyHandler) Unprepare(resource grizzly.Resource) *g
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *AlertNotificationPolicyHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
 	return &resource
+}
+
+// Validate returns the uid of resource
+func (h *AlertNotificationPolicyHandler) Validate(resource grizzly.Resource) error {
+	if resource.Name() != GlobalAlertNotificationPolicyName {
+		return fmt.Errorf("name of notification policy must be '%s', got '%s'", GlobalAlertNotificationPolicyName, resource.Name())
+	}
+	return nil
 }
 
 // GetUID returns the UID for a resource

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -32,17 +32,6 @@ func (h *RuleHandler) Kind() string {
 	return "PrometheusRuleGroup"
 }
 
-// Validate returns the uid of resource
-func (h *RuleHandler) Validate(resource grizzly.Resource) error {
-	uid, exist := resource.GetSpecString("uid")
-	if exist {
-		if uid != resource.Name() {
-			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
-		}
-	}
-	return nil
-}
-
 // APIVersion returns the group and version for the provider of which this handler is a part
 func (h *RuleHandler) APIVersion() string {
 	return h.Provider.APIVersion()
@@ -81,6 +70,15 @@ func (h *RuleHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *RuleHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
 	return &resource
+}
+
+// Validate returns the uid of resource
+func (h *RuleHandler) Validate(resource grizzly.Resource) error {
+	uid, exist := resource.GetSpecString("uid")
+	if exist && uid != resource.Name() {
+		return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
+	}
+	return nil
 }
 
 // GetUID returns the UID for a resource

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -71,21 +71,6 @@ func (h *SyntheticMonitoringHandler) FindResourceFiles(dir string) ([]string, er
 	return filepath.Glob(path)
 }
 
-// Validate returns the uid of resource
-func (h *SyntheticMonitoringHandler) Validate(resource grizzly.Resource) error {
-	job, exist := resource.GetSpecString("job")
-	if exist {
-		if job != resource.Name() {
-			return fmt.Errorf("job '%s' and name '%s', don't match", job, resource.Name())
-		}
-	}
-	settings := resource.GetSpecValue("settings").(map[string]interface{})
-	if _, ok := settings[resource.GetMetadata("type")]; !ok {
-		return fmt.Errorf("type '%s' is incorrect", resource.GetMetadata("type"))
-	}
-	return nil
-}
-
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *SyntheticMonitoringHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {
 	return fmt.Sprintf(syntheticMonitoringPattern, resource.Name(), filetype)
@@ -115,6 +100,19 @@ func (h *SyntheticMonitoringHandler) Prepare(existing, resource grizzly.Resource
 	resource.SetSpecValue("tenantId", existing.GetSpecValue("tenantId"))
 	resource.SetSpecValue("id", existing.GetSpecValue("id"))
 	return &resource
+}
+
+// Validate returns the uid of resource
+func (h *SyntheticMonitoringHandler) Validate(resource grizzly.Resource) error {
+	job, exist := resource.GetSpecString("job")
+	if exist && job != resource.Name() {
+		return fmt.Errorf("job '%s' and name '%s', don't match", job, resource.Name())
+	}
+	settings := resource.GetSpecValue("settings").(map[string]interface{})
+	if _, ok := settings[resource.GetMetadata("type")]; !ok {
+		return fmt.Errorf("type '%s' is incorrect", resource.GetMetadata("type"))
+	}
+	return nil
 }
 
 // GetUID returns the UID for a resource

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -283,8 +283,7 @@ func Apply(resources Resources) error {
 		if err != nil {
 			return err
 		}
-
-		err = handler.Validate(resource)
+		err = resource.Validate()
 		if err != nil {
 			return fmt.Errorf("resource %s is not valid: %v", resource.Key(), err)
 		}

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -284,15 +284,15 @@ func Apply(resources Resources) error {
 			return err
 		}
 
+		err = handler.Validate(resource)
+		if err != nil {
+			return fmt.Errorf("resource %s is not valid: %v", resource.Key(), err)
+		}
+
 		log.Debugf("Getting the remote value for `%s`", resource.Key())
 		existingResource, err := handler.GetRemote(resource)
 		if errors.Is(err, ErrNotFound) {
 			log.Debugf("`%s` was not found, adding it...", resource.Key())
-
-			err := handler.Validate(resource)
-			if err != nil {
-				return fmt.Errorf("resource %s is not valid: %v", resource.Key(), err)
-			}
 
 			if err := handler.Add(resource); err != nil {
 				return err


### PR DESCRIPTION
We now have `Validate()` and `Prepare()`. Validate, well, validates. That is, it either returns nil
or an error. Prepare mutates the resource.

This PR moves these two related funcs closer to each other in the code. Also, for dashboards it
refactors the validation logic:

* if UID not set or ="", then use name as UID
* if UID and name set, but not equal, throw an error
* if name is blank, throw an error.﻿
