### PR TITLE
Add insecure-skip-verify for grafana

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -143,6 +143,7 @@ var acceptableKeys = map[string]string{
 	"grafana.url":                     "string",
 	"grafana.token":                   "string",
 	"grafana.user":                    "string",
+	"grafana.insecure-skip-verify":    "bool",
 	"mimir.address":                   "string",
 	"mimir.tenant-id":                 "string",
 	"mimir.api-key":                   "string",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,6 +144,7 @@ var acceptableKeys = map[string]string{
 	"grafana.token":                   "string",
 	"grafana.user":                    "string",
 	"grafana.insecure-skip-verify":    "bool",
+	"grafana.tls-host":                "string",
 	"mimir.address":                   "string",
 	"mimir.tenant-id":                 "string",
 	"mimir.api-key":                   "string",

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -1,9 +1,10 @@
 package config
 
 type GrafanaConfig struct {
-	URL   string `yaml:"url" mapstructure:"url"`
-	User  string `yaml:"user" mapstructure:"user"`
-	Token string `yaml:"token" mapstructure:"token"`
+	URL                string `yaml:"url" mapstructure:"url"`
+	User               string `yaml:"user" mapstructure:"user"`
+	Token              string `yaml:"token" mapstructure:"token"`
+	InsecureSkipVerify bool   `yaml:"insecure-skip-verify" mapstructure:"insecure-skip-verify"`
 }
 
 type MimirConfig struct {

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -5,6 +5,7 @@ type GrafanaConfig struct {
 	User               string `yaml:"user" mapstructure:"user"`
 	Token              string `yaml:"token" mapstructure:"token"`
 	InsecureSkipVerify bool   `yaml:"insecure-skip-verify" mapstructure:"insecure-skip-verify"`
+	TLSHost            string `yaml:"tls-host" mapstructure:"tls-host"`
 }
 
 type MimirConfig struct {

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -1,6 +1,7 @@
 package grafana
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"net/http/httputil"
@@ -54,6 +55,10 @@ func (p *Provider) Client() (*gclient.GrafanaHTTPAPI, error) {
 		WithHost(parsedUrl.Host).
 		WithSchemes([]string{parsedUrl.Scheme}).
 		WithBasePath(filepath.Join(parsedUrl.Path, "api"))
+
+	if parsedUrl.Scheme == "https" && p.config.InsecureSkipVerify {
+		transportConfig.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 
 	if p.config.Token != "" {
 		if p.config.User != "" {

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -57,7 +57,10 @@ func (p *Provider) Client() (*gclient.GrafanaHTTPAPI, error) {
 		WithBasePath(filepath.Join(parsedUrl.Path, "api"))
 
 	if parsedUrl.Scheme == "https" && p.config.InsecureSkipVerify {
-		transportConfig.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+		transportConfig.TLSConfig = &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         p.config.TLSHost,
+		}
 	}
 
 	if p.config.Token != "" {


### PR DESCRIPTION
When Grafana uses HTTPS, clients verify that the certificate is as expected.

Sometimes, when the server is knowingly incorrectly configured, it can be useful to
skip this verification step. This should be done knowingly - it is working around
security protections.

This PR adds a `grafana.insecure-skip-verify` option to the context, that can be set
with:

```
grr config set grafana.insecure-skip-verify true
```
