### PR TITLE
Consistent parsing for all types

### DIFF
--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -36,7 +35,7 @@ func (h *AlertRuleGroupHandler) ResourceFilePath(resource grizzly.Resource, file
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *AlertRuleGroupHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+func (h *AlertRuleGroupHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -34,7 +33,7 @@ func (h *AlertContactPointHandler) ResourceFilePath(resource grizzly.Resource, f
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *AlertContactPointHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+func (h *AlertContactPointHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/grizzly/pkg/grizzly/notifier"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
@@ -46,7 +45,7 @@ func (h *DashboardHandler) ResourceFilePath(resource grizzly.Resource, filetype 
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *DashboardHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+func (h *DashboardHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/grafana/grizzly/pkg/grizzly"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 
 	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -38,7 +37,7 @@ func (h *DatasourceHandler) ResourceFilePath(resource grizzly.Resource, filetype
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+func (h *DatasourceHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
@@ -63,7 +62,7 @@ func (h *DatasourceHandler) Parse(m manifest.Manifest) (grizzly.Resources, error
 			spec[k] = defaults[k]
 		}
 	}
-	spec["uid"] = m.Metadata().Name()
+	spec["uid"] = resource.Name()
 	resource["spec"] = spec
 	return grizzly.Resources{resource}, nil
 }

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 
 	gclient "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
@@ -37,7 +36,7 @@ func (h *FolderHandler) ResourceFilePath(resource grizzly.Resource, filetype str
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *FolderHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+func (h *FolderHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 
 	library "github.com/grafana/grafana-openapi-client-go/client/library_elements"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -46,7 +45,7 @@ func (h *LibraryElementHandler) ResourceFilePath(resource grizzly.Resource, file
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *LibraryElementHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+func (h *LibraryElementHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -38,7 +37,7 @@ func (h *AlertNotificationPolicyHandler) ResourceFilePath(resource grizzly.Resou
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *AlertNotificationPolicyHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+func (h *AlertNotificationPolicyHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err

--- a/pkg/grafana/rules-handler.go
+++ b/pkg/grafana/rules-handler.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/grizzly"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 	"gopkg.in/yaml.v3"
 )
 
@@ -36,7 +35,7 @@ func (h *RuleHandler) ResourceFilePath(resource grizzly.Resource, filetype strin
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *RuleHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+func (h *RuleHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
@@ -226,7 +225,7 @@ func (h *RuleHandler) writeRuleGroup(resource grizzly.Resource) error {
 
 	output, err := cortexTool(&mimirConfig, "rules", "load", tmpfile.Name())
 	if err != nil {
-		log.Println("OUTPUT", output)
+		log.Println(output)
 		return err
 	}
 	os.Remove(tmpfile.Name())

--- a/pkg/grafana/synthetic-monitoring-handler.go
+++ b/pkg/grafana/synthetic-monitoring-handler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 
 	smapi "github.com/grafana/synthetic-monitoring-api-go-client"
 )
@@ -59,7 +58,7 @@ func (h *SyntheticMonitoringHandler) ResourceFilePath(resource grizzly.Resource,
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *SyntheticMonitoringHandler) Parse(m manifest.Manifest) (grizzly.Resources, error) {
+func (h *SyntheticMonitoringHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -2,8 +2,6 @@ package grizzly
 
 import (
 	"net/http"
-
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
 
 type BaseHandler struct {
@@ -61,7 +59,7 @@ type Handler interface {
 	ResourceFilePath(resource Resource, filetype string) string
 
 	// Parse parses a manifest object into a struct for this resource type
-	Parse(m manifest.Manifest) (Resources, error)
+	Parse(m map[string]any) (Resources, error)
 
 	// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 	Unprepare(resource Resource) *Resource

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -9,13 +9,12 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/google/go-jsonnet"
 	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/tanka/pkg/jsonnet/native"
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
-	"github.com/grafana/tanka/pkg/process"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -31,7 +30,7 @@ func Parse(registry Registry, resourcePath string, opts *Opts) (Resources, error
 	}
 	opts.IsDir = true
 
-	var resources Resources
+	var parsedResources Resources
 	files, err := FindResourceFiles(resourcePath)
 	if err != nil {
 		return nil, err
@@ -42,7 +41,18 @@ func Parse(registry Registry, resourcePath string, opts *Opts) (Resources, error
 		if err != nil {
 			return nil, err
 		}
-		resources = append(resources, r...)
+		parsedResources = append(parsedResources, r...)
+	}
+	currentContext, err := config.CurrentContext()
+	if err != nil {
+		return nil, err
+	}
+	var resources Resources
+	targets := currentContext.GetTargets(opts.Targets)
+	for _, parsedResource := range parsedResources {
+		if registry.ResourceMatchesTarget(parsedResource.Kind(), parsedResource.Name(), targets) {
+			resources = append(resources, parsedResource)
+		}
 	}
 	resources = registry.Sort(resources)
 	return resources, nil
@@ -84,28 +94,12 @@ func ParseJSON(registry Registry, resourceFile string, opts Opts) (Resources, er
 	if err != nil {
 		return nil, err
 	}
-	hasEnvelope := DetectEnvelope(m)
-	if !hasEnvelope {
-		kind := registry.Detect(m)
-		if kind == "" {
-			if opts.ResourceKind == "" {
-				return nil, fmt.Errorf("cannot deduce kind of %s", resourceFile)
-			}
-			kind = opts.ResourceKind
-		}
-		resources, err := newOnlySpecResources(registry, m, kind, opts.FolderUID)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing %s: %v", resourceFile, err)
-		}
-		return resources, nil
 
-	} else {
-		resources, err := newWithEnvelopeResources(registry, m)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing %s: %v", resourceFile, err)
-		}
-		return resources, nil
+	resources, err := parseAny(registry, m, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %v", resourceFile, err)
 	}
+	return resources, err
 }
 
 // ParseYAML evaluates a YAML file and parses it into resources
@@ -124,159 +118,15 @@ func ParseYAML(registry Registry, yamlFile string, opts Opts) (Resources, error)
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("xError decoding %s: %v", yamlFile, err)
+			return nil, fmt.Errorf("Error decoding %s: %v", yamlFile, err)
 		}
-		var parsedResources Resources
-
-		var kind string
-		hasEnvelope := DetectEnvelope(m)
-		if !hasEnvelope {
-			kind = registry.Detect(m)
-			if kind == "" {
-				if opts.ResourceKind == "" {
-					return nil, fmt.Errorf("cannot deduce kind of %s", yamlFile)
-				}
-				kind = opts.ResourceKind
-			}
-			parsedResources, err = newOnlySpecResources(registry, m, kind, opts.FolderUID)
-			if err != nil {
-				return nil, fmt.Errorf("Error parsing %s: %v", yamlFile, err)
-			}
-		} else {
-			parsedResources, err = newWithEnvelopeResources(registry, m)
-			if err != nil {
-				return nil, fmt.Errorf("Error parsing %s: %v", yamlFile, err)
-			}
-			kind = parsedResources[0].Kind()
-		}
-		handler, err := registry.GetHandler(kind)
+		parsedResources, err := parseAny(registry, m, opts)
 		if err != nil {
 			return nil, err
 		}
-		currentContext, err := config.CurrentContext()
-		if err != nil {
-			return nil, err
-		}
-		targets := currentContext.GetTargets(opts.Targets)
-		for _, parsedResource := range parsedResources {
-			if registry.ResourceMatchesTarget(handler, parsedResource.Name(), targets) {
-				resources = append(resources, parsedResource)
-			}
-		}
+		resources = append(resources, parsedResources...)
 	}
 	return resources, nil
-}
-
-func newOnlySpecResources(registry Registry, data map[string]any, kind, folderUID string) (Resources, error) {
-	if kind == "" {
-		return nil, fmt.Errorf("Kind (-k) required with --onlyspec")
-	}
-	handler, err := registry.GetHandler(kind)
-	if err != nil {
-		return nil, err
-	}
-	if handler.UsesFolders() && folderUID == "" {
-		return nil, fmt.Errorf("folder (-f) required with --onlyspec")
-	}
-	resource, err := NewResource(handler.APIVersion(), handler.Kind(), "dummy", data)
-	if err != nil {
-		return nil, err
-	}
-	uid, err := handler.GetSpecUID(resource)
-	if err != nil {
-		return nil, err
-	}
-	resource.SetMetadata("name", uid)
-
-	if handler.UsesFolders() {
-		resource.SetMetadata("folder", folderUID)
-	}
-	m := manifest.Manifest(resource)
-	return handler.Parse(m)
-}
-
-func newWithEnvelopeResources(registry Registry, data map[string]any) (Resources, error) {
-	err := ValidateEnvelope(data)
-	if err != nil {
-		return nil, err
-	}
-
-	resource, err := ResourceFromMap(data)
-	if err != nil {
-		return nil, err
-	}
-	handler, err := registry.GetHandler(resource.Kind())
-	if err != nil {
-		return nil, err
-	}
-	m := manifest.Manifest(resource)
-	return handler.Parse(m)
-}
-
-// DetectEnvelope identifies whether this resource is enveloped or not
-func DetectEnvelope(data map[string]any) bool {
-	expectedKeys := []string{
-		"kind",
-		"metadata",
-		"spec",
-	}
-	for _, key := range expectedKeys {
-		_, ok := data[key]
-		if !ok {
-			return false
-		}
-	}
-	return true
-}
-
-// ValidateEnvelope confirms that this resource is a complete enveloped resource
-func ValidateEnvelope(data map[string]any) error {
-	errors := []string{}
-
-	kind, ok := data["kind"]
-	if !ok || kind == "" {
-		errors = append(errors, "kind missing")
-	}
-	metadata, ok := data["metadata"]
-	if !ok {
-		errors = append(errors, "metadata missing")
-	} else {
-		m, ok := metadata.(map[string]interface{})
-		if !ok {
-			errors = append(errors, "Metadata is not a map")
-		} else {
-			name, ok := m["name"]
-			if !ok || name == nil || name == "" {
-				errors = append(errors, "metadata/name missing")
-			} else {
-				n, ok := name.(string)
-				if !ok {
-					errors = append(errors, "metadata/name is not a string")
-				}
-				if n == "" {
-					errors = append(errors, "metadata/name is blank")
-				}
-			}
-		}
-	}
-	spec, ok := data["spec"]
-	if !ok || spec == nil {
-		errors = append(errors, "spec missing")
-	} else {
-		s, ok := spec.(map[string]any)
-		if !ok {
-			errors = append(errors, "spec is not a map")
-		} else {
-			if len(s) == 0 {
-				errors = append(errors, "spec should not be empty")
-			}
-		}
-	}
-
-	if len(errors) > 0 {
-		return fmt.Errorf("errors parsing resource: %s", strings.Join(errors, ", "))
-	}
-	return nil
 }
 
 //go:embed grizzly.jsonnet
@@ -308,41 +158,268 @@ func ParseJsonnet(registry Registry, jsonnetFile string, opts Opts) (Resources, 
 		return nil, err
 	}
 
-	extracted, err := process.Extract(data)
+	resources, err := parseAny(registry, data, opts)
 	if err != nil {
 		return nil, err
 	}
+	return resources, nil
+}
 
-	// Unwrap *List types
-	if err := process.Unwrap(extracted); err != nil {
-		return nil, err
-	}
-	currentContext, err := config.CurrentContext()
-	if err != nil {
-		return nil, err
-	}
-	targets := currentContext.GetTargets(opts.Targets)
-	resources := Resources{}
-	for _, m := range extracted {
-		handler, err := registry.GetHandler(m.Kind())
-		if err != nil {
-			log.Error("Error getting handler: ", err)
-			continue
-		}
-		parsedResources, err := handler.Parse(m)
+func parseAny(registry Registry, data any, opts Opts) (Resources, error) {
+	hasEnvelope := DetectEnvelope(data)
+	if hasEnvelope {
+		m := data.(map[string]any)
+		err := ValidateEnvelope(m)
 		if err != nil {
 			return nil, err
 		}
-		for _, parsedResource := range parsedResources {
-			err := ValidateEnvelope(parsedResource)
-			if err != nil {
-				return nil, err
-			}
 
-			if registry.ResourceMatchesTarget(handler, parsedResource.Name(), targets) {
-				resources = append(resources, parsedResource)
+		resource, err := ResourceFromMap(m)
+		if err != nil {
+			return nil, err
+		}
+		handler, err := registry.GetHandler(resource.Kind())
+		if err != nil {
+			return nil, err
+		}
+		return handler.Parse(resource)
+	}
+	kind := registry.Detect(data)
+	if kind == "" && opts.ResourceKind != "" {
+		kind = opts.ResourceKind
+	}
+	if kind != "" {
+		handler, err := registry.GetHandler(kind)
+		if err != nil {
+			return nil, err
+		}
+		if handler.UsesFolders() && opts.FolderUID == "" {
+			return nil, fmt.Errorf("folder (-f) required with --onlyspec")
+		}
+		m := data.(map[string]any)
+		resource, err := NewResource(handler.APIVersion(), handler.Kind(), "dummy", m)
+		if err != nil {
+			return nil, err
+		}
+		uid, err := handler.GetSpecUID(resource)
+		if err != nil {
+			return nil, err
+		}
+		resource.SetMetadata("name", uid)
+
+		if handler.UsesFolders() {
+			resource.SetMetadata("folder", opts.FolderUID)
+		}
+		return handler.Parse(resource)
+	}
+	walker := walker{}
+	err := walker.Walk(data)
+	return walker.Resources, err
+}
+
+// DetectEnvelope identifies whether this resource is enveloped or not
+func DetectEnvelope(data any) bool {
+	m, ok := data.(map[string]any)
+	if !ok {
+		return false
+	}
+	expectedKeys := []string{
+		"kind",
+		"metadata",
+		"spec",
+	}
+	for _, key := range expectedKeys {
+		_, ok := m[key]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// ValidateEnvelope confirms that this resource is a complete enveloped resource
+func ValidateEnvelope(data any) error {
+	m, ok := data.(map[string]any)
+	if !ok {
+		return fmt.Errorf("resource is not a map")
+	}
+	errors := []string{}
+
+	kind, ok := m["kind"]
+	if !ok || kind == "" {
+		errors = append(errors, "kind missing")
+	}
+	metadata, ok := m["metadata"]
+	if !ok {
+		errors = append(errors, "metadata missing")
+	} else {
+		m, ok := metadata.(map[string]interface{})
+		if !ok {
+			errors = append(errors, "Metadata is not a map")
+		} else {
+			name, ok := m["name"]
+			if !ok || name == nil || name == "" {
+				errors = append(errors, "metadata/name missing")
+			} else {
+				n, ok := name.(string)
+				if !ok {
+					errors = append(errors, "metadata/name is not a string")
+				}
+				if n == "" {
+					errors = append(errors, "metadata/name is blank")
+				}
 			}
 		}
 	}
-	return resources, nil
+	spec, ok := m["spec"]
+	if !ok || spec == nil {
+		errors = append(errors, "spec missing")
+	} else {
+		s, ok := spec.(map[string]any)
+		if !ok {
+			errors = append(errors, "spec is not a map")
+		} else {
+			if len(s) == 0 {
+				errors = append(errors, "spec should not be empty")
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("errors parsing resource: %s", strings.Join(errors, ", "))
+	}
+	return nil
+}
+
+type walker struct {
+	Resources Resources
+}
+
+// Walk scans the raw interface{} for objects that look like enveloped objects and
+// extracts those into a list
+func (w *walker) Walk(raw interface{}) error {
+	if err := w.walkJSON(raw, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// walkJSON recurses into either a map or list, returning a list of all objects that look
+// like kubernetes resources. We support resources at an arbitrary level of nesting, and
+// return an error if a node is not walkable.
+//
+// Handling the different types is quite gross, so we split this method into a generic
+// walkJSON, and then walkObj/walkList to handle the two different types of collection we
+// support.
+func (w *walker) walkJSON(raw interface{}, path trace) error {
+	// check for known types
+	switch v := raw.(type) {
+	case map[string]interface{}:
+		return w.walkObj(v, path)
+	case []interface{}:
+		return w.walkList(v, path)
+	}
+
+	log.Debugf("recursion ended on key %q of type %T which does not belong to a valid Kubernetes object", path.Name(), raw)
+	return ErrorPrimitiveReached{
+		path:      path.Base(),
+		key:       path.Name(),
+		primitive: raw,
+	}
+}
+
+func (w *walker) walkList(list []interface{}, path trace) error {
+	for idx, value := range list {
+		err := w.walkJSON(value, append(path, fmt.Sprintf("[%d]", idx)))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *walker) walkObj(obj map[string]any, path trace) error {
+
+	// This looks like a kubernetes manifest, so make one and return it
+	validateErr := ValidateEnvelope(obj)
+	if validateErr != nil {
+		// this is not an envelope, skip.
+	} else {
+		resource, err := ResourceFromMap(obj)
+		if err != nil {
+			return err
+		}
+
+		w.Resources = append(w.Resources, resource)
+		return nil
+	}
+
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		path := append(path, key)
+		if obj[key] == nil { // result from false if condition in Jsonnet
+			continue
+		}
+		err := w.walkJSON(obj[key], path)
+		if err != nil {
+			return err.(ErrorPrimitiveReached).WithContainingObj(obj, validateErr)
+		}
+	}
+
+	return nil
+}
+
+type trace []string
+
+func (t trace) Full() string {
+	return "." + strings.Join(t, ".")
+}
+
+func (t trace) Base() string {
+	if len(t) > 0 {
+		t = t[:len(t)-1]
+	}
+	return "." + strings.Join(t, ".")
+}
+
+func (t trace) Name() string {
+	if len(t) > 0 {
+		return t[len(t)-1]
+	}
+
+	return ""
+}
+
+// ErrorPrimitiveReached occurs when walkJSON reaches the end of nested dicts without finding a valid Kubernetes manifest
+type ErrorPrimitiveReached struct {
+	path, key        string
+	primitive        interface{}
+	containingObj    map[string]any
+	containingObjErr error
+}
+
+func (e ErrorPrimitiveReached) WithContainingObj(obj map[string]any, err error) ErrorPrimitiveReached {
+	if e.containingObj == nil {
+		e.containingObj = obj
+		e.containingObjErr = err
+	}
+	return e
+}
+
+func (e ErrorPrimitiveReached) Error() string {
+	errMessage := fmt.Sprintf(`found invalid object (at %s): %s`, e.path, e.containingObjErr)
+
+	container, err := yaml.Marshal(e.containingObj)
+	if err != nil {
+		log.Errorf("failed to marshal invalid object: %s", err)
+	} else {
+		errMessage += "\n\n" + string(container)
+	}
+
+	return errMessage
 }

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -297,7 +297,7 @@ func (w *walker) Walk(raw interface{}) error {
 }
 
 // walkJSON recurses into either a map or list, returning a list of all objects that look
-// like kubernetes resources. We support resources at an arbitrary level of nesting, and
+// like envelopedresources. We support resources at an arbitrary level of nesting, and
 // return an error if a node is not walkable.
 //
 // Handling the different types is quite gross, so we split this method into a generic
@@ -312,7 +312,7 @@ func (w *walker) walkJSON(raw interface{}, path trace) error {
 		return w.walkList(v, path)
 	}
 
-	log.Debugf("recursion ended on key %q of type %T which does not belong to a valid Kubernetes object", path.Name(), raw)
+	log.Debugf("recursion ended on key %q of type %T which does not belong to a valid resource", path.Name(), raw)
 	return ErrorPrimitiveReached{
 		path:      path.Base(),
 		key:       path.Name(),
@@ -332,7 +332,6 @@ func (w *walker) walkList(list []interface{}, path trace) error {
 
 func (w *walker) walkObj(obj map[string]any, path trace) error {
 
-	// This looks like a kubernetes manifest, so make one and return it
 	validateErr := ValidateEnvelope(obj)
 	if validateErr != nil {
 		// this is not an envelope, skip.
@@ -387,7 +386,7 @@ func (t trace) Name() string {
 	return ""
 }
 
-// ErrorPrimitiveReached occurs when walkJSON reaches the end of nested dicts without finding a valid Kubernetes manifest
+// ErrorPrimitiveReached occurs when walkJSON reaches the end of nested dicts without finding a valid resource
 type ErrorPrimitiveReached struct {
 	path, key        string
 	primitive        interface{}

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -30,12 +30,15 @@ func Parse(registry Registry, resourcePath string, opts *Opts) (Resources, error
 	}
 	opts.IsDir = true
 
-	var parsedResources Resources
-	files, err := FindResourceFiles(resourcePath)
-	if err != nil {
-		return nil, err
-	}
+	var files []string
+	_ = filepath.WalkDir(resourcePath, func(path string, info fs.DirEntry, err error) error {
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
 
+	var parsedResources Resources
 	for _, file := range files {
 		r, err := ParseFile(registry, *opts, file)
 		if err != nil {
@@ -56,17 +59,6 @@ func Parse(registry Registry, resourcePath string, opts *Opts) (Resources, error
 	}
 	resources = registry.Sort(resources)
 	return resources, nil
-}
-
-func FindResourceFiles(resourcePath string) ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(resourcePath, func(path string, info fs.DirEntry, err error) error {
-		if !info.IsDir() {
-			files = append(files, path)
-		}
-		return nil
-	})
-	return files, err
 }
 
 func ParseFile(registry Registry, opts Opts, resourceFile string) (Resources, error) {

--- a/pkg/grizzly/parsing_test.go
+++ b/pkg/grizzly/parsing_test.go
@@ -90,10 +90,11 @@ func TestValidateEnvelope(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.Name, func(t *testing.T) {
-				err := grizzly.ValidateEnvelope(test.Resource)
+				m := map[string]any(test.Resource)
+				err := grizzly.ValidateEnvelope(m)
 				if test.ExpectedError != "" {
 					require.Error(t, err)
-					require.Equal(t, err.Error(), "errors parsing resource: "+test.ExpectedError)
+					require.Equal(t, "errors parsing resource: "+test.ExpectedError, err.Error())
 					return
 				}
 				require.NoError(t, err)
@@ -162,7 +163,7 @@ func TestParseKindDetection(t *testing.T) {
 				// of a datasource, thus resulting in an error.
 				Name:          "json datasource input, without envelope",
 				InputFile:     "testdata/parsing/datasource-without-envelope.json",
-				ExpectedError: "cannot deduce kind of testdata/parsing/datasource-without-envelope.json",
+				ExpectedError: "error reading testdata/parsing/datasource-without-envelope.json: found invalid object (at .): errors parsing resource: kind missing, metadata missing, spec missing\n\naccess: proxy\nisDefault: true\njsonData:\n    httpMethod: GET\ntype: prometheus\nurl: http://localhost/prometheus/\n",
 			},
 		}
 		for _, test := range tests {
@@ -170,7 +171,7 @@ func TestParseKindDetection(t *testing.T) {
 				resources, err := grizzly.Parse(registry, test.InputFile, &opts)
 				if test.ExpectedError != "" {
 					require.Error(t, err)
-					require.Equal(t, err.Error(), test.ExpectedError)
+					require.Equal(t, test.ExpectedError, err.Error())
 					return
 				}
 				require.NoError(t, err)

--- a/pkg/grizzly/parsing_test.go
+++ b/pkg/grizzly/parsing_test.go
@@ -1,6 +1,7 @@
 package grizzly_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/grafana/grizzly/pkg/grafana"
@@ -116,10 +117,11 @@ func TestParseKindDetection(t *testing.T) {
 		}
 
 		tests := []struct {
-			Name          string
-			InputFile     string
-			ExpectedKind  string
-			ExpectedError string
+			Name              string
+			InputFile         string
+			ExpectedKind      string
+			ExpectedError     string
+			ExpectedResources int
 		}{
 			{
 				Name:         "json dashboard input, with envelope",
@@ -132,6 +134,12 @@ func TestParseKindDetection(t *testing.T) {
 				ExpectedKind: "Dashboard",
 			},
 			{
+				Name:              "json dashboards input, with envelope",
+				InputFile:         "testdata/parsing/dashboards-with-envelope.json",
+				ExpectedKind:      "Dashboard",
+				ExpectedResources: 2,
+			},
+			{
 				Name:         "yaml dashboard input, with envelope",
 				InputFile:    "testdata/parsing/dashboard-with-envelope.yaml",
 				ExpectedKind: "Dashboard",
@@ -142,17 +150,27 @@ func TestParseKindDetection(t *testing.T) {
 				ExpectedKind: "Dashboard",
 			},
 			{
+				Name:              "yaml dashboards input, with envelope",
+				InputFile:         "testdata/parsing/dashboards-with-envelope.yaml",
+				ExpectedKind:      "Dashboard",
+				ExpectedResources: 2,
+			},
+			{
 				Name:         "jsonnet dashboard input, with envelope",
 				InputFile:    "testdata/parsing/dashboard-with-envelope.jsonnet",
 				ExpectedKind: "Dashboard",
 			},
-			/*
-				{
-					Name:         "jsonnet dashboard input, without envelope",
-					InputFile:    "testdata/parsing/dashboard-without-envelope.jsonnet",
-					ExpectedKind: "Dashboard",
-				},
-			*/
+			{
+				Name:         "jsonnet dashboard input, without envelope",
+				InputFile:    "testdata/parsing/dashboard-without-envelope.jsonnet",
+				ExpectedKind: "Dashboard",
+			},
+			{
+				Name:              "jsonnet dashboards input, with envelope",
+				InputFile:         "testdata/parsing/dashboards-with-envelope.jsonnet",
+				ExpectedKind:      "Dashboard",
+				ExpectedResources: 2,
+			},
 			{
 				Name:         "json datasource input, with envelope",
 				InputFile:    "testdata/parsing/datasource-with-envelope.json",
@@ -175,7 +193,11 @@ func TestParseKindDetection(t *testing.T) {
 					return
 				}
 				require.NoError(t, err)
-				require.Equal(t, 1, len(resources), "Expected one resource from parsing")
+				if test.ExpectedResources == 0 { // i.e. the default, which actually means 1
+					require.Equal(t, 1, len(resources), "Expected one resource from parsing")
+				} else {
+					require.Equal(t, test.ExpectedResources, len(resources), fmt.Sprintf("Expected %d resources from parsing", test.ExpectedResources))
+				}
 			})
 		}
 	})

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -67,11 +67,10 @@ func (r *Registry) HandlerMatchesTarget(handler Handler, targets []string) bool 
 }
 
 // ResourceMatchesTarget identifies whether a resource is in a target list
-func (r *Registry) ResourceMatchesTarget(handler Handler, UID string, targets []string) bool {
+func (r *Registry) ResourceMatchesTarget(kind string, UID string, targets []string) bool {
 	if len(targets) == 0 {
 		return true
 	}
-	kind := handler.Kind()
 	// I mistakenly assumed 'dot' was a special character for globs, so opted for '/' as separator.
 	// This keeps back-compat
 	slashKey := fmt.Sprintf("%s/%s", kind, UID)
@@ -106,9 +105,13 @@ func (r *Registry) Sort(resources Resources) Resources {
 	return resources
 }
 
-func (r *Registry) Detect(data map[string]any) string {
+func (r *Registry) Detect(data any) string {
+	m, ok := data.(map[string]any)
+	if !ok {
+		return ""
+	}
 	for _, handler := range r.HandlerOrder {
-		if handler.Detect(data) {
+		if handler.Detect(m) {
 			return handler.Kind()
 		}
 	}

--- a/pkg/grizzly/testdata/parsing/dashboards-with-envelope.json
+++ b/pkg/grizzly/testdata/parsing/dashboards-with-envelope.json
@@ -1,0 +1,296 @@
+{
+   "application_1": {
+      "dashboard": {
+         "apiVersion": "grizzly.grafana.com/v1alpha1",
+         "kind": "Dashboard",
+         "metadata": {
+            "name": "application-1"
+         },
+         "spec": {
+            "annotations": {
+               "list": [
+                  {
+                     "builtIn": 1,
+                     "datasource": {
+                        "type": "grafana",
+                        "uid": "-- Grafana --"
+                     },
+                     "enable": true,
+                     "hide": true,
+                     "iconColor": "rgba(0, 211, 255, 1)",
+                     "name": "Annotations & Alerts",
+                     "type": "dashboard"
+                  }
+               ]
+            },
+            "editable": true,
+            "fiscalYearStartMonth": 0,
+            "graphTooltip": 0,
+            "id": 4278,
+            "links": [ ],
+            "liveNow": false,
+            "panels": [
+               {
+                  "datasource": {
+                     "type": "datasource",
+                     "uid": "grafana"
+                  },
+                  "fieldConfig": {
+                     "defaults": {
+                        "color": {
+                           "mode": "palette-classic"
+                        },
+                        "custom": {
+                           "axisCenteredZero": false,
+                           "axisColorMode": "text",
+                           "axisLabel": "",
+                           "axisPlacement": "auto",
+                           "axisShow": false,
+                           "fillOpacity": 80,
+                           "gradientMode": "none",
+                           "hideFrom": {
+                              "legend": false,
+                              "tooltip": false,
+                              "viz": false
+                           },
+                           "lineWidth": 1,
+                           "scaleDistribution": {
+                              "type": "linear"
+                           },
+                           "thresholdsStyle": {
+                              "mode": "off"
+                           }
+                        },
+                        "mappings": [ ],
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 80
+                              }
+                           ]
+                        }
+                     },
+                     "overrides": [ ]
+                  },
+                  "gridPos": {
+                     "h": 8,
+                     "w": 12,
+                     "x": 0,
+                     "y": 0
+                  },
+                  "id": 1,
+                  "options": {
+                     "barRadius": 0,
+                     "barWidth": 0.96999999999999997,
+                     "fullHighlight": false,
+                     "groupWidth": 0.69999999999999996,
+                     "legend": {
+                        "calcs": [ ],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                     },
+                     "orientation": "auto",
+                     "showValue": "auto",
+                     "stacking": "none",
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     },
+                     "xTickLabelRotation": 0,
+                     "xTickLabelSpacing": 0
+                  },
+                  "targets": [
+                     {
+                        "channel": "plugin/testdata/random-2s-stream",
+                        "datasource": {
+                           "type": "datasource",
+                           "uid": "grafana"
+                        },
+                        "filter": {
+                           "fields": [
+                              "Time",
+                              "Min"
+                           ]
+                        },
+                        "queryType": "randomWalk",
+                        "refId": "A"
+                     }
+                  ],
+                  "title": "Panel Title",
+                  "type": "barchart"
+               }
+            ],
+            "refresh": "",
+            "schemaVersion": 38,
+            "tags": [ ],
+            "templating": {
+               "list": [ ]
+            },
+            "time": {
+               "from": "now-6h",
+               "to": "now"
+            },
+            "timepicker": { },
+            "timezone": "",
+            "title": "application-1",
+            "uid": "application-1",
+            "version": 1,
+            "weekStart": ""
+         }
+      }
+   },
+   "application_2": {
+      "dashboard": {
+         "apiVersion": "grizzly.grafana.com/v1alpha1",
+         "kind": "Dashboard",
+         "metadata": {
+            "name": "application-2"
+         },
+         "spec": {
+            "annotations": {
+               "list": [
+                  {
+                     "builtIn": 1,
+                     "datasource": {
+                        "type": "grafana",
+                        "uid": "-- Grafana --"
+                     },
+                     "enable": true,
+                     "hide": true,
+                     "iconColor": "rgba(0, 211, 255, 1)",
+                     "name": "Annotations & Alerts",
+                     "type": "dashboard"
+                  }
+               ]
+            },
+            "editable": true,
+            "fiscalYearStartMonth": 0,
+            "graphTooltip": 0,
+            "id": 4278,
+            "links": [ ],
+            "liveNow": false,
+            "panels": [
+               {
+                  "datasource": {
+                     "type": "datasource",
+                     "uid": "grafana"
+                  },
+                  "fieldConfig": {
+                     "defaults": {
+                        "color": {
+                           "mode": "palette-classic"
+                        },
+                        "custom": {
+                           "axisCenteredZero": false,
+                           "axisColorMode": "text",
+                           "axisLabel": "",
+                           "axisPlacement": "auto",
+                           "axisShow": false,
+                           "fillOpacity": 80,
+                           "gradientMode": "none",
+                           "hideFrom": {
+                              "legend": false,
+                              "tooltip": false,
+                              "viz": false
+                           },
+                           "lineWidth": 1,
+                           "scaleDistribution": {
+                              "type": "linear"
+                           },
+                           "thresholdsStyle": {
+                              "mode": "off"
+                           }
+                        },
+                        "mappings": [ ],
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 80
+                              }
+                           ]
+                        }
+                     },
+                     "overrides": [ ]
+                  },
+                  "gridPos": {
+                     "h": 8,
+                     "w": 12,
+                     "x": 0,
+                     "y": 0
+                  },
+                  "id": 1,
+                  "options": {
+                     "barRadius": 0,
+                     "barWidth": 0.96999999999999997,
+                     "fullHighlight": false,
+                     "groupWidth": 0.69999999999999996,
+                     "legend": {
+                        "calcs": [ ],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                     },
+                     "orientation": "auto",
+                     "showValue": "auto",
+                     "stacking": "none",
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     },
+                     "xTickLabelRotation": 0,
+                     "xTickLabelSpacing": 0
+                  },
+                  "targets": [
+                     {
+                        "channel": "plugin/testdata/random-2s-stream",
+                        "datasource": {
+                           "type": "datasource",
+                           "uid": "grafana"
+                        },
+                        "filter": {
+                           "fields": [
+                              "Time",
+                              "Min"
+                           ]
+                        },
+                        "queryType": "randomWalk",
+                        "refId": "A"
+                     }
+                  ],
+                  "title": "Panel Title",
+                  "type": "barchart"
+               }
+            ],
+            "refresh": "",
+            "schemaVersion": 38,
+            "tags": [ ],
+            "templating": {
+               "list": [ ]
+            },
+            "time": {
+               "from": "now-6h",
+               "to": "now"
+            },
+            "timepicker": { },
+            "timezone": "",
+            "title": "application-2",
+            "uid": "application-2",
+            "version": 1,
+            "weekStart": ""
+         }
+      }
+   }
+}

--- a/pkg/grizzly/testdata/parsing/dashboards-with-envelope.jsonnet
+++ b/pkg/grizzly/testdata/parsing/dashboards-with-envelope.jsonnet
@@ -1,0 +1,154 @@
+local dashboard(name) = {
+  "apiVersion": "grizzly.grafana.com/v1alpha1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": name,
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 4278,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "axisShow": false,
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "barRadius": 0,
+          "barWidth": 0.97,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "auto",
+          "showValue": "auto",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "targets": [
+          {
+            "channel": "plugin/testdata/random-2s-stream",
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "filter": {
+              "fields": [
+                "Time",
+                "Min"
+              ]
+            },
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "title": "Panel Title",
+        "type": "barchart"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": name,
+    "uid": name,
+    "version": 1,
+    "weekStart": ""
+  }
+};
+
+{
+  application_1: {
+    dashboard: dashboard("application-1"),
+  },
+  application_2: {
+    dashboard: dashboard("application-2"),
+  }
+}

--- a/pkg/grizzly/testdata/parsing/dashboards-with-envelope.yaml
+++ b/pkg/grizzly/testdata/parsing/dashboards-with-envelope.yaml
@@ -1,0 +1,218 @@
+application_1:
+  dashboard:
+    apiVersion: grizzly.grafana.com/v1alpha1
+    kind: Dashboard
+    metadata:
+      name: application-1
+    spec:
+      annotations:
+        list:
+          - builtIn: 1
+            datasource:
+              type: grafana
+              uid: -- Grafana --
+            enable: true
+            hide: true
+            iconColor: rgba(0, 211, 255, 1)
+            name: Annotations & Alerts
+            type: dashboard
+      editable: true
+      fiscalYearStartMonth: 0
+      graphTooltip: 0
+      id: 4278
+      links: []
+      liveNow: false
+      panels:
+        - datasource:
+            type: datasource
+            uid: grafana
+          fieldConfig:
+            defaults:
+              color:
+                mode: palette-classic
+              custom:
+                axisCenteredZero: false
+                axisColorMode: text
+                axisLabel: ""
+                axisPlacement: auto
+                axisShow: false
+                fillOpacity: 80
+                gradientMode: none
+                hideFrom:
+                  legend: false
+                  tooltip: false
+                  viz: false
+                lineWidth: 1
+                scaleDistribution:
+                  type: linear
+                thresholdsStyle:
+                  mode: off
+              mappings: []
+              thresholds:
+                mode: absolute
+                steps:
+                  - color: green
+                    value: null
+                  - color: red
+                    value: 80
+            overrides: []
+          gridPos:
+            h: 8
+            w: 12
+            x: 0
+            y: 0
+          id: 1
+          options:
+            barRadius: 0
+            barWidth: 0.97
+            fullHighlight: false
+            groupWidth: 0.7
+            legend:
+              calcs: []
+              displayMode: list
+              placement: bottom
+              showLegend: true
+            orientation: auto
+            showValue: auto
+            stacking: none
+            tooltip:
+              mode: single
+              sort: none
+            xTickLabelRotation: 0
+            xTickLabelSpacing: 0
+          targets:
+            - channel: plugin/testdata/random-2s-stream
+              datasource:
+                type: datasource
+                uid: grafana
+              filter:
+                fields:
+                  - Time
+                  - Min
+              queryType: randomWalk
+              refId: A
+          title: Panel Title
+          type: barchart
+      refresh: ""
+      schemaVersion: 38
+      tags: []
+      templating:
+        list: []
+      time:
+        from: now-6h
+        to: now
+      timepicker: {}
+      timezone: ""
+      title: application-1
+      uid: application-1
+      version: 1
+      weekStart: ""
+application_2:
+  dashboard:
+    apiVersion: grizzly.grafana.com/v1alpha1
+    kind: Dashboard
+    metadata:
+      name: application-2
+    spec:
+      annotations:
+        list:
+          - builtIn: 1
+            datasource:
+              type: grafana
+              uid: -- Grafana --
+            enable: true
+            hide: true
+            iconColor: rgba(0, 211, 255, 1)
+            name: Annotations & Alerts
+            type: dashboard
+      editable: true
+      fiscalYearStartMonth: 0
+      graphTooltip: 0
+      id: 4278
+      links: []
+      liveNow: false
+      panels:
+        - datasource:
+            type: datasource
+            uid: grafana
+          fieldConfig:
+            defaults:
+              color:
+                mode: palette-classic
+              custom:
+                axisCenteredZero: false
+                axisColorMode: text
+                axisLabel: ""
+                axisPlacement: auto
+                axisShow: false
+                fillOpacity: 80
+                gradientMode: none
+                hideFrom:
+                  legend: false
+                  tooltip: false
+                  viz: false
+                lineWidth: 1
+                scaleDistribution:
+                  type: linear
+                thresholdsStyle:
+                  mode: off
+              mappings: []
+              thresholds:
+                mode: absolute
+                steps:
+                  - color: green
+                    value: null
+                  - color: red
+                    value: 80
+            overrides: []
+          gridPos:
+            h: 8
+            w: 12
+            x: 0
+            y: 0
+          id: 1
+          options:
+            barRadius: 0
+            barWidth: 0.97
+            fullHighlight: false
+            groupWidth: 0.7
+            legend:
+              calcs: []
+              displayMode: list
+              placement: bottom
+              showLegend: true
+            orientation: auto
+            showValue: auto
+            stacking: none
+            tooltip:
+              mode: single
+              sort: none
+            xTickLabelRotation: 0
+            xTickLabelSpacing: 0
+          targets:
+            - channel: plugin/testdata/random-2s-stream
+              datasource:
+                type: datasource
+                uid: grafana
+              filter:
+                fields:
+                  - Time
+                  - Min
+              queryType: randomWalk
+              refId: A
+          title: Panel Title
+          type: barchart
+      refresh: ""
+      schemaVersion: 38
+      tags: []
+      templating:
+        list: []
+      time:
+        from: now-6h
+        to: now
+      timepicker: {}
+      timezone: ""
+      title: application-2
+      uid: application-2
+      version: 1
+      weekStart: ""

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -105,7 +105,7 @@ func ListRemote(registry Registry, opts Opts) error {
 			return err
 		}
 		for _, id := range IDs {
-			if registry.ResourceMatchesTarget(handler, id, targets) {
+			if registry.ResourceMatchesTarget(handler.Kind(), id, targets) {
 				fmt.Fprintf(w, f, handler.APIVersion(), handler.Kind(), id)
 			}
 		}
@@ -153,7 +153,7 @@ func Pull(registry Registry, resourcePath string, opts Opts) error {
 		}
 		notifier.Warn(nil, fmt.Sprintf("Pulling %d resources", len(UIDs)))
 		for _, UID := range UIDs {
-			if !registry.ResourceMatchesTarget(handler, UID, targets) {
+			if !registry.ResourceMatchesTarget(handler.Kind(), UID, targets) {
 				continue
 			}
 			resource, err := handler.GetByUID(UID)


### PR DESCRIPTION
Currently, Grizzly can parse single resources as JSON/YAML, but will crawl a tree for enveloped
resources when they are generated with Jsonnet. This gives Jsonnet an undue advantage. Grizzly
uses Tanka functionality to seek out these Kubernetes objects.

Therefore, this PR pulls the "Walk" functionality out of Tanka and into Grizzly, and makes it
work for itself. Now, a file when parsed will either be enveloped, not enveloped or crawled,
in that order.
