### PR TITLE
Conditional Providers: Only use providers that are configured properly

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -33,12 +33,30 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	registry := grizzly.NewRegistry(
-		[]grizzly.Provider{
-			grafana.NewProvider(&context.Grafana),
-			mimir.NewProvider(&context.Mimir),
-			syntheticmonitoring.NewProvider(&context.SyntheticMonitoring),
-		})
+	providers := []grizzly.Provider{}
+
+	grafanaProvider, err := grafana.NewProvider(&context.Grafana)
+	if err != nil {
+		log.Warnf("Grafana provider is not configured: %v", err)
+	} else {
+		providers = append(providers, grafanaProvider)
+	}
+
+	mimirProvider, err := mimir.NewProvider(&context.Mimir)
+	if err != nil {
+		log.Warnf("Mimir provider is not configured: %v", err)
+	} else {
+		providers = append(providers, mimirProvider)
+	}
+
+	syntheticMonitoringProvider, err := syntheticmonitoring.NewProvider(&context.SyntheticMonitoring)
+	if err != nil {
+		log.Warnf("Synthetic Monitoring provider is not configured: %v", err)
+	} else {
+		providers = append(providers, syntheticMonitoringProvider)
+	}
+
+	registry := grizzly.NewRegistry(providers)
 
 	// workflow commands
 	rootCmd.AddCommand(

--- a/integration/dashboard_test.go
+++ b/integration/dashboard_test.go
@@ -137,7 +137,9 @@ func TestDashboard(t *testing.T) {
 }
 
 func TestDashboardHandler(t *testing.T) {
-	handler := grafana.NewDashboardHandler(grafana.NewProvider(&testutil.TestContext().Grafana))
+	provider, err := grafana.NewProvider(&testutil.TestContext().Grafana)
+	require.NoError(t, err)
+	handler := grafana.NewDashboardHandler(provider)
 
 	t.Run("get remote dashboard - success", func(t *testing.T) {
 		resource, err := handler.GetByUID("ReciqtgGk")

--- a/integration/datasource_test.go
+++ b/integration/datasource_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestDatasources(t *testing.T) {
-	handler := grafana.NewDatasourceHandler(grafana.NewProvider(&testutil.TestContext().Grafana))
+	provider, err := grafana.NewProvider(&testutil.TestContext().Grafana)
+	require.NoError(t, err)
+	handler := grafana.NewDatasourceHandler(provider)
 
 	t.Run("get remote datasource - success", func(t *testing.T) {
 		resource, err := handler.GetByUID("AppDynamics")

--- a/integration/folder_test.go
+++ b/integration/folder_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestFolders(t *testing.T) {
-	handler := grafana.NewFolderHandler(grafana.NewProvider(&testutil.TestContext().Grafana))
+	provider, err := grafana.NewProvider(&testutil.TestContext().Grafana)
+	require.NoError(t, err)
+	handler := grafana.NewFolderHandler(provider)
 
 	t.Run("get remote folder - success", func(t *testing.T) {
 		resource, err := handler.GetByUID("abcdefghi")

--- a/integration/library-element_test.go
+++ b/integration/library-element_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestLibraryElements(t *testing.T) {
-	handler := grafana.NewLibraryElementHandler(grafana.NewProvider(&testutil.TestContext().Grafana))
+	provider, err := grafana.NewProvider(&testutil.TestContext().Grafana)
+	require.NoError(t, err)
+	handler := grafana.NewLibraryElementHandler(provider)
 
 	t.Run("create libraryElement - success", func(t *testing.T) {
 		libraryElement, err := os.ReadFile("testdata/test_json/post_library-element.json")

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -1,0 +1,36 @@
+package integration_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPull(t *testing.T) {
+	dir := t.TempDir()
+	setupContexts(t, dir)
+
+	t.Run("Pull everything - success", func(t *testing.T) {
+		pullDir := t.TempDir()
+		runTest(t, GrizzlyTest{
+			TestDir:       dir,
+			RunOnContexts: allContexts,
+			Commands: []Command{
+				{
+					Command:                "pull " + pullDir,
+					ExpectedCode:           0,
+					ExpectedOutputContains: `Dashboard.ReciqtgGk pulled`,
+				},
+			},
+			Validate: func(t *testing.T) {
+				// Check the files
+				assert.DirExists(t, filepath.Join(pullDir, "dashboards"))
+				assert.FileExists(t, filepath.Join(pullDir, "dashboards", "abcdefghi", "dashboard-ReciqtgGk.yaml"))
+				assert.DirExists(t, filepath.Join(pullDir, "datasources"))
+				assert.DirExists(t, filepath.Join(pullDir, "folders"))
+
+			},
+		})
+	})
+}

--- a/pkg/grafana/folder_test.go
+++ b/pkg/grafana/folder_test.go
@@ -3,13 +3,12 @@ package grafana
 import (
 	"testing"
 
-	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSortFolders(t *testing.T) {
-	handler := NewFolderHandler(NewProvider(&config.GrafanaConfig{}))
+	handler := NewFolderHandler(&Provider{})
 	folder := func(uid string, parentUID string) grizzly.Resource {
 		spec := map[string]interface{}{
 			"uid": uid,

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -24,10 +24,13 @@ type ClientProvider interface {
 }
 
 // NewProvider instantiates a new Provider.
-func NewProvider(config *config.GrafanaConfig) *Provider {
+func NewProvider(config *config.GrafanaConfig) (*Provider, error) {
+	if config.URL == "" {
+		return nil, fmt.Errorf("grafana URL is not set")
+	}
 	return &Provider{
 		config: config,
-	}
+	}, nil
 }
 
 // Group returns the group name of the Grafana provider

--- a/pkg/grafana/utils_test.go
+++ b/pkg/grafana/utils_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestExtractFolderUID(t *testing.T) {
-	provider := NewProvider(&config.GrafanaConfig{})
+	provider, err := NewProvider(&config.GrafanaConfig{URL: "http://localhost:3000"})
+	require.NoError(t, err)
 
 	client, err := provider.Client()
 	require.NoError(t, err)

--- a/pkg/grizzly/parsing_test.go
+++ b/pkg/grizzly/parsing_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/grafana"
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/stretchr/testify/require"
@@ -110,7 +109,7 @@ func TestParseKindDetection(t *testing.T) {
 
 		registry := grizzly.NewRegistry(
 			[]grizzly.Provider{
-				grafana.NewProvider(&config.GrafanaConfig{}),
+				&grafana.Provider{},
 			},
 		)
 		tests := []struct {

--- a/pkg/mimir/provider.go
+++ b/pkg/mimir/provider.go
@@ -1,6 +1,8 @@
 package mimir
 
 import (
+	"fmt"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/grafana/grizzly/pkg/config"
@@ -17,10 +19,20 @@ type ClientConfigProvider interface {
 }
 
 // NewProvider instantiates a new Provider.
-func NewProvider(config *config.MimirConfig) *Provider {
+func NewProvider(config *config.MimirConfig) (*Provider, error) {
+	if _, err := exec.LookPath("cortextool"); err != nil {
+		return nil, err
+	}
+	if config.Address == "" {
+		return nil, fmt.Errorf("mimir address is not set")
+	}
+	if config.ApiKey == "" {
+		return nil, fmt.Errorf("mimir api key is not set")
+	}
+
 	return &Provider{
 		config: config,
-	}
+	}, nil
 }
 
 // Group returns the group name of the Grafana provider

--- a/pkg/mimir/rules_test.go
+++ b/pkg/mimir/rules_test.go
@@ -15,8 +15,7 @@ import (
 var errCortextoolClient = errors.New("error coming from cortextool client")
 
 func TestRules(t *testing.T) {
-	provider := NewProvider(&config.MimirConfig{})
-	h := NewRuleHandler(provider)
+	h := NewRuleHandler(&Provider{})
 	t.Run("get remote rule group", func(t *testing.T) {
 		mockCortexTool(t, "testdata/list_rules.yaml", nil)
 

--- a/pkg/syntheticmonitoring/provider.go
+++ b/pkg/syntheticmonitoring/provider.go
@@ -21,10 +21,22 @@ type ClientProvider interface {
 }
 
 // NewProvider instantiates a new Provider.
-func NewProvider(config *config.SyntheticMonitoringConfig) *Provider {
+func NewProvider(config *config.SyntheticMonitoringConfig) (*Provider, error) {
+	if config.StackID == 0 {
+		return nil, fmt.Errorf("stack id is not set")
+	}
+	if config.MetricsID == 0 {
+		return nil, fmt.Errorf("metrics id is not set")
+	}
+	if config.LogsID == 0 {
+		return nil, fmt.Errorf("logs id is not set")
+	}
+	if config.Token == "" {
+		return nil, fmt.Errorf("token is not set")
+	}
 	return &Provider{
 		config: config,
-	}
+	}, nil
 }
 
 // Group returns the group name of the Grafana provider

--- a/pkg/syntheticmonitoring/synthetic-monitoring_test.go
+++ b/pkg/syntheticmonitoring/synthetic-monitoring_test.go
@@ -3,7 +3,6 @@ package syntheticmonitoring
 import (
 	"testing"
 
-	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,7 @@ func TestSyntheticMonitoring(t *testing.T) {
 				"type": "http",
 			},
 		}
-		handler := NewSyntheticMonitoringHandler(NewProvider(&config.SyntheticMonitoringConfig{}))
+		handler := NewSyntheticMonitoringHandler(nil)
 
 		uid, err := handler.GetUID(resource)
 		require.NoError(t, err)
@@ -76,7 +75,7 @@ func TestSyntheticMonitoringCheckUID(t *testing.T) {
 		},
 	}
 
-	h := NewSyntheticMonitoringHandler(NewProvider(&config.SyntheticMonitoringConfig{}))
+	h := NewSyntheticMonitoringHandler(nil)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expectedUID, h.getUID(tc.check))


### PR DESCRIPTION
My use case: Instead of failing because mimir is not configured, or SM, only use the Grafana provider 
A warning is output to mention that mimir and SM won't be used