### PR TITLE
Add --kind to set the kind of object when --only-spec is set

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/go-clix/cli"
@@ -71,10 +70,6 @@ func pullCmd() *cli.Command {
 	var opts grizzly.Opts
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		if err := checkDashboardTarget(opts); err != nil {
-			return err
-		}
-
 		return grizzly.Pull(args[0], opts)
 	}
 
@@ -128,10 +123,6 @@ func applyCmd() *cli.Command {
 	var opts grizzly.Opts
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		if err := checkDashboardTarget(opts); err != nil {
-			return err
-		}
-
 		resources, err := grizzly.Parse(args[0], opts)
 		if err != nil {
 			return err
@@ -141,27 +132,6 @@ func applyCmd() *cli.Command {
 
 	cmd = initialiseOnlySpec(cmd, &opts)
 	return initialiseCmd(cmd, &opts)
-}
-
-// targetsOfKind checks if the specified targets are of certain kind
-func targetsOfKind(kind string, opts grizzly.Opts) bool {
-	for _, t := range opts.Targets {
-		if !(strings.Contains(t, "/") && strings.Split(t, "/")[0] == kind) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// checkDashboardTarget ensures that the specified targets are of dashboards kind
-func checkDashboardTarget(opts grizzly.Opts) error {
-	ok := targetsOfKind("Dashboard", opts)
-	if opts.OnlySpec && !ok {
-		return fmt.Errorf("-s flag is only supported for dashboards")
-	}
-
-	return nil
 }
 
 type jsonnetWatchParser struct {

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -139,7 +139,6 @@ func applyCmd() *cli.Command {
 		return grizzly.Apply(resources)
 	}
 
-	cmd.Flags().StringVarP(&opts.FolderUID, "folder", "f", generalFolderUID, "folder to push dashboards to")
 	cmd = initialiseOnlySpec(cmd, &opts)
 	return initialiseCmd(cmd, &opts)
 }
@@ -297,6 +296,9 @@ func initialiseCmd(cmd *cli.Command, opts *grizzly.Opts) *cli.Command {
 
 func initialiseOnlySpec(cmd *cli.Command, opts *grizzly.Opts) *cli.Command {
 	cmd.Flags().BoolVarP(&opts.OnlySpec, "only-spec", "s", false, "this flag is only used for dashboards to output the spec")
+	cmd.Flags().StringVarP(&opts.FolderUID, "folder", "f", generalFolderUID, "folder to push dashboards to")
+	cmd.Flags().StringVarP(&opts.FolderUID, "kind", "k", "", "Kind to use for resources. Required by --only-spec")
+
 	cmdRun := cmd.Run
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		opts.HasOnlySpec = cmd.Flags().Changed("only-spec")

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -27,4 +27,6 @@ type Context struct {
 	Targets             []string                  `yaml:"targets" mapstructure:"targets"`
 	OutputFormat        string                    `yaml:"output-format" mapstructure:"output-format"`
 	OnlySpec            bool                      `yaml:"only-spec" mapstructure:"only-spec"`
+	ResourceKind        string                    `yaml:"resource-kind" mapstructure:"resource-kind"`
+	FolderUID           string                    `yaml:"folder-uid" mapstructure:"folder-uid"`
 }

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -117,6 +117,11 @@ func (h *AlertRuleGroupHandler) Update(existing, resource grizzly.Resource) erro
 	return h.putAlertRuleGroup(resource)
 }
 
+// UsesFolders identifies whether this resource lives within a folder
+func (h *AlertRuleGroupHandler) UsesFolders() bool {
+	return false
+}
+
 // getRemoteAlertRuleGroup retrieves a alertRuleGroup object from Grafana
 func (h *AlertRuleGroupHandler) getRemoteAlertRuleGroup(uid string) (*grizzly.Resource, error) {
 	folder, group := h.splitUID(uid)
@@ -141,7 +146,10 @@ func (h *AlertRuleGroupHandler) getRemoteAlertRuleGroup(uid string) (*grizzly.Re
 		return nil, err
 	}
 
-	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	if err != nil {
+		return nil, err
+	}
 	return &resource, nil
 }
 

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -109,6 +109,11 @@ func (h *AlertContactPointHandler) Update(existing, resource grizzly.Resource) e
 	return h.putContactPoint(resource)
 }
 
+// UsesFolders identifies whether this resource lives within a folder
+func (h *AlertContactPointHandler) UsesFolders() bool {
+	return false
+}
+
 // getRemoteContactPoint retrieves a contactPoint object from Grafana
 func (h *AlertContactPointHandler) getRemoteContactPoint(uid string) (*grizzly.Resource, error) {
 	client, err := h.Provider.(ClientProvider).Client()
@@ -137,7 +142,10 @@ func (h *AlertContactPointHandler) getRemoteContactPoint(uid string) (*grizzly.R
 		return nil, err
 	}
 
-	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	if err != nil {
+		return nil, err
+	}
 	return &resource, nil
 }
 

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -147,6 +147,11 @@ func (h *DashboardHandler) Preview(resource grizzly.Resource, opts *grizzly.Prev
 	return nil
 }
 
+// UsesFolders identifies whether this resource lives within a folder
+func (h *DashboardHandler) UsesFolders() bool {
+	return true
+}
+
 // getRemoteDashboard retrieves a dashboard object from Grafana
 func (h *DashboardHandler) getRemoteDashboard(uid string) (*grizzly.Resource, error) {
 	client, err := h.Provider.(ClientProvider).Client()
@@ -169,7 +174,10 @@ func (h *DashboardHandler) getRemoteDashboard(uid string) (*grizzly.Resource, er
 		return nil, err
 	}
 
-	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	if err != nil {
+		return nil, err
+	}
 	folderUid := extractFolderUID(client, *dashboard)
 	resource.SetMetadata("folder", folderUid)
 	return &resource, nil

--- a/pkg/grafana/dashboard_test.go
+++ b/pkg/grafana/dashboard_test.go
@@ -88,50 +88,54 @@ func TestDashboard(t *testing.T) {
 				NewProvider(),
 			})
 
+		newResource := func(name string, spec map[string]any) grizzly.Resource {
+			resource := grizzly.Resource{
+				"apiVersion": "apiVersion",
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"name": name,
+				},
+				"spec": spec,
+			}
+			return resource
+		}
 		handler := DashboardHandler{}
 		tests := []struct {
 			Name                string
-			Kind                string
 			Resource            grizzly.Resource
 			ValidateErrorString string
 			ExpectedUID         string
 		}{
 			{
 				Name:                "name and UID match",
-				Kind:                "Dashboard",
-				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{"uid": "name1"}),
+				Resource:            newResource("name1", map[string]any{"uid": "name1"}),
 				ValidateErrorString: "",
 				ExpectedUID:         "name1",
 			},
 			{
 				Name:                "no UID provided",
-				Kind:                "Dashboard",
-				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{"title": "something"}),
+				Resource:            newResource("name1", map[string]any{"title": "something"}),
 				ValidateErrorString: "",
 				ExpectedUID:         "name1",
 			},
 			{
 				Name:                "name and UID differ",
-				Kind:                "Dashboard",
-				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{"uid": "name2"}),
+				Resource:            newResource("name1", map[string]any{"uid": "name2"}),
 				ValidateErrorString: "uid 'name2' and name 'name1', don't match",
 			},
 			{
 				Name:                "no name provided",
-				Kind:                "Dashboard",
-				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "", map[string]any{"uid": "name1"}),
+				Resource:            newResource("", map[string]any{"uid": "name1"}),
 				ValidateErrorString: "Resource lacks name",
 			},
 			{
 				Name:                "no spec provided",
-				Kind:                "Dashboard",
-				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "name1", map[string]any{}),
+				Resource:            newResource("name1", map[string]any{}),
 				ValidateErrorString: "Resource name1 lacks spec",
 			},
 			{
 				Name:                "neither name nor UID provided",
-				Kind:                "Dashboard",
-				Resource:            grizzly.NewResource("apiVersion", "Dashboard", "", map[string]any{"title": "something"}),
+				Resource:            newResource("", map[string]any{"title": "something"}),
 				ValidateErrorString: "Resource lacks name",
 			},
 		}

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -138,6 +138,11 @@ func (h *DatasourceHandler) Update(existing, resource grizzly.Resource) error {
 	return h.putDatasource(resource)
 }
 
