### PR TITLE
Remove handler boilerplate by defining a "base handler"

### DIFF
--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -16,24 +16,14 @@ import (
 
 // AlertRuleGroupHandler is a Grizzly Handler for Grafana alertRuleGroups
 type AlertRuleGroupHandler struct {
-	Provider grizzly.Provider
+	grizzly.BaseHandler
 }
 
 // NewAlertRuleGroupHandler returns a new Grizzly Handler for Grafana alertRuleGroups
 func NewAlertRuleGroupHandler(provider grizzly.Provider) *AlertRuleGroupHandler {
 	return &AlertRuleGroupHandler{
-		Provider: provider,
+		BaseHandler: grizzly.NewBaseHandler(provider, "AlertRuleGroup", false),
 	}
-}
-
-// Kind returns the kind for this handler
-func (h *AlertRuleGroupHandler) Kind() string {
-	return "AlertRuleGroup"
-}
-
-// APIVersion returns group and version of the provider of this resource
-func (h *AlertRuleGroupHandler) APIVersion() string {
-	return h.Provider.APIVersion()
 }
 
 const (
@@ -54,16 +44,6 @@ func (h *AlertRuleGroupHandler) Parse(m manifest.Manifest) (grizzly.Resources, e
 	return grizzly.Resources{resource}, nil
 }
 
-// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
-func (h *AlertRuleGroupHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
-	return &resource
-}
-
-// Prepare gets a resource ready for dispatch to the remote endpoint
-func (h *AlertRuleGroupHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	return &resource
-}
-
 // Validate checks that the uid format is valid
 func (h *AlertRuleGroupHandler) Validate(resource grizzly.Resource) error {
 	data, err := json.Marshal(resource.Spec())
@@ -82,22 +62,12 @@ func (h *AlertRuleGroupHandler) Validate(resource grizzly.Resource) error {
 	return nil
 }
 
-// GetUID returns the UID for a resource
-func (h *AlertRuleGroupHandler) GetUID(resource grizzly.Resource) (string, error) {
-	return resource.Name(), nil
-}
-
 func (h *AlertRuleGroupHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
 	spec := resource["spec"].(map[string]interface{})
 	if val, ok := spec["name"]; ok {
 		return val.(string), nil
 	}
 	return "", fmt.Errorf("UID not specified")
-}
-
-// Sort sorts according to handler needs
-func (h *AlertRuleGroupHandler) Sort(resources grizzly.Resources) grizzly.Resources {
-	return resources
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
@@ -123,11 +93,6 @@ func (h *AlertRuleGroupHandler) Add(resource grizzly.Resource) error {
 // Update pushes a alertRuleGroup to Grafana via the API
 func (h *AlertRuleGroupHandler) Update(existing, resource grizzly.Resource) error {
 	return h.putAlertRuleGroup(resource)
-}
-
-// UsesFolders identifies whether this resource lives within a folder
-func (h *AlertRuleGroupHandler) UsesFolders() bool {
-	return false
 }
 
 // getRemoteAlertRuleGroup retrieves a alertRuleGroup object from Grafana

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -14,24 +14,14 @@ import (
 
 // AlertContactPointHandler is a Grizzly Handler for Grafana contactPoints
 type AlertContactPointHandler struct {
-	Provider grizzly.Provider
+	grizzly.BaseHandler
 }
 
 // NewAlertContactPointHandler returns a new Grizzly Handler for Grafana contactPoints
 func NewAlertContactPointHandler(provider grizzly.Provider) *AlertContactPointHandler {
 	return &AlertContactPointHandler{
-		Provider: provider,
+		BaseHandler: grizzly.NewBaseHandler(provider, "AlertContactPoint", false),
 	}
-}
-
-// Kind returns the kind for this handler
-func (h *AlertContactPointHandler) Kind() string {
-	return "AlertContactPoint"
-}
-
-// APIVersion returns group and version of the provider of this resource
-func (h *AlertContactPointHandler) APIVersion() string {
-	return h.Provider.APIVersion()
 }
 
 const (
@@ -53,16 +43,6 @@ func (h *AlertContactPointHandler) Parse(m manifest.Manifest) (grizzly.Resources
 	return grizzly.Resources{resource}, nil
 }
 
-// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
-func (h *AlertContactPointHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
-	return &resource
-}
-
-// Prepare gets a resource ready for dispatch to the remote endpoint
-func (h *AlertContactPointHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	return &resource
-}
-
 // Validate returns the uid of resource
 func (h *AlertContactPointHandler) Validate(resource grizzly.Resource) error {
 	uid, exist := resource.GetSpecString("uid")
@@ -74,22 +54,12 @@ func (h *AlertContactPointHandler) Validate(resource grizzly.Resource) error {
 	return nil
 }
 
-// GetUID returns the UID for a resource
-func (h *AlertContactPointHandler) GetUID(resource grizzly.Resource) (string, error) {
-	return resource.Name(), nil
-}
-
 func (h *AlertContactPointHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
 	spec := resource["spec"].(map[string]interface{})
 	if val, ok := spec["uid"]; ok {
 		return val.(string), nil
 	}
 	return "", fmt.Errorf("UID not specified")
-}
-
-// Sort sorts according to handler needs
-func (h *AlertContactPointHandler) Sort(resources grizzly.Resources) grizzly.Resources {
-	return resources
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
@@ -115,11 +85,6 @@ func (h *AlertContactPointHandler) Add(resource grizzly.Resource) error {
 // Update pushes a contactPoint to Grafana via the API
 func (h *AlertContactPointHandler) Update(existing, resource grizzly.Resource) error {
 	return h.putContactPoint(resource)
-}
-
-// UsesFolders identifies whether this resource lives within a folder
-func (h *AlertContactPointHandler) UsesFolders() bool {
-	return false
 }
 
 // getRemoteContactPoint retrieves a contactPoint object from Grafana

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -20,24 +20,14 @@ const generalFolderUID = "general"
 
 // DashboardHandler is a Grizzly Handler for Grafana dashboards
 type DashboardHandler struct {
-	Provider grizzly.Provider
+	grizzly.BaseHandler
 }
 
 // NewDashboardHandler returns configuration defining a new Grafana Dashboard Handler
 func NewDashboardHandler(provider grizzly.Provider) *DashboardHandler {
 	return &DashboardHandler{
-		Provider: provider,
+		BaseHandler: grizzly.NewBaseHandler(provider, "Dashboard", true),
 	}
-}
-
-// Kind returns the name for this handler
-func (h *DashboardHandler) Kind() string {
-	return "Dashboard"
-}
-
-// APIVersion returns the group and version for the provider of which this handler is a part
-func (h *DashboardHandler) APIVersion() string {
-	return h.Provider.APIVersion()
 }
 
 const (
@@ -87,22 +77,12 @@ func (h *DashboardHandler) Validate(resource grizzly.Resource) error {
 	return nil
 }
 
-// GetUID returns the UID for a resource
-func (h *DashboardHandler) GetUID(resource grizzly.Resource) (string, error) {
-	return resource.Name(), nil
-}
-
 func (h *DashboardHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
 	spec := resource["spec"].(map[string]interface{})
 	if val, ok := spec["uid"]; ok {
 		return val.(string), nil
 	}
 	return "", fmt.Errorf("UID not specified")
-}
-
-// Sort sorts according to handler needs
-func (h *DashboardHandler) Sort(resources grizzly.Resources) grizzly.Resources {
-	return resources
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
@@ -153,11 +133,6 @@ func (h *DashboardHandler) Preview(resource grizzly.Resource, opts *grizzly.Prev
 		notifier.Error(resource, "delete: "+s.DeleteURL)
 	}
 	return nil
-}
-
-// UsesFolders identifies whether this resource lives within a folder
-func (h *DashboardHandler) UsesFolders() bool {
-	return true
 }
 
 // getRemoteDashboard retrieves a dashboard object from Grafana

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -18,24 +18,14 @@ import (
 
 // DatasourceHandler is a Grizzly Handler for Grafana datasources
 type DatasourceHandler struct {
-	Provider grizzly.Provider
+	grizzly.BaseHandler
 }
 
 // NewDatasourceHandler returns a new Grizzly Handler for Grafana datasources
 func NewDatasourceHandler(provider grizzly.Provider) *DatasourceHandler {
 	return &DatasourceHandler{
-		Provider: provider,
+		BaseHandler: grizzly.NewBaseHandler(provider, "Datasource", false),
 	}
-}
-
-// Kind returns the kind for this handler
-func (h *DatasourceHandler) Kind() string {
-	return "Datasource"
-}
-
-// APIVersion returns group and version of the provider of this resource
-func (h *DatasourceHandler) APIVersion() string {
-	return h.Provider.APIVersion()
 }
 
 const (
@@ -103,22 +93,12 @@ func (h *DatasourceHandler) Validate(resource grizzly.Resource) error {
 	return nil
 }
 
-// GetUID returns the UID for a resource
-func (h *DatasourceHandler) GetUID(resource grizzly.Resource) (string, error) {
-	return resource.Name(), nil
-}
-
 func (h *DatasourceHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
 	spec := resource["spec"].(map[string]interface{})
 	if val, ok := spec["uid"]; ok {
 		return val.(string), nil
 	}
 	return "", fmt.Errorf("UID not specified")
-}
-
-// Sort sorts according to handler needs
-func (h *DatasourceHandler) Sort(resources grizzly.Resources) grizzly.Resources {
-	return resources
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
@@ -144,11 +124,6 @@ func (h *DatasourceHandler) Add(resource grizzly.Resource) error {
 // Update pushes a datasource to Grafana via the API
 func (h *DatasourceHandler) Update(existing, resource grizzly.Resource) error {
 	return h.putDatasource(resource)
-}
-
-// UsesFolders identifies whether this resource lives within a folder
-func (h *DatasourceHandler) UsesFolders() bool {
-	return false
 }
 
 // getRemoteDatasource retrieves a datasource object from Grafana

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -17,24 +17,14 @@ import (
 
 // FolderHandler is a Grizzly Handler for Grafana dashboard folders
 type FolderHandler struct {
-	Provider grizzly.Provider
+	grizzly.BaseHandler
 }
 
 // NewFolderHandler returns configuration defining a new Grafana Folder Handler
 func NewFolderHandler(provider grizzly.Provider) *FolderHandler {
 	return &FolderHandler{
-		Provider: provider,
+		BaseHandler: grizzly.NewBaseHandler(provider, "DashboardFolder", false),
 	}
-}
-
-// Kind returns the name for this handler
-func (h *FolderHandler) Kind() string {
-	return "DashboardFolder"
-}
-
-// APIVersion returns the group and version for the provider of which this handler is a part
-func (h *FolderHandler) APIVersion() string {
-	return h.Provider.APIVersion()
 }
 
 const (
@@ -56,16 +46,6 @@ func (h *FolderHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
 	return grizzly.Resources{resource}, nil
 }
 
-// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
-func (h *FolderHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
-	return &resource
-}
-
-// Prepare gets a resource ready for dispatch to the remote endpoint
-func (h *FolderHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	return &resource
-}
-
 // Validate returns the uid of resource
 func (h *FolderHandler) Validate(resource grizzly.Resource) error {
 	uid, exist := resource.GetSpecString("uid")
@@ -76,11 +56,6 @@ func (h *FolderHandler) Validate(resource grizzly.Resource) error {
 	}
 
 	return nil
-}
-
-// GetUID returns the UID for a resource
-func (h *FolderHandler) GetUID(resource grizzly.Resource) (string, error) {
-	return resource.Name(), nil
 }
 
 func (h *FolderHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
@@ -160,11 +135,6 @@ func (h *FolderHandler) Add(resource grizzly.Resource) error {
 // Update pushes a folder to Grafana via the API
 func (h *FolderHandler) Update(existing, resource grizzly.Resource) error {
 	return h.putFolder(resource)
-}
-
-// UsesFolders identifies whether this resource lives within a folder
-func (h *FolderHandler) UsesFolders() bool {
-	return false
 }
 
 // getRemoteFolder retrieves a folder object from Grafana

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -15,7 +15,7 @@ import (
 
 // LibraryElementHandler is a Grizzly Handler for Grafana dashboard folders
 type LibraryElementHandler struct {
-	Provider grizzly.Provider
+	grizzly.BaseHandler
 }
 
 var _ grizzly.Handler = &LibraryElementHandler{}
@@ -23,18 +23,8 @@ var _ grizzly.Handler = &LibraryElementHandler{}
 // NewLibraryElementHandler returns configuration defining a new Grafana Library Element Handler
 func NewLibraryElementHandler(provider grizzly.Provider) *LibraryElementHandler {
 	return &LibraryElementHandler{
-		Provider: provider,
+		BaseHandler: grizzly.NewBaseHandler(provider, "LibraryElement", false),
 	}
-}
-
-// Kind returns the name for this handler
-func (h *LibraryElementHandler) Kind() string {
-	return "LibraryElement"
-}
-
-// APIVersion returns the group and version for the provider of which this handler is a part
-func (h *LibraryElementHandler) APIVersion() string {
-	return h.Provider.APIVersion()
 }
 
 const (
@@ -95,22 +85,12 @@ func (h *LibraryElementHandler) Validate(resource grizzly.Resource) error {
 	return nil
 }
 
-// GetUID returns the UID for a resource
-func (h *LibraryElementHandler) GetUID(resource grizzly.Resource) (string, error) {
-	return resource.Name(), nil
-}
-
 func (h *LibraryElementHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
 	spec := resource["spec"].(map[string]interface{})
 	if val, ok := spec["uid"]; ok {
 		return val.(string), nil
 	}
 	return "", fmt.Errorf("UID not specified")
-}
-
-// Sort sorts according to handler needs
-func (h *LibraryElementHandler) Sort(resources grizzly.Resources) grizzly.Resources {
-	return resources
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
@@ -141,11 +121,6 @@ func (h *LibraryElementHandler) Add(resource grizzly.Resource) error {
 // Update pushes an element to Grafana via the API
 func (h *LibraryElementHandler) Update(existing, resource grizzly.Resource) error {
 	return h.updateElement(existing, resource)
-}
-
-// UsesFolders identifies whether this resource lives within a folder
-func (h *LibraryElementHandler) UsesFolders() bool {
-	return false
 }
 
 func (h *LibraryElementHandler) listElements() ([]string, error) {

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -18,24 +18,14 @@ const (
 
 // AlertNotificationPolicyHandler is a Grizzly Handler for Grafana alertNotificationPolicies
 type AlertNotificationPolicyHandler struct {
-	Provider grizzly.Provider
+	grizzly.BaseHandler
 }
 
 // NewAlertNotificationPolicyHandler returns a new Grizzly Handler for Grafana alertNotificationPolicies
 func NewAlertNotificationPolicyHandler(provider grizzly.Provider) *AlertNotificationPolicyHandler {
 	return &AlertNotificationPolicyHandler{
-		Provider: provider,
+		BaseHandler: grizzly.NewBaseHandler(provider, "AlertNotificationPolicy", false),
 	}
-}
-
-// Kind returns the kind for this handler
-func (h *AlertNotificationPolicyHandler) Kind() string {
-	return "AlertNotificationPolicy"
-}
-
-// APIVersion returns group and version of the provider of this resource
-func (h *AlertNotificationPolicyHandler) APIVersion() string {
-	return h.Provider.APIVersion()
 }
 
 const (
@@ -56,16 +46,6 @@ func (h *AlertNotificationPolicyHandler) Parse(m manifest.Manifest) (grizzly.Res
 	return grizzly.Resources{resource}, h.Validate(resource)
 }
 
-// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
-func (h *AlertNotificationPolicyHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
-	return &resource
-}
-
-// Prepare gets a resource ready for dispatch to the remote endpoint
-func (h *AlertNotificationPolicyHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	return &resource
-}
-
 // Validate returns the uid of resource
 func (h *AlertNotificationPolicyHandler) Validate(resource grizzly.Resource) error {
 	if resource.Name() != GlobalAlertNotificationPolicyName {
@@ -74,22 +54,12 @@ func (h *AlertNotificationPolicyHandler) Validate(resource grizzly.Resource) err
 	return nil
 }
 
-// GetUID returns the UID for a resource
-func (h *AlertNotificationPolicyHandler) GetUID(resource grizzly.Resource) (string, error) {
-	return resource.Name(), nil
-}
-
 func (h *AlertNotificationPolicyHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
 	spec := resource["spec"].(map[string]interface{})
 	if val, ok := spec["XXXXXXX"]; ok {
 		return val.(string), nil
 	}
 	return "", fmt.Errorf("UID not specified")
-}
-
-// Sort sorts according to handler needs
-func (h *AlertNotificationPolicyHandler) Sort(resources grizzly.Resources) grizzly.Resources {
-	return resources
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
@@ -115,11 +85,6 @@ func (h *AlertNotificationPolicyHandler) Add(resource grizzly.Resource) error {
 // Update pushes a alertNotificationPolicy to Grafana via the API
 func (h *AlertNotificationPolicyHandler) Update(existing, resource grizzly.Resource) error {
 	return h.putAlertNotificationPolicy(resource)
-}
-
-// UsesFolders identifies whether this resource lives within a folder
-func (h *AlertNotificationPolicyHandler) UsesFolders() bool {
-	return false
 }
 
 // getRemoteAlertNotificationPolicy retrieves a alertNotificationPolicy object from Grafana

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -16,24 +16,14 @@ import (
 
 // RuleHandler is a Grizzly Handler for Prometheus Rules
 type RuleHandler struct {
-	Provider grizzly.Provider
+	grizzly.BaseHandler
 }
 
 // NewRuleHandler returns a new Grizzly Handler for Prometheus Rules
 func NewRuleHandler(provider grizzly.Provider) *RuleHandler {
 	return &RuleHandler{
-		Provider: provider,
+		BaseHandler: grizzly.NewBaseHandler(provider, "PrometheusRuleGroup", false),
 	}
-}
-
-// Kind returns the name for this handler
-func (h *RuleHandler) Kind() string {
-	return "PrometheusRuleGroup"
-}
-
-// APIVersion returns the group and version for the provider of which this handler is a part
-func (h *RuleHandler) APIVersion() string {
-	return h.Provider.APIVersion()
 }
 
 const (
@@ -52,16 +42,6 @@ func (h *RuleHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
 		return nil, err
 	}
 	return grizzly.Resources{resource}, nil
-}
-
-// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
-func (h *RuleHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
-	return &resource
-}
-
-// Prepare gets a resource ready for dispatch to the remote endpoint
-func (h *RuleHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	return &resource
 }
 
 // Validate returns the uid of resource
@@ -89,11 +69,6 @@ func (h *RuleHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
 	return "", fmt.Errorf("UID not specified")
 }
 
-// Sort sorts according to handler needs
-func (h *RuleHandler) Sort(resources grizzly.Resources) grizzly.Resources {
-	return resources
-}
-
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *RuleHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 	return h.getRemoteRuleGroup(UID)
@@ -118,11 +93,6 @@ func (h *RuleHandler) Add(resource grizzly.Resource) error {
 // Update pushes a datasource to Grafana via the API
 func (h *RuleHandler) Update(existing, resource grizzly.Resource) error {
 	return h.writeRuleGroup(resource)
-}
-
-// UsesFolders identifies whether this resource lives within a folder
-func (h *RuleHandler) UsesFolders() bool {
-	return false
 }
 
 var cortexTool = func(mimirConfig *config.MimirConfig, args ...string) ([]byte, error) {

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -39,24 +39,14 @@ type Probes struct {
 
 // SyntheticMonitoringHandler is a Grizzly Handler for Grafana Synthetic Monitoring
 type SyntheticMonitoringHandler struct {
-	Provider grizzly.Provider
+	grizzly.BaseHandler
 }
 
 // NewSyntheticMonitoringHandler returns a Grizzly Handler for Grafana Synthetic Monitoring
 func NewSyntheticMonitoringHandler(provider grizzly.Provider) *SyntheticMonitoringHandler {
 	return &SyntheticMonitoringHandler{
-		Provider: provider,
+		BaseHandler: grizzly.NewBaseHandler(provider, "SyntheticMonitoringCheck", false),
 	}
-}
-
-// Kind returns the name for this handler
-func (h *SyntheticMonitoringHandler) Kind() string {
-	return "SyntheticMonitoringCheck"
-}
-
-// APIVersion returns the group and version for the provider of which this handler is a part
-func (h *SyntheticMonitoringHandler) APIVersion() string {
-	return h.Provider.APIVersion()
 }
 
 const (
@@ -122,11 +112,6 @@ func (h *SyntheticMonitoringHandler) GetSpecUID(resource grizzly.Resource) (stri
 	return "", fmt.Errorf("UID not specified")
 }
 
-// Sort sorts according to handler needs
-func (h *SyntheticMonitoringHandler) Sort(resources grizzly.Resources) grizzly.Resources {
-	return resources
-}
-
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
 func (h *SyntheticMonitoringHandler) GetByUID(UID string) (*grizzly.Resource, error) {
 	return h.getRemoteCheck(UID)
@@ -151,11 +136,6 @@ func (h *SyntheticMonitoringHandler) Add(resource grizzly.Resource) error {
 // Update pushes an updated check to the SyntheticMonitoring endpoing
 func (h *SyntheticMonitoringHandler) Update(existing, resource grizzly.Resource) error {
 	return h.updateCheck(resource)
-}
-
-// UsesFolders identifies whether this resource lives within a folder
-func (h *SyntheticMonitoringHandler) UsesFolders() bool {
-	return false
 }
 
 // NewSyntheticMonitoringClient creates a new client for synthetic monitoring go client

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -4,6 +4,48 @@ import (
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
 
+type BaseHandler struct {
+	Provider    Provider
+	kind        string
+	usesFolders bool
+}
+
+func NewBaseHandler(provider Provider, kind string, usesFolders bool) BaseHandler {
+	return BaseHandler{
+		Provider:    provider,
+		kind:        kind,
+		usesFolders: usesFolders,
+	}
+}
+
+func (h *BaseHandler) Kind() string {
+	return h.kind
+}
+
+func (h *BaseHandler) APIVersion() string {
+	return h.Provider.APIVersion()
+}
+
+func (h *BaseHandler) UsesFolders() bool {
+	return h.usesFolders
+}
+
+func (h *BaseHandler) Unprepare(resource Resource) *Resource {
+	return &resource
+}
+
+func (h *BaseHandler) Prepare(existing, resource Resource) *Resource {
+	return &resource
+}
+
+func (h *BaseHandler) GetUID(resource Resource) (string, error) {
+	return resource.Name(), nil
+}
+
+func (h *BaseHandler) Sort(resources Resources) Resources {
+	return resources
+}
+
 // Handler describes a handler for a single API resource handled by a single provider
 type Handler interface {
 	APIVersion() string


### PR DESCRIPTION
Lots of the handler functions are just placeholders and used in some contexts 
By using a base handler, we can set defaults that do nothing and can be overridden (shadowed)

If this is accepted, I think I'd do a follow-up where we could switch to TF-provider-style handler provisioning where each handler is a struct of the same type rather than an interface with various attributes that describe it (CRUD+List functions, etc) and it would make it even easier to specify new resource types