### PR TITLE
Correctly deduce UID, and track isDir

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -51,7 +51,7 @@ func listCmd() *cli.Command {
 			notifier.Error(nil, "resource-path required when listing local resources")
 			return nil
 		}
-		resources, err := grizzly.Parse(args[0], opts)
+		resources, err := grizzly.Parse(args[0], &opts)
 		if err != nil {
 			return err
 		}
@@ -86,12 +86,13 @@ func showCmd() *cli.Command {
 	var opts grizzly.Opts
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		resources, err := grizzly.Parse(args[0], opts)
+		resources, err := grizzly.Parse(args[0], &opts)
 		if err != nil {
 			return err
 		}
 		return grizzly.Show(resources, opts)
 	}
+	cmd = initialiseOnlySpec(cmd, &opts)
 	return initialiseCmd(cmd, &opts)
 }
 
@@ -104,7 +105,7 @@ func diffCmd() *cli.Command {
 	var opts grizzly.Opts
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		resources, err := grizzly.Parse(args[0], opts)
+		resources, err := grizzly.Parse(args[0], &opts)
 		if err != nil {
 			return err
 		}
@@ -123,7 +124,7 @@ func applyCmd() *cli.Command {
 	var opts grizzly.Opts
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		resources, err := grizzly.Parse(args[0], opts)
+		resources, err := grizzly.Parse(args[0], &opts)
 		if err != nil {
 			return err
 		}
@@ -144,7 +145,7 @@ func (p *jsonnetWatchParser) Name() string {
 }
 
 func (p *jsonnetWatchParser) Parse() (grizzly.Resources, error) {
-	return grizzly.Parse(p.resourcePath, p.opts)
+	return grizzly.Parse(p.resourcePath, &p.opts)
 }
 
 func watchCmd() *cli.Command {
@@ -178,7 +179,7 @@ func previewCmd() *cli.Command {
 	expires := cmd.Flags().IntP("expires", "e", 0, "when the preview should expire. Default 0 (never)")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		resources, err := grizzly.Parse(args[0], opts)
+		resources, err := grizzly.Parse(args[0], &opts)
 		if err != nil {
 			return err
 		}
@@ -202,7 +203,7 @@ func exportCmd() *cli.Command {
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		dashboardDir := args[1]
-		resources, err := grizzly.Parse(args[0], opts)
+		resources, err := grizzly.Parse(args[0], &opts)
 		if err != nil {
 			return err
 		}
@@ -267,7 +268,7 @@ func initialiseCmd(cmd *cli.Command, opts *grizzly.Opts) *cli.Command {
 func initialiseOnlySpec(cmd *cli.Command, opts *grizzly.Opts) *cli.Command {
 	cmd.Flags().BoolVarP(&opts.OnlySpec, "only-spec", "s", false, "this flag is only used for dashboards to output the spec")
 	cmd.Flags().StringVarP(&opts.FolderUID, "folder", "f", generalFolderUID, "folder to push dashboards to")
-	cmd.Flags().StringVarP(&opts.FolderUID, "kind", "k", "", "Kind to use for resources. Required by --only-spec")
+	cmd.Flags().StringVarP(&opts.ResourceKind, "kind", "k", "", "Kind to use for resources. Required by --only-spec")
 
 	cmdRun := cmd.Run
 	cmd.Run = func(cmd *cli.Command, args []string) error {

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -87,6 +87,14 @@ func (h *AlertRuleGroupHandler) GetUID(resource grizzly.Resource) (string, error
 	return resource.Name(), nil
 }
 
+func (h *AlertRuleGroupHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
+	spec := resource["spec"].(map[string]interface{})
+	if val, ok := spec["name"]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("UID not specified")
+}
+
 // Sort sorts according to handler needs
 func (h *AlertRuleGroupHandler) Sort(resources grizzly.Resources) grizzly.Resources {
 	return resources

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -79,6 +79,14 @@ func (h *AlertContactPointHandler) GetUID(resource grizzly.Resource) (string, er
 	return resource.Name(), nil
 }
 
+func (h *AlertContactPointHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
+	spec := resource["spec"].(map[string]interface{})
+	if val, ok := spec["uid"]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("UID not specified")
+}
+
 // Sort sorts according to handler needs
 func (h *AlertContactPointHandler) Sort(resources grizzly.Resources) grizzly.Resources {
 	return resources

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -92,6 +92,14 @@ func (h *DashboardHandler) GetUID(resource grizzly.Resource) (string, error) {
 	return resource.Name(), nil
 }
 
+func (h *DashboardHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
+	spec := resource["spec"].(map[string]interface{})
+	if val, ok := spec["uid"]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("UID not specified")
+}
+
 // Sort sorts according to handler needs
 func (h *DashboardHandler) Sort(resources grizzly.Resources) grizzly.Resources {
 	return resources

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -108,6 +108,14 @@ func (h *DatasourceHandler) GetUID(resource grizzly.Resource) (string, error) {
 	return resource.Name(), nil
 }
 
+func (h *DatasourceHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
+	spec := resource["spec"].(map[string]interface{})
+	if val, ok := spec["uid"]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("UID not specified")
+}
+
 // Sort sorts according to handler needs
 func (h *DatasourceHandler) Sort(resources grizzly.Resources) grizzly.Resources {
 	return resources

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -83,6 +83,14 @@ func (h *FolderHandler) GetUID(resource grizzly.Resource) (string, error) {
 	return resource.Name(), nil
 }
 
+func (h *FolderHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
+	spec := resource["spec"].(map[string]interface{})
+	if val, ok := spec["uid"]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("UID not specified")
+}
+
 // Sort sorts according to handler needs
 func (h *FolderHandler) Sort(resources grizzly.Resources) grizzly.Resources {
 	result := grizzly.Resources{}

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -100,6 +100,14 @@ func (h *LibraryElementHandler) GetUID(resource grizzly.Resource) (string, error
 	return resource.Name(), nil
 }
 
+func (h *LibraryElementHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
+	spec := resource["spec"].(map[string]interface{})
+	if val, ok := spec["uid"]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("UID not specified")
+}
+
 // Sort sorts according to handler needs
 func (h *LibraryElementHandler) Sort(resources grizzly.Resources) grizzly.Resources {
 	return resources

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -79,6 +79,14 @@ func (h *AlertNotificationPolicyHandler) GetUID(resource grizzly.Resource) (stri
 	return resource.Name(), nil
 }
 
+func (h *AlertNotificationPolicyHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
+	spec := resource["spec"].(map[string]interface{})
+	if val, ok := spec["XXXXXXX"]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("UID not specified")
+}
+
 // Sort sorts according to handler needs
 func (h *AlertNotificationPolicyHandler) Sort(resources grizzly.Resources) grizzly.Resources {
 	return resources

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -81,6 +81,14 @@ func (h *RuleHandler) GetUID(resource grizzly.Resource) (string, error) {
 	return fmt.Sprintf("%s.%s", resource.GetMetadata("namespace"), resource.Name()), nil
 }
 
+func (h *RuleHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
+	spec := resource["spec"].(map[string]interface{})
+	if val, ok := spec["XXXXXXX"]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("UID not specified")
+}
+
 // Sort sorts according to handler needs
 func (h *RuleHandler) Sort(resources grizzly.Resources) grizzly.Resources {
 	return resources

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -114,6 +114,13 @@ func (h *SyntheticMonitoringHandler) GetUID(resource grizzly.Resource) (string, 
 	}
 	return fmt.Sprintf("%s.%s", resource.GetMetadata("type"), resource.Name()), nil
 }
+func (h *SyntheticMonitoringHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
+	spec := resource["spec"].(map[string]interface{})
+	if val, ok := spec["XXXXXXX"]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("UID not specified")
+}
 
 // Sort sorts according to handler needs
 func (h *SyntheticMonitoringHandler) Sort(resources grizzly.Resources) grizzly.Resources {

--- a/pkg/grizzly/config.go
+++ b/pkg/grizzly/config.go
@@ -12,6 +12,7 @@ type Opts struct {
 	JsonnetPaths []string
 	Targets      []string
 	OutputFormat string
+	IsDir        bool // used internally to denote that the resource path argument pointed at a directory
 
 	// Used for supporting resources without envelopes
 	OnlySpec     bool

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -24,6 +24,9 @@ type Handler interface {
 	// Retrieves a UID for a resource
 	GetUID(resource Resource) (string, error)
 
+	// GetSpecUID retrieves a UID from the spec of a raw resource
+	GetSpecUID(resource Resource) (string, error)
+
 	// Get retrieves JSON for a resource from an endpoint, by UID
 	GetByUID(UID string) (*Resource, error)
 

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -191,11 +191,11 @@ func Show(resources Resources, opts Opts) error {
 		}
 		resource = *(handler.Unprepare(resource))
 
-		format, onlySpec, err := getOutputFormat(opts)
+		format, _, err := getOutputFormat(opts)
 		if err != nil {
 			return err
 		}
-		content, _, _, err := Format("", &resource, format, onlySpec)
+		content, _, _, err := Format("", &resource, format, false) // we always show full resource, even if only-spec was specified
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When a resource (likely a dashboard) is provided in `only-spec` format, then Grizzly needs a way to deduce
the UID. This provides that functionality.

It also adds the ability for mutation of `Opts`, which allows parsing to identify whether a file or a directory
was parsed. This will be useful later.﻿
