### PR TITLE
Utility to generate jsonnet imports

### DIFF
--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -9,6 +9,23 @@ import (
 	"github.com/spf13/viper"
 )
 
+func configCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "config <sub-command>",
+		Short: "Show, select or configure configuration",
+		Args:  cli.ArgsExact(0),
+	}
+	cmd.AddCommand(configPathCmd())
+	cmd.AddCommand(currentContextCmd())
+	cmd.AddCommand(useContextCmd())
+	cmd.AddCommand(getContextsCmd())
+	cmd.AddCommand(configImportCmd())
+	cmd.AddCommand(getConfigCmd())
+	cmd.AddCommand(setCmd())
+	cmd.AddCommand(createContextCmd())
+	return cmd
+}
+
 func configPathCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "path",

--- a/cmd/grr/jsonnet.go
+++ b/cmd/grr/jsonnet.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/go-clix/cli"
+	"github.com/grafana/grizzly/pkg/grizzly"
+)
+
+func jsonnetCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "jsonnet <sub-command>",
+		Short: "Jsonnet related commands",
+		Args:  cli.ArgsExact(0),
+	}
+	cmd.AddCommand(jsonnetImportsCmd())
+	return cmd
+}
+
+func jsonnetImportsCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "imports <dir> <imports-file>",
+		Short: "Generate a Jsonnet file that imports all files in a directory",
+		Args:  cli.ArgsExact(2),
+	}
+	var opts grizzly.Opts
+
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		dir := args[0]
+		out := args[1]
+		return grizzly.GenerateJsonnetImports(dir, out)
+	}
+
+	cmd.Flags().StringVarP(&opts.FolderUID, "folder", "f", generalFolderUID, "folder to push dashboards to")
+	cmd = initialiseOnlySpec(cmd, &opts)
+	return initialiseCmd(cmd, &opts)
+}

--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -45,6 +45,7 @@ func main() {
 		previewCmd(),
 		providersCmd(),
 		configCmd(),
+		jsonnetCmd(),
 	)
 
 	// Run!

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -266,23 +266,6 @@ func providersCmd() *cli.Command {
 	return initialiseLogging(cmd, &opts)
 }
 
-func configCmd() *cli.Command {
-	cmd := &cli.Command{
-		Use:   "config <sub-command>",
-		Short: "Show, select or configure configuration",
-		Args:  cli.ArgsExact(0),
-	}
-	cmd.AddCommand(configPathCmd())
-	cmd.AddCommand(currentContextCmd())
-	cmd.AddCommand(useContextCmd())
-	cmd.AddCommand(getContextsCmd())
-	cmd.AddCommand(configImportCmd())
-	cmd.AddCommand(getConfigCmd())
-	cmd.AddCommand(setCmd())
-	cmd.AddCommand(createContextCmd())
-	return cmd
-}
-
 func initialiseCmd(cmd *cli.Command, opts *grizzly.Opts) *cli.Command {
 	// Keep the old flags for backwards compatibility
 	cmd.Flags().BoolVarP(&opts.Directory, "directory", "d", false, "treat resource path as a directory")

--- a/pkg/grizzly/jsonnet.go
+++ b/pkg/grizzly/jsonnet.go
@@ -98,7 +98,7 @@ func GenerateJsonnetImports(dir, out string) error {
 			b.WriteString(fmt.Sprintf("    \"path\": \"%s\",\n", path))
 			b.WriteString(fmt.Sprintf("    \"type\": \"%s\",\n", strings.TrimPrefix(ext, ".")))
 			if ext == ".yaml" || ext == ".yml" {
-				b.WriteString(fmt.Sprintf("    \"resource\": std.parseYAML(importstr \"%s\"),\n", path))
+				b.WriteString(fmt.Sprintf("    \"resource\": std.parseYaml(importstr \"%s\"),\n", path))
 			} else if ext == ".json" {
 				b.WriteString(fmt.Sprintf("    \"resource\": import \"%s\",\n", path))
 			}

--- a/pkg/grizzly/jsonnet.go
+++ b/pkg/grizzly/jsonnet.go
@@ -95,12 +95,12 @@ func GenerateJsonnetImports(dir, out string) error {
 			ext := filepath.Ext(d.Name())
 			base := strings.TrimSuffix(d.Name(), ext)
 			b.WriteString(fmt.Sprintf("  \"%s\": {\n", base))
-			b.WriteString(fmt.Sprintf("    \"path\": \"%s\",\n", path))
-			b.WriteString(fmt.Sprintf("    \"type\": \"%s\",\n", strings.TrimPrefix(ext, ".")))
+			b.WriteString(fmt.Sprintf("    path: \"%s\",\n", path))
+			b.WriteString(fmt.Sprintf("    type: \"%s\",\n", strings.TrimPrefix(ext, ".")))
 			if ext == ".yaml" || ext == ".yml" {
-				b.WriteString(fmt.Sprintf("    \"resource\": std.parseYaml(importstr \"%s\"),\n", path))
+				b.WriteString(fmt.Sprintf("    resource: std.parseYaml(importstr \"%s\"),\n", path))
 			} else if ext == ".json" {
-				b.WriteString(fmt.Sprintf("    \"resource\": import \"%s\",\n", path))
+				b.WriteString(fmt.Sprintf("    resource: import \"%s\",\n", path))
 			}
 			b.WriteString("  },\n")
 		}


### PR DESCRIPTION
Grizzly already has support for the use of Jsonnet to generate resources. It also has
the ability to pull resources from Grafana/etc. However, it lacks the ability to
mutate those downloaded resources with Jsonnet.

This is due to Jsonnet's lack of dynamic imports. Due to this lack, it is not possible
to write a Jsonnet program that loads a set of files from within a directory, if the
filenames are not known at 'compile' time.

This is worked around by generating a file that contains a set of import statements that
can be consumed by a Jsonnet script.

This PR adds a command to generate such an imports file. The output will be of this
command will be of the form shown below. Jsonnet scripts can now iterate over the objects
imported in this file:

```
{
  "dashboard-id-test": {
    "path": "odoko/dashboards/odoko/dashboard-id-test.json",
    "type": "json",
    "resource": import "odoko/dashboards/odoko/dashboard-id-test.json",
  },
  "test-dashboard": {
    "path": "odoko/dashboards/test-dashboard.json",
    "type": "json",
    "resource": import "odoko/dashboards/test-dashboard.json",
  },
}
```

This would be generated with a command such as:

```
grr jsonnet imports dir imports.libsonnet
```
