### PR TITLE
Re-add unprepare

### DIFF
--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -147,6 +147,7 @@ func Pull(registry Registry, resourcePath string, onlySpec bool, outputFormat st
 			if err != nil {
 				return err
 			}
+			resource = handler.Unprepare(*resource)
 
 			content, filename, _, err := Format(registry, resourcePath, resource, outputFormat, onlySpec)
 			if err != nil {


### PR DESCRIPTION
This PR fixes a regression. The `unprepare()` function strips from a resource coming from a
server any elements that aren't relevant in an as-code context. Examples include, in Grafana
dashboards, the `id` and `version` fields, as they are specific to an individual Grafana
instance and thus cause problems when trying to migrate resources from one instance to
another.
