### PR TITLE
Changes to release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - uses: ./.github/actions/setup-goversion
       - run: make cross
       - id: docker_tag
@@ -25,7 +23,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body: |
-            This is release `${{ env.GITHUB_REF_NAME }}` of Grizzly (`grr`). Check out the [CHANGELOG](CHANGELOG.md) for detailed release notes.
+            This is release `${{ env.GITHUB_REF_NAME }}` of Grizzly (`grr`).
             ## Install instructions
 
             #### Binary:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+**Changelogs for v0.4.0+ can be found [here](https://github.com/grafana/grizzly/releases)**
+
 ## 0.3.1 (2024-01-23)
 Feature improvements:
 * Allow targets to be set in contexts (#304)


### PR DESCRIPTION
- Remove `fetch-tags`. It's unneeded and failing
- Move changelogs to be auto-generated by Github