### PR TITLE
Add gotestsum options to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,15 @@ test-clean:
 test:
 	go test -v ./cmd/... ./pkg/...
 
+testsum:
+	gotestsum ./cmd/... ./pkg/...
+
 integration: run-test-image-locally dev
 	go test -v ./integration/...
+	make stop-test-image-locally
+
+integrationsum: run-test-image-locally dev
+	gotestsum ./integration/...
 	make stop-test-image-locally
 
 # Compilation


### PR DESCRIPTION
Go test does not report failure numbers. When making big changes this can make it hard to
analyse the output.

This PR adds `gotestsum` options to the makefile. It does this instead of replacing the
standard `go test` options to avoid a required dependency.﻿
