### PR TITLE
Add Github issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,30 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+projects: ["grafana/513"] # Platform Client Administration Tooling
+body:
+  - type: input
+    id: grizzly_version
+    attributes:
+      label: Grizzly Version
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      placeholder: |
+        What should have happened?
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+      placeholder: |
+        What actually happened?
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        Please list the steps required to reproduce the issue, for example:
+        1. `grr pull ...`
+        

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,12 @@
+name: Feature Request
+description: Suggest an improvement for Grizzly
+title: "[Feature Request]: "
+labels: ["enhancement", "triage"]
+projects: ["grafana/513"] # Platform Client Administration Tooling
+body:
+  - type: textarea
+    id: request
+    attributes:
+      label: Feature Request
+      placeholder: |
+        What would you like to see added/changed to Grizzly?


### PR DESCRIPTION
Format here: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
This will guide users to make better bug reports
It will also set labels and the Github project for all new issues