### PR TITLE
Make registry non-global

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -27,23 +27,23 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	grizzly.ConfigureProviderRegistry(
+	registry := grizzly.NewRegistry(
 		[]grizzly.Provider{
 			grafana.NewProvider(),
 		})
 
 	// workflow commands
 	rootCmd.AddCommand(
-		getCmd(),
-		listCmd(),
-		pullCmd(),
-		showCmd(),
-		diffCmd(),
-		applyCmd(),
-		watchCmd(),
-		exportCmd(),
-		previewCmd(),
-		providersCmd(),
+		getCmd(registry),
+		listCmd(registry),
+		pullCmd(registry),
+		showCmd(registry),
+		diffCmd(registry),
+		applyCmd(registry),
+		watchCmd(registry),
+		exportCmd(registry),
+		previewCmd(registry),
+		providersCmd(registry),
 		configCmd(),
 	)
 

--- a/integration/dashboard_test.go
+++ b/integration/dashboard_test.go
@@ -52,21 +52,6 @@ func TestDashboard(t *testing.T) {
 		})
 	})
 
-	// Check that the spec must be a map
-	t.Run("Apply dashboard - spec as string", func(t *testing.T) {
-		runTest(t, GrizzlyTest{
-			TestDir:       dir,
-			RunOnContexts: allContexts,
-			Commands: []Command{
-				{
-					Command:             "apply spec-as-string-post.yml",
-					ExpectedCode:        1,
-					ExpectedLogsContain: "resource spec-as-string has an invalid spec. Expected a map, got a value of type string",
-				},
-			},
-		})
-	})
-
 	t.Run("Diff dashboard - success", func(t *testing.T) {
 		runTest(t, GrizzlyTest{
 			TestDir:       dir,

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -174,7 +174,7 @@ func (h *AlertRuleGroupHandler) createAlertRuleGroup(resource grizzly.Resource) 
 
 	for _, r := range group.Rules {
 		if err := h.createAlertRule(r); err != nil {
-			return fmt.Errorf("creating rule for group %s: %w", resource.UID(), err)
+			return fmt.Errorf("creating rule for group %s: %w", resource.Name(), err)
 		}
 	}
 

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -184,7 +184,7 @@ func (h *AlertContactPointHandler) putContactPoint(resource grizzly.Resource) er
 	}
 	stringtrue := "true"
 	params := provisioning.NewPutContactpointParams().
-		WithUID(resource.UID()).
+		WithUID(resource.Name()).
 		WithBody(&modelContactPoint).
 		WithXDisableProvenance(&stringtrue)
 	_, err = client.Provisioning.PutContactpoint(params)

--- a/pkg/grafana/dashboard_test.go
+++ b/pkg/grafana/dashboard_test.go
@@ -83,11 +83,6 @@ func TestDashboard(t *testing.T) {
 	_ = os.Unsetenv("GRAFANA_URL")
 
 	t.Run("Validate/Prepare", func(t *testing.T) {
-		grizzly.ConfigureProviderRegistry(
-			[]grizzly.Provider{
-				NewProvider(),
-			})
-
 		newResource := func(name string, spec map[string]any) grizzly.Resource {
 			resource := grizzly.Resource{
 				"apiVersion": "apiVersion",
@@ -123,25 +118,10 @@ func TestDashboard(t *testing.T) {
 				Resource:            newResource("name1", map[string]any{"uid": "name2"}),
 				ValidateErrorString: "uid 'name2' and name 'name1', don't match",
 			},
-			{
-				Name:                "no name provided",
-				Resource:            newResource("", map[string]any{"uid": "name1"}),
-				ValidateErrorString: "Resource lacks name",
-			},
-			{
-				Name:                "no spec provided",
-				Resource:            newResource("name1", map[string]any{}),
-				ValidateErrorString: "Resource name1 lacks spec",
-			},
-			{
-				Name:                "neither name nor UID provided",
-				Resource:            newResource("", map[string]any{"title": "something"}),
-				ValidateErrorString: "Resource lacks name",
-			},
 		}
 		for _, test := range tests {
 			t.Run(test.Name, func(t *testing.T) {
-				err := test.Resource.Validate()
+				err := handler.Validate(test.Resource)
 				if test.ValidateErrorString != "" {
 					require.Error(t, err)
 					require.Contains(t, err.Error(), test.ValidateErrorString)

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -71,26 +71,26 @@ func (h *FolderHandler) Sort(resources grizzly.Resources) grizzly.Resources {
 	result := grizzly.Resources{}
 	addedToResult := map[string]bool{}
 	for _, resource := range resources {
-		addedToResult[resource.UID()] = false
+		addedToResult[resource.Name()] = false
 	}
 	for {
 		continueLoop := false
 		for _, resource := range resources {
-			if addedToResult[resource.UID()] {
+			if addedToResult[resource.Name()] {
 				// already added
 				continue
 			}
 			parentUID, hasParentUID := resource.Spec()["parentUid"]
 			// Add root folders
 			if !hasParentUID {
-				addedToResult[resource.UID()] = true
+				addedToResult[resource.Name()] = true
 				result = append(result, resource)
 				continue
 			}
 			parentAdded, parentExists := addedToResult[parentUID.(string)]
 			// Add folders with parents which aren't declared in Grizzly, or which have already been added
 			if !parentExists || parentAdded {
-				addedToResult[resource.UID()] = true
+				addedToResult[resource.Name()] = true
 				result = append(result, resource)
 				continue
 			}
@@ -271,7 +271,7 @@ func (h *FolderHandler) putFolder(resource grizzly.Resource) error {
 		return err
 	}
 
-	_, err = client.Folders.UpdateFolder(resource.UID(), &body)
+	_, err = client.Folders.UpdateFolder(resource.Name(), &body)
 	return err
 }
 

--- a/pkg/grafana/folder_test.go
+++ b/pkg/grafana/folder_test.go
@@ -81,10 +81,8 @@ func TestFolders(t *testing.T) {
 }
 
 func TestSortFolders(t *testing.T) {
-	provider := NewProvider()
 	InitialiseTestConfig()
 	handler := NewFolderHandler(NewProvider())
-	grizzly.ConfigureProviderRegistry([]grizzly.Provider{provider})
 	folder := func(uid string, parentUID string) grizzly.Resource {
 		spec := map[string]interface{}{
 			"uid": uid,
@@ -166,7 +164,7 @@ func TestSortFolders(t *testing.T) {
 			sorted := handler.Sort(tc.folders)
 			require.Len(t, sorted, len(tc.expected))
 			for i, resource := range sorted {
-				require.Equal(t, tc.expected[i], resource.UID())
+				require.Equal(t, tc.expected[i], resource.Name())
 			}
 		})
 	}

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -155,7 +155,7 @@ func (h *LibraryElementHandler) updateElement(existing, resource grizzly.Resourc
 	if err != nil {
 		return err
 	}
-	_, err = client.LibraryElements.UpdateLibraryElement(resource.UID(), &command)
+	_, err = client.LibraryElements.UpdateLibraryElement(resource.Name(), &command)
 	return err
 }
 

--- a/pkg/grafana/rules_test.go
+++ b/pkg/grafana/rules_test.go
@@ -19,11 +19,6 @@ func TestRules(t *testing.T) {
 	InitialiseTestConfig()
 	provider := NewProvider()
 	h := NewRuleHandler(provider)
-	grizzly.ConfigureProviderRegistry(
-		[]grizzly.Provider{
-			provider,
-		})
-
 	t.Run("get remote rule group", func(t *testing.T) {
 		mockCortexTool(t, "testdata/list_rules.yaml", nil)
 
@@ -35,9 +30,6 @@ func TestRules(t *testing.T) {
 		require.Equal(t, "first_rules.grizzly_alerts", uid)
 		require.Equal(t, "first_rules", res.GetMetadata("namespace"))
 		require.Equal(t, "PrometheusRuleGroup", res.Kind())
-		key := res.Key()
-		require.NoError(t, err)
-		require.Equal(t, "PrometheusRuleGroup.first_rules.grizzly_alerts", key)
 	})
 
 	t.Run("get remote rule group - error from cortextool client", func(t *testing.T) {

--- a/pkg/grafana/utils_test.go
+++ b/pkg/grafana/utils_test.go
@@ -5,7 +5,6 @@ import (
 
 	gclient "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/models"
-	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,11 +13,6 @@ func TestExtractFolderUID(t *testing.T) {
 
 	client, err := provider.Client()
 	require.NoError(t, err)
-
-	grizzly.ConfigureProviderRegistry(
-		[]grizzly.Provider{
-			&Provider{client: client},
-		})
 
 	t.Run("extract folder uid successfully - uid exists", func(t *testing.T) {
 		meta := models.DashboardMeta{

--- a/pkg/grizzly/formatting.go
+++ b/pkg/grizzly/formatting.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-func Format(resourcePath string, resource *Resource, format string, onlySpec bool) ([]byte, string, string, error) {
+func Format(registry Registry, resourcePath string, resource *Resource, format string, onlySpec bool) ([]byte, string, string, error) {
 	var content string
 	var filename string
 	var extension string
@@ -20,21 +20,21 @@ func Format(resourcePath string, resource *Resource, format string, onlySpec boo
 	switch format {
 	case "yaml":
 		extension = "yaml"
-		filename, err = getFilename(resourcePath, resource, extension)
+		filename, err = getFilename(registry, resourcePath, resource, extension)
 		if err != nil {
 			return nil, "", "", err
 		}
 		content, err = spec.YAML()
 	case "json":
 		extension = "json"
-		filename, err = getFilename(resourcePath, resource, extension)
+		filename, err = getFilename(registry, resourcePath, resource, extension)
 		if err != nil {
 			return nil, "", "", err
 		}
 		content, err = spec.JSON()
 	default:
 		extension = "yaml"
-		filename, err = getFilename(resourcePath, resource, extension)
+		filename, err = getFilename(registry, resourcePath, resource, extension)
 		if err != nil {
 			return nil, "", "", err
 		}
@@ -43,8 +43,8 @@ func Format(resourcePath string, resource *Resource, format string, onlySpec boo
 	return []byte(content), filename, extension, err
 }
 
-func getFilename(resourcePath string, resource *Resource, extension string) (string, error) {
-	handler, err := Registry.GetHandler(resource.Kind())
+func getFilename(registry Registry, resourcePath string, resource *Resource, extension string) (string, error) {
+	handler, err := registry.GetHandler(resource.Kind())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/grizzly/parsing_test.go
+++ b/pkg/grizzly/parsing_test.go
@@ -1,0 +1,102 @@
+package grizzly_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grizzly/pkg/grizzly"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateEnvelope(t *testing.T) {
+	t.Run("Validate/Prepare", func(t *testing.T) {
+		kind := "some-kind"
+		metadata := map[string]any{
+			"name": "a-name",
+		}
+		spec := map[string]any{
+			"uid": "a-uid",
+		}
+
+		tests := []struct {
+			Name          string
+			Resource      grizzly.Resource
+			ExpectedError string
+		}{
+			{
+				Name: "missing kind",
+				Resource: map[string]any{
+					"metadata": metadata,
+					"spec":     spec,
+				},
+				ExpectedError: "kind missing",
+			},
+			{
+				Name: "missing metadata",
+				Resource: map[string]any{
+					"kind": kind,
+					"spec": spec,
+				},
+				ExpectedError: "metadata missing",
+			},
+			{
+				Name: "missing name",
+				Resource: map[string]any{
+					"kind":     kind,
+					"metadata": map[string]any{},
+					"spec":     spec,
+				},
+				ExpectedError: "metadata/name missing",
+			},
+			{
+				Name: "missing spec",
+				Resource: map[string]any{
+					"kind":     kind,
+					"metadata": metadata,
+				},
+				ExpectedError: "spec missing",
+			},
+			{
+				Name: "empty spec",
+				Resource: map[string]any{
+					"kind":     kind,
+					"metadata": metadata,
+					"spec":     map[string]any{},
+				},
+				ExpectedError: "spec should not be empty",
+			},
+			{
+				Name: "invalid spec",
+				Resource: map[string]any{
+					"kind":     kind,
+					"metadata": metadata,
+					"spec":     "a string spec",
+				},
+				ExpectedError: "spec is not a map",
+			},
+			{
+				Name:          "empty resource",
+				Resource:      map[string]any{},
+				ExpectedError: "kind missing, metadata missing, spec missing",
+			},
+			{
+				Name: "everything correct",
+				Resource: map[string]any{
+					"kind":     kind,
+					"metadata": metadata,
+					"spec":     spec,
+				},
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.Name, func(t *testing.T) {
+				err := grizzly.ValidateEnvelope(test.Resource)
+				if test.ExpectedError != "" {
+					require.Error(t, err)
+					require.Equal(t, err.Error(), "errors parsing resource: "+test.ExpectedError)
+					return
+				}
+				require.NoError(t, err)
+			})
+		}
+	})
+}

--- a/pkg/grizzly/workflow_test.go
+++ b/pkg/grizzly/workflow_test.go
@@ -15,7 +15,7 @@ import (
 func TestPull(t *testing.T) {
 	InitialiseTestConfig()
 	provider := grafana.NewProvider()
-	grizzly.ConfigureProviderRegistry(
+	registry := grizzly.NewRegistry(
 		[]grizzly.Provider{
 			provider,
 		})
@@ -34,7 +34,7 @@ func TestPull(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
-		err = grizzly.Pull(path, opts)
+		err = grizzly.Pull(registry, path, opts)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "pull <resource-path> must be a directory")
 	})
@@ -46,7 +46,7 @@ func TestPull(t *testing.T) {
 		err := os.MkdirAll(path, 0755)
 		require.NoError(t, err)
 
-		err = grizzly.Pull(path, opts)
+		err = grizzly.Pull(registry, path, opts)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, numOfFiles(path))
 	})
@@ -55,7 +55,7 @@ func TestPull(t *testing.T) {
 		t.Parallel()
 
 		path := filepath.Join(t.TempDir(), filepath.Base(t.Name()))
-		err := grizzly.Pull(path, opts)
+		err := grizzly.Pull(registry, path, opts)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, numOfFiles(path))
 	})


### PR DESCRIPTION
Currently, the registry is a global. This is (a) not ideal and (b) will likely
lead to issues later on.

The PR also clears up some old issues (e.g. the Resource type referencing
Handlers, and some funcs e.g. Key() which are not used anymore.﻿
