### PR TITLE
Reinstate preview as snapshot cmd

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -78,6 +78,7 @@ func main() {
 		applyCmd(registry),
 		watchCmd(registry),
 		exportCmd(registry),
+		snapshotCmd(registry),
 		providersCmd(registry),
 		configCmd(),
 		serveCmd(registry),

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -101,6 +101,13 @@ type Handler interface {
 	Detect(map[string]any) bool
 }
 
+// SnapshotHandler describes a handler that has the ability to push a resource as
+// a snapshot
+type SnapshotHandler interface {
+	// Snapshot pushes a resource as a snapshot with an expiry
+	Snapshot(resource Resource, expiresSeconds int) error
+}
+
 // ListenHandler describes a handler that has the ability to watch a single
 // resource for changes, and write changes to that resource to a local file
 type ListenHandler interface {

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -396,6 +396,26 @@ func applyResource(registry Registry, resource Resource, trailRecorder eventsRec
 	return nil
 }
 
+// Snapshot pushes resources to endpoints as snapshots, if supported
+func Snapshot(registry Registry, resources Resources, expiresSeconds int) error {
+	for _, resource := range resources {
+		handler, err := registry.GetHandler(resource.Kind())
+		if err != nil {
+			return err
+		}
+		snapshotHandler, ok := handler.(SnapshotHandler)
+		if !ok {
+			notifier.NotSupported(resource, "preview")
+			continue
+		}
+		err = snapshotHandler.Snapshot(resource, expiresSeconds)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // WatchParser encapsulates the action of parsing a resource (jsonnet or otherwise)
 type WatchParser interface {
 	Name() string


### PR DESCRIPTION
PR #349 removed the preview feature, as it was an old (and believed unused) feature. After
discussion with colleagues and some users, we propose to re-add it, but with a more
on-target name: `snapshot`, given that previewing something should not have side-effects.﻿
