### PR TITLE
Simplify the Handler.Parse() method's signature to match implementations

### DIFF
--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -1,16 +1,14 @@
 package grafana
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
-	"encoding/json"
-	"errors"
-
-	"github.com/grafana/grizzly/pkg/grizzly"
-
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
 // AlertRuleGroupHandler is a Grizzly Handler for Grafana alertRuleGroups
@@ -35,12 +33,8 @@ func (h *AlertRuleGroupHandler) ResourceFilePath(resource grizzly.Resource, file
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *AlertRuleGroupHandler) Parse(m map[string]any) (grizzly.Resources, error) {
-	resource, err := grizzly.ResourceFromMap(m)
-	if err != nil {
-		return nil, err
-	}
-	return grizzly.Resources{resource}, nil
+func (h *AlertRuleGroupHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+	return grizzly.ResourceFromMap(m)
 }
 
 // Validate checks that the uid format is valid

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -1,14 +1,12 @@
 package grafana
 
 import (
-	"fmt"
-
 	"encoding/json"
-
-	"github.com/grafana/grizzly/pkg/grizzly"
+	"fmt"
 
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
 // AlertContactPointHandler is a Grizzly Handler for Grafana contactPoints
@@ -33,13 +31,15 @@ func (h *AlertContactPointHandler) ResourceFilePath(resource grizzly.Resource, f
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *AlertContactPointHandler) Parse(m map[string]any) (grizzly.Resources, error) {
+func (h *AlertContactPointHandler) Parse(m map[string]any) (grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
 	}
+
 	resource.SetSpecString("uid", resource.Name())
-	return grizzly.Resources{resource}, nil
+
+	return resource, nil
 }
 
 // Validate returns the uid of resource

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -9,12 +9,11 @@ import (
 	"os"
 
 	"github.com/go-chi/chi"
-	"github.com/grafana/grizzly/pkg/grizzly"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
 	"github.com/grafana/grafana-openapi-client-go/client/search"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grizzly/pkg/grizzly"
+	log "github.com/sirupsen/logrus"
 )
 
 // Moved from utils.go
@@ -43,16 +42,18 @@ func (h *DashboardHandler) ResourceFilePath(resource grizzly.Resource, filetype 
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *DashboardHandler) Parse(m map[string]any) (grizzly.Resources, error) {
+func (h *DashboardHandler) Parse(m map[string]any) (grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
 	}
+
 	resource.SetSpecString("uid", resource.Name())
 	if !resource.HasMetadata("folder") {
 		resource.SetMetadata("folder", generalFolderUID)
 	}
-	return grizzly.Resources{resource}, nil
+
+	return resource, nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -1,18 +1,16 @@
 package grafana
 
 import (
-	"fmt"
-
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/go-openapi/runtime"
-	"github.com/grafana/grizzly/pkg/grizzly"
-
 	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
 // DatasourceHandler is a Grizzly Handler for Grafana datasources
@@ -37,11 +35,12 @@ func (h *DatasourceHandler) ResourceFilePath(resource grizzly.Resource, filetype
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *DatasourceHandler) Parse(m map[string]any) (grizzly.Resources, error) {
+func (h *DatasourceHandler) Parse(m map[string]any) (grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
 	}
+
 	defaults := map[string]interface{}{
 		"basicAuth":         false,
 		"basicAuthPassword": "",
@@ -64,7 +63,8 @@ func (h *DatasourceHandler) Parse(m map[string]any) (grizzly.Resources, error) {
 	}
 	spec["uid"] = resource.Name()
 	resource["spec"] = spec
-	return grizzly.Resources{resource}, nil
+
+	return resource, nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -1,17 +1,15 @@
 package grafana
 
 import (
-	"fmt"
-
 	"encoding/json"
 	"errors"
-
-	"github.com/grafana/grizzly/pkg/grizzly"
+	"fmt"
 
 	gclient "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/client/search"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
 // FolderHandler is a Grizzly Handler for Grafana dashboard folders
@@ -36,13 +34,15 @@ func (h *FolderHandler) ResourceFilePath(resource grizzly.Resource, filetype str
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *FolderHandler) Parse(m map[string]any) (grizzly.Resources, error) {
+func (h *FolderHandler) Parse(m map[string]any) (grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
 	}
+
 	resource.SetSpecString("uid", resource.Name())
-	return grizzly.Resources{resource}, nil
+
+	return resource, nil
 }
 
 // Validate returns the uid of resource

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -2,14 +2,12 @@ package grafana
 
 import (
 	"encoding/json"
-	"fmt"
-
 	"errors"
-
-	"github.com/grafana/grizzly/pkg/grizzly"
+	"fmt"
 
 	library "github.com/grafana/grafana-openapi-client-go/client/library_elements"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
 // LibraryElementHandler is a Grizzly Handler for Grafana dashboard folders
@@ -45,13 +43,15 @@ func (h *LibraryElementHandler) ResourceFilePath(resource grizzly.Resource, file
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *LibraryElementHandler) Parse(m map[string]any) (grizzly.Resources, error) {
+func (h *LibraryElementHandler) Parse(m map[string]any) (grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
 	}
+
 	resource.SetSpecString("uid", resource.Name())
-	return grizzly.Resources{resource}, nil
+
+	return resource, nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -1,14 +1,12 @@
 package grafana
 
 import (
-	"fmt"
-
 	"encoding/json"
-
-	"github.com/grafana/grizzly/pkg/grizzly"
+	"fmt"
 
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
 const (
@@ -37,12 +35,13 @@ func (h *AlertNotificationPolicyHandler) ResourceFilePath(resource grizzly.Resou
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *AlertNotificationPolicyHandler) Parse(m map[string]any) (grizzly.Resources, error) {
+func (h *AlertNotificationPolicyHandler) Parse(m map[string]any) (grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
 	}
-	return grizzly.Resources{resource}, h.Validate(resource)
+
+	return resource, h.Validate(resource)
 }
 
 // Validate returns the uid of resource

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -59,7 +59,7 @@ type Handler interface {
 	ResourceFilePath(resource Resource, filetype string) string
 
 	// Parse parses a manifest object into a struct for this resource type
-	Parse(m map[string]any) (Resources, error)
+	Parse(m map[string]any) (Resource, error)
 
 	// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 	Unprepare(resource Resource) *Resource

--- a/pkg/mimir/rules-handler.go
+++ b/pkg/mimir/rules-handler.go
@@ -2,7 +2,6 @@ package mimir
 
 import (
 	"fmt"
-
 	"log"
 	"os"
 	"os/exec"
@@ -35,12 +34,8 @@ func (h *RuleHandler) ResourceFilePath(resource grizzly.Resource, filetype strin
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *RuleHandler) Parse(m map[string]any) (grizzly.Resources, error) {
-	resource, err := grizzly.ResourceFromMap(m)
-	if err != nil {
-		return nil, err
-	}
-	return grizzly.Resources{resource}, nil
+func (h *RuleHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+	return grizzly.ResourceFromMap(m)
 }
 
 // Validate returns the uid of resource

--- a/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
+++ b/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
@@ -1,10 +1,9 @@
 package syntheticmonitoring
 
 import (
-	"fmt"
-
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grizzly/pkg/grizzly"
@@ -56,13 +55,15 @@ func (h *SyntheticMonitoringHandler) ResourceFilePath(resource grizzly.Resource,
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *SyntheticMonitoringHandler) Parse(m map[string]any) (grizzly.Resources, error) {
+func (h *SyntheticMonitoringHandler) Parse(m map[string]any) (grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
 	}
+
 	resource.SetSpecString("job", resource.GetMetadata("name"))
-	return grizzly.Resources{resource}, nil
+
+	return resource, nil
 }
 
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison


### PR DESCRIPTION
Refactoring introduced in #361: switches `Parse()` to return a single resource - no resource types need to return multiple