### PR TITLE
Read files anywhere, not in fixed directory structure

### DIFF
--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"encoding/json"
@@ -38,15 +37,8 @@ func (h *AlertRuleGroupHandler) APIVersion() string {
 }
 
 const (
-	alertRuleGroupGlob    = "alert-rules/alertRuleGroup-*"
 	alertRuleGroupPattern = "alert-rules/alertRuleGroup-%s.%s"
 )
-
-// FindResourceFiles identifies files within a directory that this handler can process
-func (h *AlertRuleGroupHandler) FindResourceFiles(dir string) ([]string, error) {
-	path := filepath.Join(dir, alertRuleGroupGlob)
-	return filepath.Glob(path)
-}
 
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *AlertRuleGroupHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"encoding/json"
 
@@ -36,15 +35,8 @@ func (h *AlertContactPointHandler) APIVersion() string {
 }
 
 const (
-	contactPointGlob    = "alert-contact-points/contactPoint-*"
 	contactPointPattern = "alert-contact-points/contactPoint-%s.%s"
 )
-
-// FindResourceFiles identifies files within a directory that this handler can process
-func (h *AlertContactPointHandler) FindResourceFiles(dir string) ([]string, error) {
-	path := filepath.Join(dir, contactPointGlob)
-	return filepath.Glob(path)
-}
 
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *AlertContactPointHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"errors"
 
@@ -42,15 +41,8 @@ func (h *DashboardHandler) APIVersion() string {
 }
 
 const (
-	dashboardGlob    = "dashboards/*/dashboard-*"
 	dashboardPattern = "dashboards/%s/dashboard-%s.%s"
 )
-
-// FindResourceFiles identifies files within a directory that this handler can process
-func (h *DashboardHandler) FindResourceFiles(dir string) ([]string, error) {
-	path := filepath.Join(dir, dashboardGlob)
-	return filepath.Glob(path)
-}
 
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *DashboardHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"encoding/json"
 	"errors"
@@ -40,15 +39,8 @@ func (h *DatasourceHandler) APIVersion() string {
 }
 
 const (
-	datasourceGlob    = "datasources/datasource-*"
 	datasourcePattern = "datasources/datasource-%s.%s"
 )
-
-// FindResourceFiles identifies files within a directory that this handler can process
-func (h *DatasourceHandler) FindResourceFiles(dir string) ([]string, error) {
-	path := filepath.Join(dir, datasourceGlob)
-	return filepath.Glob(path)
-}
 
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *DatasourceHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"encoding/json"
 	"errors"
@@ -39,15 +38,8 @@ func (h *FolderHandler) APIVersion() string {
 }
 
 const (
-	folderGlob    = "folders/folder-*"
 	folderPattern = "folders/folder-%s.%s"
 )
-
-// FindResourceFiles identifies files within a directory that this handler can process
-func (h *FolderHandler) FindResourceFiles(dir string) ([]string, error) {
-	path := filepath.Join(dir, folderGlob)
-	return filepath.Glob(path)
-}
 
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *FolderHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -3,7 +3,6 @@ package grafana
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 
 	"errors"
 
@@ -39,15 +38,8 @@ func (h *LibraryElementHandler) APIVersion() string {
 }
 
 const (
-	libraryElementGlob    = "library-elements/*-*"
 	libraryElementPattern = "library-elements/%s-%s.%s"
 )
-
-// FindResourceFiles identifies files within a directory that this handler can process
-func (h *LibraryElementHandler) FindResourceFiles(dir string) ([]string, error) {
-	path := filepath.Join(dir, libraryElementGlob)
-	return filepath.Glob(path)
-}
 
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *LibraryElementHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -2,8 +2,6 @@ package grafana
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"encoding/json"
 
@@ -43,17 +41,6 @@ func (h *AlertNotificationPolicyHandler) APIVersion() string {
 const (
 	alertNotificationPolicyFile = "alertNotificationPolicy.yaml"
 )
-
-// FindResourceFiles identifies files within a directory that this handler can process
-func (h *AlertNotificationPolicyHandler) FindResourceFiles(dir string) ([]string, error) {
-	p := filepath.Join(dir, alertNotificationPolicyFile)
-	_, err := os.Stat(p)
-	if err == nil {
-		return []string{p}, nil
-	}
-	// just return empty, ignore error
-	return nil, nil
-}
 
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *AlertNotificationPolicyHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"log"
 	"os"
@@ -38,15 +37,8 @@ func (h *RuleHandler) APIVersion() string {
 }
 
 const (
-	prometheusRuleGroupGlob    = "prometheus/rules-*"
 	prometheusRuleGroupPattern = "prometheus/rules-%s.%s"
 )
-
-// FindResourceFiles identifies files within a directory that this handler can process
-func (h *RuleHandler) FindResourceFiles(dir string) ([]string, error) {
-	path := filepath.Join(dir, prometheusRuleGroupGlob)
-	return filepath.Glob(path)
-}
 
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *RuleHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"context"
 	"encoding/json"
@@ -61,15 +60,8 @@ func (h *SyntheticMonitoringHandler) APIVersion() string {
 }
 
 const (
-	syntheticMonitoringCheckGlob = "synthetic-monitoring/check-*"
-	syntheticMonitoringPattern   = "synthetic-monitoring/check-%s.%s"
+	syntheticMonitoringPattern = "synthetic-monitoring/check-%s.%s"
 )
-
-// FindResourceFiles identifies files within a directory that this handler can process
-func (h *SyntheticMonitoringHandler) FindResourceFiles(dir string) ([]string, error) {
-	path := filepath.Join(dir, syntheticMonitoringCheckGlob)
-	return filepath.Glob(path)
-}
 
 // ResourceFilePath returns the location on disk where a resource should be updated
 func (h *SyntheticMonitoringHandler) ResourceFilePath(resource grizzly.Resource, filetype string) string {

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -9,9 +9,6 @@ type Handler interface {
 	APIVersion() string
 	Kind() string
 
-	// FindResourceFiles identifies files within a directory that this handler can process
-	FindResourceFiles(dir string) ([]string, error)
-
 	// ResourceFilePath returns the location on disk where a resource should be updated
 	ResourceFilePath(resource Resource, filetype string) string
 

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -48,14 +49,13 @@ func Parse(resourcePath string, opts Opts) (Resources, error) {
 
 func FindResourceFiles(resourcePath string) ([]string, error) {
 	var files []string
-	for _, handler := range Registry.Handlers {
-		handlerFiles, err := handler.FindResourceFiles(resourcePath)
-		if err != nil {
-			return nil, err
+	err := filepath.WalkDir(resourcePath, func(path string, info fs.DirEntry, err error) error {
+		if !info.IsDir() {
+			files = append(files, path)
 		}
-		files = append(files, handlerFiles...)
-	}
-	return files, nil
+		return nil
+	})
+	return files, err
 }
 
 func ParseFile(opts Opts, resourceFile string) (Resources, error) {


### PR DESCRIPTION
When Grizzly pulls resources from Grafana, it writes them in a pre-defined file system structure.

Currently, when reading files, Grizzly expects them in this same structure. This is unnecessary.

This PR changes Grizzly to accept files anywhere within the referenced directory.﻿