+// UsesFolders identifies whether this resource lives within a folder
+func (h *DatasourceHandler) UsesFolders() bool {
+	return false
+}
+
 // getRemoteDatasource retrieves a datasource object from Grafana
 func (h *DatasourceHandler) getRemoteDatasource(uid string) (*grizzly.Resource, error) {
 	client, err := h.Provider.(ClientProvider).Client()
@@ -174,7 +179,10 @@ func (h *DatasourceHandler) getRemoteDatasource(uid string) (*grizzly.Resource, 
 		return nil, err
 	}
 
-	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	if err != nil {
+		return nil, err
+	}
 	return &resource, nil
 }
 

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -154,6 +154,11 @@ func (h *FolderHandler) Update(existing, resource grizzly.Resource) error {
 	return h.putFolder(resource)
 }
 
+// UsesFolders identifies whether this resource lives within a folder
+func (h *FolderHandler) UsesFolders() bool {
+	return false
+}
+
 // getRemoteFolder retrieves a folder object from Grafana
 func (h *FolderHandler) getRemoteFolder(uid string) (*grizzly.Resource, error) {
 	var folder *models.Folder
@@ -188,7 +193,10 @@ func (h *FolderHandler) getRemoteFolder(uid string) (*grizzly.Resource, error) {
 		return nil, err
 	}
 
-	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	if err != nil {
+		return nil, err
+	}
 	return &resource, nil
 }
 

