### PR TITLE
Split the parsers implementation in decoupled, more manageable components

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -69,7 +69,7 @@ func listCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 
-		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.Options{
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.ParserOptions{
 			DefaultResourceKind: resourceKind,
 			DefaultFolderUID:    folderUID,
 		})
@@ -128,7 +128,7 @@ func showCmd(registry grizzly.Registry) *cli.Command {
 		}
 		targets := currentContext.GetTargets(opts.Targets)
 
-		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.Options{
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.ParserOptions{
 			DefaultResourceKind: resourceKind,
 			DefaultFolderUID:    folderUID,
 		})
@@ -167,7 +167,7 @@ func diffCmd(registry grizzly.Registry) *cli.Command {
 
 		targets := currentContext.GetTargets(opts.Targets)
 
-		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.Options{
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.ParserOptions{
 			DefaultResourceKind: resourceKind,
 			DefaultFolderUID:    folderUID,
 		})
@@ -207,7 +207,7 @@ func applyCmd(registry grizzly.Registry) *cli.Command {
 
 		targets := currentContext.GetTargets(opts.Targets)
 
-		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.Options{
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.ParserOptions{
 			DefaultResourceKind: resourceKind,
 			DefaultFolderUID:    folderUID,
 		})
@@ -236,7 +236,7 @@ func (p *jsonnetWatchParser) Name() string {
 }
 
 func (p *jsonnetWatchParser) Parse() (grizzly.Resources, error) {
-	return grizzly.DefaultParser(p.registry, p.targets, p.jsonnetPaths).Parse(p.resourcePath, grizzly.Options{
+	return grizzly.DefaultParser(p.registry, p.targets, p.jsonnetPaths).Parse(p.resourcePath, grizzly.ParserOptions{
 		DefaultResourceKind: p.resourceKind,
 		DefaultFolderUID:    p.folderUID,
 	})
@@ -341,7 +341,7 @@ func exportCmd(registry grizzly.Registry) *cli.Command {
 
 		targets := currentContext.GetTargets(opts.Targets)
 
-		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(resourcePath, grizzly.Options{
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(resourcePath, grizzly.ParserOptions{
 			DefaultResourceKind: resourceKind,
 			DefaultFolderUID:    folderUID,
 		})

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -69,7 +69,10 @@ func listCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 
-		resources, err := grizzly.Parse(registry, args[0], resourceKind, folderUID, targets, opts.JsonnetPaths)
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.Options{
+			DefaultResourceKind: resourceKind,
+			DefaultFolderUID:    folderUID,
+		})
 		if err != nil {
 			return err
 		}
@@ -125,7 +128,10 @@ func showCmd(registry grizzly.Registry) *cli.Command {
 		}
 		targets := currentContext.GetTargets(opts.Targets)
 
-		resources, err := grizzly.Parse(registry, args[0], resourceKind, folderUID, targets, opts.JsonnetPaths)
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.Options{
+			DefaultResourceKind: resourceKind,
+			DefaultFolderUID:    folderUID,
+		})
 		if err != nil {
 			return err
 		}
@@ -158,12 +164,17 @@ func diffCmd(registry grizzly.Registry) *cli.Command {
 		if err != nil {
 			return err
 		}
+
 		targets := currentContext.GetTargets(opts.Targets)
 
-		resources, err := grizzly.Parse(registry, args[0], resourceKind, folderUID, targets, opts.JsonnetPaths)
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.Options{
+			DefaultResourceKind: resourceKind,
+			DefaultFolderUID:    folderUID,
+		})
 		if err != nil {
 			return err
 		}
+
 		format, onlySpec, err := getOutputFormat(opts)
 		if err != nil {
 			return err
@@ -193,12 +204,17 @@ func applyCmd(registry grizzly.Registry) *cli.Command {
 		if err != nil {
 			return err
 		}
+
 		targets := currentContext.GetTargets(opts.Targets)
 
-		resources, err := grizzly.Parse(registry, args[0], resourceKind, folderUID, targets, opts.JsonnetPaths)
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(args[0], grizzly.Options{
+			DefaultResourceKind: resourceKind,
+			DefaultFolderUID:    folderUID,
+		})
 		if err != nil {
 			return err
 		}
+
 		return grizzly.Apply(registry, resources)
 	}
 
@@ -220,7 +236,10 @@ func (p *jsonnetWatchParser) Name() string {
 }
 
 func (p *jsonnetWatchParser) Parse() (grizzly.Resources, error) {
-	return grizzly.Parse(p.registry, p.resourcePath, p.resourceKind, p.folderUID, p.targets, p.jsonnetPaths)
+	return grizzly.DefaultParser(p.registry, p.targets, p.jsonnetPaths).Parse(p.resourcePath, grizzly.Options{
+		DefaultResourceKind: p.resourceKind,
+		DefaultFolderUID:    p.folderUID,
+	})
 }
 
 func watchCmd(registry grizzly.Registry) *cli.Command {
@@ -319,16 +338,22 @@ func exportCmd(registry grizzly.Registry) *cli.Command {
 		if err != nil {
 			return err
 		}
+
 		targets := currentContext.GetTargets(opts.Targets)
 
-		resources, err := grizzly.Parse(registry, resourcePath, resourceKind, folderUID, targets, opts.JsonnetPaths)
+		resources, err := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths).Parse(resourcePath, grizzly.Options{
+			DefaultResourceKind: resourceKind,
+			DefaultFolderUID:    folderUID,
+		})
 		if err != nil {
 			return err
 		}
+
 		format, onlySpec, err := getOutputFormat(opts)
 		if err != nil {
 			return err
 		}
+
 		return grizzly.Export(registry, dashboardDir, resources, onlySpec, format)
 	}
 	return initialiseCmd(cmd, &opts)

--- a/pkg/grizzly/json.go
+++ b/pkg/grizzly/json.go
@@ -22,7 +22,7 @@ func (parser *JSONParser) Accept(file string) bool {
 }
 
 // Parse evaluates a JSON file and parses it into resources
-func (parser *JSONParser) Parse(file string, options Options) (Resources, error) {
+func (parser *JSONParser) Parse(file string, options ParserOptions) (Resources, error) {
 	f, err := os.Open(file)
 	if err != nil {
 		return nil, err

--- a/pkg/grizzly/json.go
+++ b/pkg/grizzly/json.go
@@ -1,0 +1,44 @@
+package grizzly
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type JSONParser struct {
+	registry Registry
+}
+
+func NewJSONParser(registry Registry) *JSONParser {
+	return &JSONParser{
+		registry: registry,
+	}
+}
+
+func (parser *JSONParser) Accept(file string) bool {
+	return filepath.Ext(file) == ".json"
+}
+
+// Parse evaluates a JSON file and parses it into resources
+func (parser *JSONParser) Parse(file string, options Options) (Resources, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	m := map[string]any{}
+	err = json.NewDecoder(f).Decode(&m)
+	if err != nil {
+		return nil, err
+	}
+
+	resources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %v", file, err)
+	}
+
+	return resources, err
+}

--- a/pkg/grizzly/jsonnet.go
+++ b/pkg/grizzly/jsonnet.go
@@ -12,26 +12,26 @@ import (
 	"github.com/google/go-jsonnet/ast"
 )
 
-type JsonnerParser struct {
+type JsonnetParser struct {
 	registry     Registry
 	jsonnetPaths []string
 }
 
-func NewJsonnerParser(registry Registry, jsonnetPaths []string) *JsonnerParser {
-	return &JsonnerParser{
+func NewJsonnerParser(registry Registry, jsonnetPaths []string) *JsonnetParser {
+	return &JsonnetParser{
 		registry:     registry,
 		jsonnetPaths: jsonnetPaths,
 	}
 }
 
-func (parser *JsonnerParser) Accept(file string) bool {
+func (parser *JsonnetParser) Accept(file string) bool {
 	extension := filepath.Ext(file)
 
 	return extension == ".jsonnet" || extension == ".libsonnet"
 }
 
 // Parse evaluates a jsonnet file and parses it into an object tree
-func (parser *JsonnerParser) Parse(file string, options Options) (Resources, error) {
+func (parser *JsonnetParser) Parse(file string, options ParserOptions) (Resources, error) {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		return nil, fmt.Errorf("file does not exist: %s", file)
 	}

--- a/pkg/grizzly/parsing_test.go
+++ b/pkg/grizzly/parsing_test.go
@@ -106,7 +106,6 @@ func TestValidateEnvelope(t *testing.T) {
 
 func TestParseKindDetection(t *testing.T) {
 	t.Run("Parse kind detection", func(t *testing.T) {
-
 		registry := grizzly.NewRegistry(
 			[]grizzly.Provider{
 				&grafana.Provider{},
@@ -180,9 +179,16 @@ func TestParseKindDetection(t *testing.T) {
 				ExpectedError: "error reading testdata/parsing/datasource-without-envelope.json: found invalid object (at .): errors parsing resource: kind missing, metadata missing, spec missing\n\naccess: proxy\nisDefault: true\njsonData:\n    httpMethod: GET\ntype: prometheus\nurl: http://localhost/prometheus/\n",
 			},
 		}
+
+		parser := grizzly.DefaultParser(registry, nil, nil)
+		parseOpts := grizzly.Options{
+			DefaultResourceKind: "",
+			DefaultFolderUID:    "General",
+		}
+
 		for _, test := range tests {
 			t.Run(test.Name, func(t *testing.T) {
-				resources, err := grizzly.Parse(registry, test.InputFile, "", "General", nil, nil)
+				resources, err := parser.Parse(test.InputFile, parseOpts)
 				if test.ExpectedError != "" {
 					require.Error(t, err)
 					require.Equal(t, test.ExpectedError, err.Error())
@@ -190,7 +196,7 @@ func TestParseKindDetection(t *testing.T) {
 				}
 				require.NoError(t, err)
 				if test.ExpectedResources == 0 { // i.e. the default, which actually means 1
-					require.Equal(t, 1, len(resources), "Expected one resource from parsing")
+					require.Len(t, resources, 1, "Expected one resource from parsing")
 				} else {
 					require.Equal(t, test.ExpectedResources, len(resources), fmt.Sprintf("Expected %d resources from parsing", test.ExpectedResources))
 				}

--- a/pkg/grizzly/parsing_test.go
+++ b/pkg/grizzly/parsing_test.go
@@ -181,7 +181,7 @@ func TestParseKindDetection(t *testing.T) {
 		}
 
 		parser := grizzly.DefaultParser(registry, nil, nil)
-		parseOpts := grizzly.Options{
+		parseOpts := grizzly.ParserOptions{
 			DefaultResourceKind: "",
 			DefaultFolderUID:    "General",
 		}

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -178,6 +178,18 @@ func (r Resources) Find(ref ResourceRef) (Resource, bool) {
 	return Resource{}, false
 }
 
+func (r Resources) Filter(predicate func(Resource) bool) Resources {
+	filtered := make(Resources, 0)
+
+	for _, resource := range r {
+		if predicate(resource) {
+			filtered = append(filtered, resource)
+		}
+	}
+
+	return filtered
+}
+
 func (r Resources) Len() int {
 	return len(r)
 }

--- a/pkg/grizzly/yaml.go
+++ b/pkg/grizzly/yaml.go
@@ -1,0 +1,59 @@
+package grizzly
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type YAMLParser struct {
+	registry Registry
+}
+
+func NewYAMLParser(registry Registry) *YAMLParser {
+	return &YAMLParser{
+		registry: registry,
+	}
+}
+
+func (parser *YAMLParser) Accept(file string) bool {
+	extension := filepath.Ext(file)
+
+	return extension == ".yaml" || extension == ".yml"
+}
+
+// Parse evaluates a YAML file and parses it into resources
+func (parser *YAMLParser) Parse(file string, options Options) (Resources, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+	decoder := yaml.NewDecoder(reader)
+	var resources Resources
+	for i := 0; ; i++ {
+		var m map[string]any
+		err = decoder.Decode(&m)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error decoding %s: %v", file, err)
+		}
+
+		parsedResources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID)
+		if err != nil {
+			return nil, err
+		}
+
+		resources = append(resources, parsedResources...)
+	}
+
+	return resources, nil
+}

--- a/pkg/grizzly/yaml.go
+++ b/pkg/grizzly/yaml.go
@@ -27,7 +27,7 @@ func (parser *YAMLParser) Accept(file string) bool {
 }
 
 // Parse evaluates a YAML file and parses it into resources
-func (parser *YAMLParser) Parse(file string, options Options) (Resources, error) {
+func (parser *YAMLParser) Parse(file string, options ParserOptions) (Resources, error) {
 	f, err := os.Open(file)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR doesn't add any feature, it refactors the way parsing is done to:

* isolate/decouple responsibilities
* make parser-related things more easily unit-testable (haven't written new tests yet though)
* make it easier to add new features later (WatchParser, "continue on error", ...)