### PR TITLE
Pull continue on error

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/go-clix/cli"
@@ -113,20 +112,8 @@ func pullCmd(registry grizzly.Registry) *cli.Command {
 		targets := currentContext.GetTargets(opts.Targets)
 
 		err = grizzly.Pull(registry, args[0], onlySpec, format, targets, continueOnError, eventsRecorder)
-		summary := eventsRecorder.Summary()
 
-		var summaryParts []string
-		if summary.EventCounts[grizzly.ResourceFailure.ID] > 0 {
-			summaryParts = append(summaryParts, grizzly.Pluraliser(summary.EventCounts[grizzly.ResourceFailure.ID], "error"))
-		}
-		if summary.EventCounts[grizzly.ResourcePulled.ID] > 0 {
-			summaryParts = append(summaryParts, fmt.Sprintf("%s pulled", grizzly.Pluraliser(summary.EventCounts[grizzly.ResourcePulled.ID], "resource")))
-		}
-		if summary.EventCounts[grizzly.ResourceNotFound.ID] > 0 {
-			summaryParts = append(summaryParts, fmt.Sprintf("%s not found", grizzly.Pluraliser(summary.EventCounts[grizzly.ResourceNotFound.ID], "resource")))
-		}
-
-		notifier.Info(nil, strings.Join(summaryParts, ", "))
+		notifier.Info(nil, eventsRecorder.Summary().AsString("resource"))
 
 		// errors are already displayed by the `eventsRecorder`, so we return a
 		// "silent" one to ensure that the exit code will be non-zero
@@ -271,21 +258,8 @@ func applyCmd(registry grizzly.Registry) *cli.Command {
 		notifier.Info(nil, fmt.Sprintf("Applying %s", grizzly.Pluraliser(resources.Len(), "resource")))
 
 		applyErr := grizzly.Apply(registry, resources, continueOnError, eventsRecorder)
-		summary := eventsRecorder.Summary()
 
-		var summaryParts []string
-		if summary.EventCounts[grizzly.ResourceFailure.ID] > 0 {
-			summaryParts = append(summaryParts, grizzly.Pluraliser(summary.EventCounts[grizzly.ResourceFailure.ID], "error"))
-		}
-		appliedCount := summary.EventCounts[grizzly.ResourceAdded.ID] + summary.EventCounts[grizzly.ResourceUpdated.ID]
-		if appliedCount > 0 {
-			summaryParts = append(summaryParts, fmt.Sprintf("%s applied", grizzly.Pluraliser(appliedCount, "resource")))
-		}
-		if summary.EventCounts[grizzly.ResourceNotChanged.ID] > 0 {
-			summaryParts = append(summaryParts, fmt.Sprintf("%s unchanged", grizzly.Pluraliser(summary.EventCounts[grizzly.ResourceNotChanged.ID], "resource")))
-		}
-
-		notifier.Info(nil, strings.Join(summaryParts, ", "))
+		notifier.Info(nil, eventsRecorder.Summary().AsString("resource"))
 
 		// errors are already displayed by the `eventsRecorder`, so we return a
 		// "silent" one to ensure that the exit code will be non-zero

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -93,6 +93,9 @@ func pullCmd(registry grizzly.Registry) *cli.Command {
 		Args:  cli.ArgsExact(1),
 	}
 	var opts Opts
+	var continueOnError bool
+
+	cmd.Flags().BoolVarP(&continueOnError, "continue-on-error", "e", false, "don't stop pulling on error")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		format, onlySpec, err := getOutputFormat(opts)
@@ -105,7 +108,7 @@ func pullCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 		targets := currentContext.GetTargets(opts.Targets)
-		return grizzly.Pull(registry, args[0], onlySpec, format, targets)
+		return grizzly.Pull(registry, args[0], onlySpec, format, targets, continueOnError)
 	}
 
 	cmd = initialiseOnlySpec(cmd, &opts)

--- a/integration/dashboard_test.go
+++ b/integration/dashboard_test.go
@@ -67,7 +67,7 @@ func TestDashboard(t *testing.T) {
 			Commands: []Command{
 				{
 					Command:                "apply no-folder.yml",
-					ExpectedOutputContains: "Dashboard.no-folder no differences\n",
+					ExpectedOutputContains: "Dashboard.no-folder unchanged\n",
 				},
 				{
 					Command:                "get Dashboard.no-folder",
@@ -173,7 +173,7 @@ func TestDashboard(t *testing.T) {
 				{
 					Command:                "apply continue-on-error/workflow",
 					ExpectedCode:           1,
-					ExpectedOutputContains: "Dashboard.dashboard-2 failure: cannot upload dashboard dashboard-2 as folder non-existent-folder not found",
+					ExpectedOutputContains: "Dashboard.dashboard-2 failed: cannot upload dashboard dashboard-2 as folder non-existent-folder not found",
 				},
 			},
 		})
@@ -187,8 +187,8 @@ func TestDashboard(t *testing.T) {
 					Command:      "apply -e continue-on-error/workflow",
 					ExpectedCode: 1,
 					ExpectedOutputContainsAll: []string{
-						"Dashboard.dashboard-2 failure: cannot upload dashboard dashboard-2 as folder non-existent-folder not found",
-						"Dashboard.dashboard-3 failure: cannot upload dashboard dashboard-3 as folder non-existent-folder not found",
+						"Dashboard.dashboard-2 failed: cannot upload dashboard dashboard-2 as folder non-existent-folder not found",
+						"Dashboard.dashboard-3 failed: cannot upload dashboard dashboard-3 as folder non-existent-folder not found",
 					},
 				},
 			},

--- a/pkg/grizzly/events.go
+++ b/pkg/grizzly/events.go
@@ -24,7 +24,9 @@ type EventType struct {
 var (
 	ResourceAdded      = EventType{ID: "resource-added", Severity: Notice, HumanReadable: "added"}
 	ResourceNotChanged = EventType{ID: "resource-not-changed", Severity: Info, HumanReadable: "no differences"}
+	ResourceNotFound   = EventType{ID: "resource-not-found", Severity: Info, HumanReadable: "not found"}
 	ResourceUpdated    = EventType{ID: "resource-updated", Severity: Notice, HumanReadable: "updated"}
+	ResourcePulled     = EventType{ID: "resource-pulled", Severity: Notice, HumanReadable: "pulled"}
 	ResourceFailure    = EventType{ID: "resource-failure", Severity: Error, HumanReadable: "failure"}
 )
 

--- a/pkg/grizzly/formatting.go
+++ b/pkg/grizzly/formatting.go
@@ -20,27 +20,24 @@ func Format(registry Registry, resourcePath string, resource *Resource, format s
 	switch format {
 	case "yaml":
 		extension = "yaml"
-		filename, err = getFilename(registry, resourcePath, resource, extension)
-		if err != nil {
-			return nil, "", "", err
-		}
 		content, err = spec.YAML()
 	case "json":
 		extension = "json"
-		filename, err = getFilename(registry, resourcePath, resource, extension)
-		if err != nil {
-			return nil, "", "", err
-		}
 		content, err = spec.JSON()
 	default:
 		extension = "yaml"
-		filename, err = getFilename(registry, resourcePath, resource, extension)
-		if err != nil {
-			return nil, "", "", err
-		}
 		content, err = spec.YAML()
 	}
-	return []byte(content), filename, extension, err
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	filename, err = getFilename(registry, resourcePath, resource, extension)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	return []byte(content), filename, extension, nil
 }
 
 func getFilename(registry Registry, resourcePath string, resource *Resource, extension string) (string, error) {


### PR DESCRIPTION
Similarly to what's been done in https://github.com/grafana/grizzly/pull/361 and https://github.com/grafana/grizzly/pull/371, I add a `--continue-on-error` flag to the `grr pull` command.

This is what it looks like when I cause some errors (by removing write permissions on the destination folder mid-pull):

![Screenshot from 2024-03-13 16-55-20](https://github.com/grafana/grizzly/assets/66958/78c75cb5-2ae4-48c1-93f9-65f2583e3efe)
