### PR TITLE
Release: Fix `github.ref_name`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,13 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body: |
-            This is release `${{ env.GITHUB_REF_NAME }}` of Grizzly (`grr`).
+            This is release `${{ github.ref_name }}` of Grizzly (`grr`).
             ## Install instructions
 
             #### Binary:
             ```bash
             # download the binary (adapt os and arch as needed)
-            $ curl -fSL -o "/usr/local/bin/grr" "https://github.com/grafana/grizzly/releases/download/${{ env.GITHUB_REF_NAME }}/grr-linux-amd64"
+            $ curl -fSL -o "/usr/local/bin/grr" "https://github.com/grafana/grizzly/releases/download/${{ github.ref_name }}/grr-linux-amd64"
 
             # make it executable
             $ chmod a+x "/usr/local/bin/grr"


### PR DESCRIPTION
Everything worked last release except this string was empty. Thankfully, it's in the release description so I just filled it in manually