--- a/pkg/grafana/folder_test.go
+++ b/pkg/grafana/folder_test.go
@@ -92,7 +92,8 @@ func TestSortFolders(t *testing.T) {
 		if parentUID != "" {
 			spec["parentUid"] = parentUID
 		}
-		return grizzly.NewResource(handler.APIVersion(), handler.Kind(), uid, spec)
+		resource, _ := grizzly.NewResource(handler.APIVersion(), handler.Kind(), uid, spec)
+		return resource
 	}
 
 	cases := []struct {

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -135,6 +135,11 @@ func (h *LibraryElementHandler) Update(existing, resource grizzly.Resource) erro
 	return h.updateElement(existing, resource)
 }
 
+// UsesFolders identifies whether this resource lives within a folder
+func (h *LibraryElementHandler) UsesFolders() bool {
+	return false
+}
+
 func (h *LibraryElementHandler) listElements() ([]string, error) {
 	params := library.NewGetLibraryElementsParams()
 	client, err := h.Provider.(ClientProvider).Client()
@@ -209,6 +214,9 @@ func (h *LibraryElementHandler) getRemoteLibraryElement(uid string) (*grizzly.Re
 		return nil, err
 	}
 
-	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), uid, spec)
+	if err != nil {
+		return nil, err
+	}
 	return &resource, nil
 }

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -109,6 +109,11 @@ func (h *AlertNotificationPolicyHandler) Update(existing, resource grizzly.Resou
 	return h.putAlertNotificationPolicy(resource)
 }
 
+// UsesFolders identifies whether this resource lives within a folder
+func (h *AlertNotificationPolicyHandler) UsesFolders() bool {
+	return false
+}
+
 // getRemoteAlertNotificationPolicy retrieves a alertNotificationPolicy object from Grafana
 func (h *AlertNotificationPolicyHandler) getRemoteAlertNotificationPolicy() (*grizzly.Resource, error) {
 	client, err := h.Provider.(ClientProvider).Client()
@@ -128,7 +133,10 @@ func (h *AlertNotificationPolicyHandler) getRemoteAlertNotificationPolicy() (*gr
 		return nil, err
 	}
 
-	resource := grizzly.NewResource(h.APIVersion(), h.Kind(), GlobalAlertNotificationPolicyName, spec)
+	resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), GlobalAlertNotificationPolicyName, spec)
+	if err != nil {
+		return nil, err
+	}
 	return &resource, nil
 }
 

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -112,6 +112,11 @@ func (h *RuleHandler) Update(existing, resource grizzly.Resource) error {
 	return h.writeRuleGroup(resource)
 }
 
