### PR TITLE
Proxy server cleanup

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -233,7 +233,7 @@ func (h *DashboardHandler) Detect(data map[string]any) bool {
 	return true
 }
 
-func (h *DashboardHandler) GetProxyEndpoints(p grizzly.GrizzlyServer) []grizzly.ProxyEndpoint {
+func (h *DashboardHandler) GetProxyEndpoints(p grizzly.Server) []grizzly.ProxyEndpoint {
 	return []grizzly.ProxyEndpoint{
 		{
 			Method:  "GET",
@@ -253,7 +253,7 @@ func (h *DashboardHandler) GetProxyEndpoints(p grizzly.GrizzlyServer) []grizzly.
 	}
 }
 
-func (h *DashboardHandler) RootDashboardPageHandler(p grizzly.GrizzlyServer) http.HandlerFunc {
+func (h *DashboardHandler) RootDashboardPageHandler(p grizzly.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "text/html")
 		config := h.Provider.(ClientProvider).Config()
@@ -296,7 +296,7 @@ func (h *DashboardHandler) RootDashboardPageHandler(p grizzly.GrizzlyServer) htt
 	}
 }
 
-func (h *DashboardHandler) DashboardJSONGetHandler(p grizzly.GrizzlyServer) http.HandlerFunc {
+func (h *DashboardHandler) DashboardJSONGetHandler(p grizzly.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		uid := chi.URLParam(r, "uid")
 		if uid == "" {
@@ -334,7 +334,7 @@ func (h *DashboardHandler) DashboardJSONGetHandler(p grizzly.GrizzlyServer) http
 	}
 }
 
-func (h *DashboardHandler) DashboardJSONPostHandler(p grizzly.GrizzlyServer) http.HandlerFunc {
+func (h *DashboardHandler) DashboardJSONPostHandler(p grizzly.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		dash := map[string]interface{}{}

--- a/pkg/grizzly/embed/templates/proxy/index.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/index.html.tmpl
@@ -23,7 +23,7 @@
         {{ range .Resources }}
             {{ if eq .Kind "Dashboard" }}
                 <li>
-                    <a href="http://localhost:8080/d/{{ .Name }}/slug">{{ .Spec.title }}</a>
+                    <a href="http://localhost:{{ $.ServerPort }}/d/{{ .Name }}/slug">{{ .Spec.title }}</a>
                 </li>
             {{ end }}
         {{ end }}

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -117,7 +117,7 @@ type ProxyEndpoint struct {
 // ProxyHandler describes a handler that can be used to edit resources live via a proxied UI
 type ProxyHandler interface {
 	// RegisterHandlers registers HTTP handlers for proxy events
-	GetProxyEndpoints(p GrizzlyServer) []ProxyEndpoint
+	GetProxyEndpoints(p Server) []ProxyEndpoint
 
 	// ProxyURL returns a URL path for a resource on the proxy
 	ProxyURL(Resource) (string, error)

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -241,7 +241,8 @@ func (p *GrizzlyServer) RootHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	templateVars := map[string]any{
-		"Resources": resources,
+		"Resources":  resources,
+		"ServerPort": p.Port,
 	}
 	if err := templates.ExecuteTemplate(w, "proxy/index.html.tmpl", templateVars); err != nil {
 		log.Error("Error while executing template: ", err)

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -20,9 +20,6 @@ type Server struct {
 	Port         int
 	Registry     Registry
 	Parser       WatchParser
-	Url          string
-	User         string
-	Token        string
 	UserAgent    string
 	ResourcePath string
 	OpenBrowser  bool


### PR DESCRIPTION
A bit of housekeeping on the grizzly server implementation.

The first commit is a tiny fix, to make sure that the templates use the actual server port to build URLs.

The other two are "cleanup" commits.