### PR TITLE
Make Resource a struct

### DIFF
--- a/integration/datasource_test.go
+++ b/integration/datasource_test.go
@@ -44,7 +44,7 @@ func TestDatasources(t *testing.T) {
 
 		var resource grizzly.Resource
 
-		err = json.Unmarshal(datasource, &resource)
+		err = json.Unmarshal(datasource, &resource.Body)
 		require.NoError(t, err)
 
 		err = handler.Add(resource)
@@ -58,7 +58,7 @@ func TestDatasources(t *testing.T) {
 		t.Run("put remote datasource - update", func(t *testing.T) {
 			ds.SetSpecString("type", "new-type")
 
-			err := handler.Update(nil, *ds)
+			err := handler.Update(grizzly.Resource{}, *ds)
 			require.NoError(t, err)
 
 			updatedDS, err := handler.GetByUID("appdynamics")
@@ -74,7 +74,7 @@ func TestDatasources(t *testing.T) {
 
 		var resource grizzly.Resource
 
-		err = json.Unmarshal(datasource, &resource)
+		err = json.Unmarshal(datasource, &resource.Body)
 		require.NoError(t, err)
 
 		resource.SetSpecString("name", "AppDynamics")
@@ -87,8 +87,10 @@ func TestDatasources(t *testing.T) {
 
 	t.Run("Check getUID is functioning correctly", func(t *testing.T) {
 		resource := grizzly.Resource{
-			"metadata": map[string]interface{}{
-				"name": "test",
+			Body: map[string]any{
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
 			},
 		}
 		handler := grafana.DatasourceHandler{}

--- a/integration/folder_test.go
+++ b/integration/folder_test.go
@@ -45,7 +45,7 @@ func TestFolders(t *testing.T) {
 
 		var resource grizzly.Resource
 
-		err = json.Unmarshal(folder, &resource)
+		err = json.Unmarshal(folder, &resource.Body)
 		require.NoError(t, err)
 
 		err = handler.Add(resource)
@@ -71,7 +71,7 @@ func TestFolders(t *testing.T) {
 
 		var resource grizzly.Resource
 
-		err = json.Unmarshal(folder, &resource)
+		err = json.Unmarshal(folder, &resource.Body)
 		require.NoError(t, err)
 
 		resource.SetSpecString("title", "Azure Data Explorer")

--- a/integration/library-element_test.go
+++ b/integration/library-element_test.go
@@ -22,7 +22,7 @@ func TestLibraryElements(t *testing.T) {
 
 		var resource grizzly.Resource
 
-		err = json.Unmarshal(libraryElement, &resource)
+		err = json.Unmarshal(libraryElement, &resource.Body)
 		require.NoError(t, err)
 
 		err = handler.Add(resource)

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -33,7 +33,7 @@ func (h *AlertRuleGroupHandler) ResourceFilePath(resource grizzly.Resource, file
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *AlertRuleGroupHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+func (h *AlertRuleGroupHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
 	return grizzly.ResourceFromMap(m)
 }
 
@@ -56,11 +56,11 @@ func (h *AlertRuleGroupHandler) Validate(resource grizzly.Resource) error {
 }
 
 func (h *AlertRuleGroupHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	spec := resource["spec"].(map[string]interface{})
-	if val, ok := spec["name"]; ok {
-		return val.(string), nil
+	name, ok := resource.GetSpecString("name")
+	if !ok {
+		return "", fmt.Errorf("UID not specified")
 	}
-	return "", fmt.Errorf("UID not specified")
+	return name, nil
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -31,7 +31,7 @@ func (h *AlertContactPointHandler) ResourceFilePath(resource grizzly.Resource, f
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *AlertContactPointHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+func (h *AlertContactPointHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
@@ -54,11 +54,11 @@ func (h *AlertContactPointHandler) Validate(resource grizzly.Resource) error {
 }
 
 func (h *AlertContactPointHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	spec := resource["spec"].(map[string]interface{})
-	if val, ok := spec["uid"]; ok {
-		return val.(string), nil
+	uid, ok := resource.GetSpecString("uid")
+	if !ok {
+		return "", fmt.Errorf("UID not specified")
 	}
-	return "", fmt.Errorf("UID not specified")
+	return uid, nil
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -42,7 +42,7 @@ func (h *DashboardHandler) ResourceFilePath(resource grizzly.Resource, filetype 
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *DashboardHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+func (h *DashboardHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
@@ -82,11 +82,11 @@ func (h *DashboardHandler) Validate(resource grizzly.Resource) error {
 }
 
 func (h *DashboardHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	spec := resource["spec"].(map[string]interface{})
-	if val, ok := spec["uid"]; ok {
-		return val.(string), nil
+	uid, ok := resource.GetSpecString("uid")
+	if !ok {
+		return "", fmt.Errorf("UID not specified")
 	}
-	return "", fmt.Errorf("UID not specified")
+	return uid, nil
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/grafana/folder-handler.go
+++ b/pkg/grafana/folder-handler.go
@@ -34,7 +34,7 @@ func (h *FolderHandler) ResourceFilePath(resource grizzly.Resource, filetype str
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *FolderHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+func (h *FolderHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
@@ -58,11 +58,11 @@ func (h *FolderHandler) Validate(resource grizzly.Resource) error {
 }
 
 func (h *FolderHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	spec := resource["spec"].(map[string]interface{})
-	if val, ok := spec["uid"]; ok {
-		return val.(string), nil
+	uid, ok := resource.GetSpecString("uid")
+	if !ok {
+		return "", fmt.Errorf("UID not specified")
 	}
-	return "", fmt.Errorf("UID not specified")
+	return uid, nil
 }
 
 // Sort sorts according to handler needs

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -43,7 +43,7 @@ func (h *LibraryElementHandler) ResourceFilePath(resource grizzly.Resource, file
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *LibraryElementHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+func (h *LibraryElementHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
@@ -64,10 +64,8 @@ func (h *LibraryElementHandler) Unprepare(resource grizzly.Resource) *grizzly.Re
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *LibraryElementHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	if existing != nil {
-		val := existing.GetSpecValue("version")
-		resource.SetSpecValue("version", val)
-	}
+	val := existing.GetSpecValue("version")
+	resource.SetSpecValue("version", val)
 	resource.DeleteSpecKey("meta")
 	return &resource
 }
@@ -85,11 +83,11 @@ func (h *LibraryElementHandler) Validate(resource grizzly.Resource) error {
 }
 
 func (h *LibraryElementHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	spec := resource["spec"].(map[string]interface{})
-	if val, ok := spec["uid"]; ok {
-		return val.(string), nil
+	uid, ok := resource.GetSpecString("uid")
+	if !ok {
+		return "", fmt.Errorf("UID not specified")
 	}
-	return "", fmt.Errorf("UID not specified")
+	return uid, nil
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -53,7 +53,7 @@ func (h *AlertNotificationPolicyHandler) Validate(resource grizzly.Resource) err
 }
 
 func (h *AlertNotificationPolicyHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	return "", fmt.Errorf("GetSpecUID not implemented for notification policies")
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -53,11 +53,7 @@ func (h *AlertNotificationPolicyHandler) Validate(resource grizzly.Resource) err
 }
 
 func (h *AlertNotificationPolicyHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	uid, ok := resource.GetSpecString("XXXXXXX")
-	if !ok {
-		return "", fmt.Errorf("UID not specified")
-	}
-	return uid, nil
+	return "", fmt.Errorf("not implemented")
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -35,13 +35,13 @@ func (h *AlertNotificationPolicyHandler) ResourceFilePath(resource grizzly.Resou
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *AlertNotificationPolicyHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+func (h *AlertNotificationPolicyHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
 	}
 
-	return resource, h.Validate(resource)
+	return resource, h.Validate(*resource)
 }
 
 // Validate returns the uid of resource
@@ -53,11 +53,11 @@ func (h *AlertNotificationPolicyHandler) Validate(resource grizzly.Resource) err
 }
 
 func (h *AlertNotificationPolicyHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	spec := resource["spec"].(map[string]interface{})
-	if val, ok := spec["XXXXXXX"]; ok {
-		return val.(string), nil
+	uid, ok := resource.GetSpecString("XXXXXXX")
+	if !ok {
+		return "", fmt.Errorf("UID not specified")
 	}
-	return "", fmt.Errorf("UID not specified")
+	return uid, nil
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/grizzly/formatting.go
+++ b/pkg/grizzly/formatting.go
@@ -1,8 +1,11 @@
 package grizzly
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 )
 
 func Format(registry Registry, resourcePath string, resource *Resource, format string, onlySpec bool) ([]byte, string, string, error) {
@@ -11,27 +14,26 @@ func Format(registry Registry, resourcePath string, resource *Resource, format s
 	var extension string
 	var err error
 
-	spec := resource
+	spec := resource.Body
 	if onlySpec {
-		s := Resource(resource.Spec())
-		spec = &s
+		spec = resource.Spec()
 	}
 
-	switch format {
-	case "yaml":
-		extension = "yaml"
-		content, err = spec.YAML()
-	case "json":
+	if format == "json" {
 		extension = "json"
-		content, err = spec.JSON()
-	default:
+		j, err := json.MarshalIndent(spec, "", "  ")
+		if err != nil {
+			return nil, "", "", err
+		}
+		content = string(j)
+	} else {
 		extension = "yaml"
-		content, err = spec.YAML()
+		y, err := yaml.Marshal(spec)
+		if err != nil {
+			return nil, "", "", err
+		}
+		content = string(y)
 	}
-	if err != nil {
-		return nil, "", "", err
-	}
-
 	filename, err = getFilename(registry, resourcePath, resource, extension)
 	if err != nil {
 		return nil, "", "", err

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -59,7 +59,7 @@ type Handler interface {
 	ResourceFilePath(resource Resource, filetype string) string
 
 	// Parse parses a manifest object into a struct for this resource type
-	Parse(m map[string]any) (Resource, error)
+	Parse(m map[string]any) (*Resource, error)
 
 	// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 	Unprepare(resource Resource) *Resource

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -185,7 +185,7 @@ func parseAny(registry Registry, data any, resourceKind, folderUID string) (Reso
 			return nil, err
 		}
 
-		return Resources{resource}, nil
+		return Resources{*resource}, nil
 	}
 
 	kind := registry.Detect(data)
@@ -220,12 +220,12 @@ func parseAny(registry Registry, data any, resourceKind, folderUID string) (Reso
 			resource.SetMetadata("folder", folderUID)
 		}
 
-		resource, err = handler.Parse(resource)
+		r, err := handler.Parse(resource.Body)
 		if err != nil {
 			return nil, err
 		}
 
-		return Resources{resource}, nil
+		return Resources{*r}, nil
 	}
 
 	walker := walker{}
@@ -365,7 +365,7 @@ func (w *walker) walkObj(obj map[string]any, path trace) error {
 			return err
 		}
 
-		w.Resources = append(w.Resources, resource)
+		w.Resources = append(w.Resources, *resource)
 		return nil
 	}
 

--- a/pkg/grizzly/parsing_test.go
+++ b/pkg/grizzly/parsing_test.go
@@ -26,73 +26,89 @@ func TestValidateEnvelope(t *testing.T) {
 		}{
 			{
 				Name: "missing kind",
-				Resource: map[string]any{
-					"metadata": metadata,
-					"spec":     spec,
+				Resource: grizzly.Resource{
+					Body: map[string]any{
+						"metadata": metadata,
+						"spec":     spec,
+					},
 				},
 				ExpectedError: "kind missing",
 			},
 			{
 				Name: "missing metadata",
-				Resource: map[string]any{
-					"kind": kind,
-					"spec": spec,
+				Resource: grizzly.Resource{
+					Body: map[string]any{
+						"kind": kind,
+						"spec": spec,
+					},
 				},
 				ExpectedError: "metadata missing",
 			},
 			{
 				Name: "missing name",
-				Resource: map[string]any{
-					"kind":     kind,
-					"metadata": map[string]any{},
-					"spec":     spec,
+				Resource: grizzly.Resource{
+					Body: map[string]any{
+						"kind":     kind,
+						"metadata": map[string]any{},
+						"spec":     spec,
+					},
 				},
 				ExpectedError: "metadata/name missing",
 			},
 			{
 				Name: "missing spec",
-				Resource: map[string]any{
-					"kind":     kind,
-					"metadata": metadata,
+				Resource: grizzly.Resource{
+					Body: map[string]any{
+						"kind":     kind,
+						"metadata": metadata,
+					},
 				},
 				ExpectedError: "spec missing",
 			},
 			{
 				Name: "empty spec",
-				Resource: map[string]any{
-					"kind":     kind,
-					"metadata": metadata,
-					"spec":     map[string]any{},
+				Resource: grizzly.Resource{
+					Body: map[string]any{
+						"kind":     kind,
+						"metadata": metadata,
+						"spec":     map[string]any{},
+					},
 				},
 				ExpectedError: "spec should not be empty",
 			},
 			{
 				Name: "invalid spec",
-				Resource: map[string]any{
-					"kind":     kind,
-					"metadata": metadata,
-					"spec":     "a string spec",
+				Resource: grizzly.Resource{
+					Body: map[string]any{
+						"kind":     kind,
+						"metadata": metadata,
+						"spec":     "a string spec",
+					},
 				},
 				ExpectedError: "spec is not a map",
 			},
 			{
-				Name:          "empty resource",
-				Resource:      map[string]any{},
+				Name: "empty resource",
+				Resource: grizzly.Resource{
+					Body: map[string]any{},
+				},
 				ExpectedError: "kind missing, metadata missing, spec missing",
 			},
+
 			{
 				Name: "everything correct",
-				Resource: map[string]any{
-					"kind":     kind,
-					"metadata": metadata,
-					"spec":     spec,
+				Resource: grizzly.Resource{
+					Body: map[string]any{
+						"kind":     kind,
+						"metadata": metadata,
+						"spec":     spec,
+					},
 				},
 			},
 		}
 		for _, test := range tests {
 			t.Run(test.Name, func(t *testing.T) {
-				m := map[string]any(test.Resource)
-				err := grizzly.ValidateEnvelope(m)
+				err := grizzly.ValidateEnvelope(test.Resource.Body)
 				if test.ExpectedError != "" {
 					require.Error(t, err)
 					require.Equal(t, "errors parsing resource: "+test.ExpectedError, err.Error())

--- a/pkg/mimir/rules-handler.go
+++ b/pkg/mimir/rules-handler.go
@@ -56,7 +56,7 @@ func (h *RuleHandler) GetUID(resource grizzly.Resource) (string, error) {
 }
 
 func (h *RuleHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	return "", fmt.Errorf("GetSpecUID not implemented for prometheus rules")
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/mimir/rules-handler.go
+++ b/pkg/mimir/rules-handler.go
@@ -34,7 +34,7 @@ func (h *RuleHandler) ResourceFilePath(resource grizzly.Resource, filetype strin
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *RuleHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+func (h *RuleHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
 	return grizzly.ResourceFromMap(m)
 }
 
@@ -56,11 +56,11 @@ func (h *RuleHandler) GetUID(resource grizzly.Resource) (string, error) {
 }
 
 func (h *RuleHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	spec := resource["spec"].(map[string]interface{})
-	if val, ok := spec["XXXXXXX"]; ok {
-		return val.(string), nil
+	uid, ok := resource.GetSpecString("XXXXXXX")
+	if !ok {
+		return "", fmt.Errorf("UID not specified")
 	}
-	return "", fmt.Errorf("UID not specified")
+	return uid, nil
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/mimir/rules-handler.go
+++ b/pkg/mimir/rules-handler.go
@@ -56,11 +56,7 @@ func (h *RuleHandler) GetUID(resource grizzly.Resource) (string, error) {
 }
 
 func (h *RuleHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	uid, ok := resource.GetSpecString("XXXXXXX")
-	if !ok {
-		return "", fmt.Errorf("UID not specified")
-	}
-	return uid, nil
+	return "", fmt.Errorf("not implemented")
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/mimir/rules_test.go
+++ b/pkg/mimir/rules_test.go
@@ -93,9 +93,11 @@ func TestRules(t *testing.T) {
 
 	t.Run("Check getUID is functioning correctly", func(t *testing.T) {
 		resource := grizzly.Resource{
-			"metadata": map[string]interface{}{
-				"name":      "test",
-				"namespace": "test_namespace",
+			Body: map[string]any{
+				"metadata": map[string]any{
+					"name":      "test",
+					"namespace": "test_namespace",
+				},
 			},
 		}
 		uid, err := h.GetUID(resource)

--- a/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
+++ b/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
@@ -103,11 +103,7 @@ func (h *SyntheticMonitoringHandler) GetUID(resource grizzly.Resource) (string, 
 	return fmt.Sprintf("%s.%s", resource.GetMetadata("type"), resource.Name()), nil
 }
 func (h *SyntheticMonitoringHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	uid, ok := resource.GetSpecString("XXXXXXX")
-	if !ok {
-		return "", fmt.Errorf("UID not specified")
-	}
-	return uid, nil
+	return "", fmt.Errorf("not implemented")
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
+++ b/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
@@ -55,7 +55,7 @@ func (h *SyntheticMonitoringHandler) ResourceFilePath(resource grizzly.Resource,
 }
 
 // Parse parses a manifest object into a struct for this resource type
-func (h *SyntheticMonitoringHandler) Parse(m map[string]any) (grizzly.Resource, error) {
+func (h *SyntheticMonitoringHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
 	resource, err := grizzly.ResourceFromMap(m)
 	if err != nil {
 		return nil, err
@@ -103,11 +103,11 @@ func (h *SyntheticMonitoringHandler) GetUID(resource grizzly.Resource) (string, 
 	return fmt.Sprintf("%s.%s", resource.GetMetadata("type"), resource.Name()), nil
 }
 func (h *SyntheticMonitoringHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	spec := resource["spec"].(map[string]interface{})
-	if val, ok := spec["XXXXXXX"]; ok {
-		return val.(string), nil
+	uid, ok := resource.GetSpecString("XXXXXXX")
+	if !ok {
+		return "", fmt.Errorf("UID not specified")
 	}
-	return "", fmt.Errorf("UID not specified")
+	return uid, nil
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID
@@ -301,7 +301,7 @@ func (h *SyntheticMonitoringHandler) updateCheck(resource grizzly.Resource) erro
 
 func (h *SyntheticMonitoringHandler) SpecToCheck(r *grizzly.Resource) (synthetic_monitoring.Check, error) {
 	var smCheck synthetic_monitoring.Check
-	data, err := json.Marshal((*r)["spec"])
+	data, err := json.Marshal(r.Body["spec"])
 	if err != nil {
 		return synthetic_monitoring.Check{}, nil
 	}

--- a/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
+++ b/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
@@ -103,7 +103,7 @@ func (h *SyntheticMonitoringHandler) GetUID(resource grizzly.Resource) (string, 
 	return fmt.Sprintf("%s.%s", resource.GetMetadata("type"), resource.Name()), nil
 }
 func (h *SyntheticMonitoringHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	return "", fmt.Errorf("GetSpecUID not implemented for Synthetic Monitoring")
 }
 
 // GetByUID retrieves JSON for a resource from an endpoint, by UID

--- a/pkg/syntheticmonitoring/synthetic-monitoring_test.go
+++ b/pkg/syntheticmonitoring/synthetic-monitoring_test.go
@@ -14,9 +14,11 @@ func TestSyntheticMonitoring(t *testing.T) {
 
 	t.Run("Check getUID is functioning correctly", func(t *testing.T) {
 		resource := grizzly.Resource{
-			"metadata": map[string]interface{}{
-				"name": "test",
-				"type": "http",
+			Body: map[string]any{
+				"metadata": map[string]interface{}{
+					"name": "test",
+					"type": "http",
+				},
 			},
 		}
 		handler := NewSyntheticMonitoringHandler(nil)


### PR DESCRIPTION
In preparation for further refactoring, particularly adding "save" support to the server/proxy,
we need to move the Resource type to a struct, rather than just a map[string]any. This PR
should be a no-op prepping for further work.
﻿