+// UsesFolders identifies whether this resource lives within a folder
+func (h *RuleHandler) UsesFolders() bool {
+	return false
+}
+
 var cortexTool = func(mimirConfig *config.MimirConfig, args ...string) ([]byte, error) {
 	path := os.Getenv("CORTEXTOOL_PATH")
 	if path == "" {
@@ -157,7 +162,10 @@ func (h *RuleHandler) getRemoteRuleGroup(uid string) (*grizzly.Resource, error) 
 					spec := map[string]interface{}{
 						"rules": group.Rules,
 					}
-					resource := grizzly.NewResource(h.APIVersion(), h.Kind(), group.Name, spec)
+					resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), group.Name, spec)
+					if err != nil {
+						return nil, err
+					}
 					resource.SetMetadata("namespace", namespace)
 					return &resource, nil
 				}

--- a/pkg/grafana/rules_test.go
+++ b/pkg/grafana/rules_test.go
@@ -81,7 +81,7 @@ func TestRules(t *testing.T) {
 		err = yaml.Unmarshal(file, &spec)
 		require.NoError(t, err)
 
-		resource := grizzly.NewResource("apiV", "kind", "name", spec)
+		resource, _ := grizzly.NewResource("apiV", "kind", "name", spec)
 		resource.SetMetadata("namespace", "value")
 		err = h.writeRuleGroup(resource)
 		require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestRules(t *testing.T) {
 		err = yaml.Unmarshal(file, &spec)
 		require.NoError(t, err)
 
-		resource := grizzly.NewResource("apiV", "kind", "name", spec)
+		resource, _ := grizzly.NewResource("apiV", "kind", "name", spec)
 		resource.SetMetadata("namespace", "value")
 		err = h.writeRuleGroup(resource)
 		require.Error(t, err)

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -146,6 +146,11 @@ func (h *SyntheticMonitoringHandler) Update(existing, resource grizzly.Resource)
 	return h.updateCheck(resource)
 }
 
+// UsesFolders identifies whether this resource lives within a folder
+func (h *SyntheticMonitoringHandler) UsesFolders() bool {
+	return false
+}
+
 // NewSyntheticMonitoringClient creates a new client for synthetic monitoring go client
 func (h *SyntheticMonitoringHandler) NewSyntheticMonitoringClient() (*smapi.Client, error) {
 	grizzlyContext, err := config.CurrentContext()
@@ -257,7 +262,10 @@ func (h *SyntheticMonitoringHandler) getRemoteCheck(uid string) (*grizzly.Resour
 				return nil, err
 			}
 			specmap["probes"] = probeNames
-			resource := grizzly.NewResource(handler.APIVersion(), handler.Kind(), check.Job, specmap)
+			resource, err := grizzly.NewResource(handler.APIVersion(), handler.Kind(), check.Job, specmap)
+			if err != nil {
+				return nil, err
+			}
 			resource.SetMetadata("type", h.getType(check))
 			return &resource, nil
 		}

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -13,10 +13,11 @@ type Opts struct {
 	Targets      []string
 	OutputFormat string
 
-	// Used for supporting commands that output dashboard JSON
-	FolderUID   string
-	OnlySpec    bool
-	HasOnlySpec bool
+	// Used for supporting resources without envelopes
+	OnlySpec     bool
+	HasOnlySpec  bool
+	FolderUID    string
+	ResourceKind string
 }
 
 // PreviewOpts contains options to configure a preview

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -44,6 +44,9 @@ type Handler interface {
 
 	// Sort sorts resources as defined by the handler
 	Sort(resources Resources) Resources
+
+	// UsesFolders identifies whether this resource lives within a folder
+	UsesFolders() bool
 }
 
 // PreviewHandler describes a handler that has the ability to render

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -28,7 +28,7 @@ func ResourceFromMap(data map[string]interface{}) (Resource, error) {
 }
 
 // NewResource returns a new Resource object
-func NewResource(apiVersion, kind, name string, spec map[string]interface{}) Resource {
+func NewResource(apiVersion, kind, name string, spec map[string]interface{}) (Resource, error) {
 	resource := Resource{
 		"apiVersion": apiVersion,
 		"kind":       kind,
@@ -37,7 +37,18 @@ func NewResource(apiVersion, kind, name string, spec map[string]interface{}) Res
 		},
 		"spec": spec,
 	}
-	return resource
+	if name == "" {
+		handler, err := Registry.GetHandler(kind)
+		if err != nil {
+			return nil, err
+		}
+		uid, err := handler.GetUID(resource)
+		if uid == "" {
+			return nil, fmt.Errorf("Resources of kind %s require a UID", kind)
+		}
+		resource.SetMetadata("name", uid)
+	}
+	return resource, nil
 }
 
 // APIVersion returns the group and version of the provider of the resource

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -3,7 +3,6 @@ package grizzly
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -181,9 +180,7 @@ func (r *Resource) Validate() error {
 	if r.Spec() == nil || len(r.Spec()) == 0 {
 		missing = append(missing, "spec")
 	}
-	jj, _ := r.JSON()
 
-	log.Printf("KIND: '%s' NAME: '%s' SPEC(%d)", r.Kind(), r.Name(), len(jj))
 	if len(missing) > 0 {
 		if r.Name() != "" {
 			return fmt.Errorf("Resource %s lacks %s", r.Name(), strings.Join(missing, ", "))

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -543,16 +543,12 @@ func getOnlySpec(opts Opts) (bool, string, string, error) {
 	if !onlySpec {
 		return false, "", "", nil
 	}
-	var kind string
-	if context.ResourceKind != "" {
-		kind = context.ResourceKind
-	} else {
+	kind := context.ResourceKind
+	if kind == "" {
 		kind = opts.ResourceKind
 	}
-	var folderUID string
-	if context.FolderUID != "" {
-		folderUID = context.FolderUID
-	} else {
+	folderUID := context.FolderUID
+	if folderUID == "" {
 		folderUID = opts.FolderUID
 	}
 	return onlySpec, kind, folderUID, nil

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -527,3 +527,33 @@ func getOutputFormat(opts Opts) (string, bool, error) {
 	}
 	return "yaml", onlySpec, nil
 }
+
+func getOnlySpec(opts Opts) (bool, string, string, error) {
+	var onlySpec bool
+	context, err := config.CurrentContext()
+	if err != nil {
+		return false, "", "", err
+	}
+	if opts.HasOnlySpec {
+		onlySpec = opts.OnlySpec
+	} else {
+		onlySpec = context.OnlySpec
+	}
+
+	if !onlySpec {
+		return false, "", "", nil
+	}
+	var kind string
+	if context.ResourceKind != "" {
+		kind = context.ResourceKind
+	} else {
+		kind = opts.ResourceKind
+	}
+	var folderUID string
+	if context.FolderUID != "" {
+		folderUID = context.FolderUID
+	} else {
+		folderUID = opts.FolderUID
+	}
+	return onlySpec, kind, folderUID, nil
+}


### PR DESCRIPTION
The `--only-spec` argument allows for working with resources that lack an "envelope". This envelope
provides a way to specify metadata, e.g. resource type (aka 'kind'), plus in the case of dashboards,
the UID of the folder the dashboard belongs in.

If there is no envelope, then this information needs to be provided in another way. Currently, it is simply hardwired to dashboards. However, this PR changes this such that it can either be set in the context, or can be set on the command line each time Grizzly is invoked.﻿
