### PR TITLE
Fix "save" via server and track provenance

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -45,7 +45,9 @@ func listCmd(registry grizzly.Registry) *cli.Command {
 	}
 	var opts Opts
 	var isRemote bool
+	var isVerbose bool
 	cmd.Flags().BoolVarP(&isRemote, "remote", "r", false, "list remote resources")
+	cmd.Flags().BoolVarP(&isVerbose, "verbose", "v", false, "show more information about resources")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		currentContext, err := config.CurrentContext()
@@ -80,7 +82,7 @@ func listCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 
-		return grizzly.List(registry, resources)
+		return grizzly.List(registry, resources, isVerbose)
 	}
 	return initialiseCmd(cmd, &opts)
 }

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -403,18 +403,18 @@ func (h *DashboardHandler) DashboardJSONPostHandler(p grizzly.Server) http.Handl
 
 		out, _, _, err := grizzly.Format(p.Registry, p.ResourcePath, &resource, p.OutputFormat, p.OnlySpec)
 		if err != nil {
-			grizzly.SendError(w, "Error formatting content", err, 400)
+			grizzly.SendError(w, "Error formatting content", err, 500)
 			return
 		}
 
 		resources, err := p.Parser.Parse()
 		if err != nil {
-			grizzly.SendError(w, "Error parsing existing resources", err, 400)
+			grizzly.SendError(w, "Error parsing existing resources", err, 500)
 			return
 		}
 		existing, found := resources.Find(grizzly.NewResourceRef("Dashboard", uid))
 		if !found {
-			grizzly.SendError(w, fmt.Sprintf("Dashboard with UID %s not found", uid), fmt.Errorf("dashboard with UID %s not found", uid), 404)
+			grizzly.SendError(w, fmt.Sprintf("Dashboard with UID %s not found", uid), fmt.Errorf("dashboard with UID %s not found", uid), 500)
 			return
 		}
 		if !existing.Source.Rewritable {
@@ -424,7 +424,7 @@ func (h *DashboardHandler) DashboardJSONPostHandler(p grizzly.Server) http.Handl
 
 		err = os.WriteFile(existing.Source.Path, out, 0644)
 		if err != nil {
-			grizzly.SendError(w, fmt.Sprintf("Error writing file: %s", err), err, 400)
+			grizzly.SendError(w, fmt.Sprintf("Error writing file: %s", err), err, 500)
 			return
 		}
 

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -353,8 +353,9 @@ func (h *DashboardHandler) DashboardJSONGetHandler(p grizzly.Server) http.Handle
 			grizzly.SendError(w, fmt.Sprintf("Dashboard with UID %s not found", uid), fmt.Errorf("dashboard with UID %s not found", uid), 404)
 			return
 		}
-		resource.SetSpecValue("version", 1)
-
+		if resource.GetSpecValue("version") == nil {
+			resource.SetSpecValue("version", 1)
+		}
 		meta := map[string]interface{}{
 			"type":      "db",
 			"isStarred": false,

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -416,6 +416,10 @@ func (h *DashboardHandler) DashboardJSONPostHandler(p grizzly.Server) http.Handl
 			grizzly.SendError(w, fmt.Sprintf("Dashboard with UID %s not found", uid), fmt.Errorf("dashboard with UID %s not found", uid), 404)
 			return
 		}
+		if !existing.Source.Rewritable {
+			grizzly.SendError(w, "The source for this dashboard is not rewritable", fmt.Errorf("the source for this dashboard is not rewritable"), 400)
+			return
+		}
 
 		err = os.WriteFile(existing.Source.Path, out, 0644)
 		if err != nil {

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grizzly/pkg/grizzly"
 	"github.com/grafana/grizzly/pkg/grizzly/notifier"
-	log "github.com/sirupsen/logrus"
 )
 
 // Moved from utils.go
@@ -283,6 +282,11 @@ func (h *DashboardHandler) GetProxyEndpoints(p grizzly.Server) []grizzly.ProxyEn
 		},
 		{
 			Method:  "POST",
+			Url:     "/api/dashboards/db",
+			Handler: h.DashboardJSONPostHandler(p),
+		},
+		{
+			Method:  "POST",
 			Url:     "/api/dashboards/db/",
 			Handler: h.DashboardJSONPostHandler(p),
 		},
@@ -294,14 +298,12 @@ func (h *DashboardHandler) RootDashboardPageHandler(p grizzly.Server) http.Handl
 		w.Header().Add("Content-Type", "text/html")
 		config := h.Provider.(ClientProvider).Config()
 		if config.URL == "" {
-			w.WriteHeader(400)
-			fmt.Fprintf(w, "<p><b>Error:</b> No URL provided")
+			grizzly.SendError(w, "Error: No Grafana URL configured", fmt.Errorf("no Grafana URL configured"), 400)
 			return
 		}
 		req, err := http.NewRequest("GET", config.URL+r.URL.Path, nil)
 		if err != nil {
-			log.Print(err)
-			http.Error(w, http.StatusText(500), 500)
+			grizzly.SendError(w, http.StatusText(500), err, 500)
 			return
 		}
 		req.Header.Set("Authorization", "Bearer "+config.Token)
@@ -336,22 +338,22 @@ func (h *DashboardHandler) DashboardJSONGetHandler(p grizzly.Server) http.Handle
 	return func(w http.ResponseWriter, r *http.Request) {
 		uid := chi.URLParam(r, "uid")
 		if uid == "" {
-			http.Error(w, "No UID specified", 400)
+			grizzly.SendError(w, "No UID specified", fmt.Errorf("no UID specified within the URL"), 400)
 			return
 		}
 
 		resources, err := p.Parser.Parse()
 		if err != nil {
-			log.Error("Error: ", err)
-			http.Error(w, fmt.Sprintf("Error: %s", err), 500)
+			grizzly.SendError(w, "Error parsing dashboard JSON", err, 500)
 			return
 		}
 
 		resource, found := resources.Find(grizzly.NewResourceRef("Dashboard", uid))
 		if !found {
-			http.Error(w, fmt.Sprintf("Dashboard with UID %s not found", uid), 404)
+			grizzly.SendError(w, fmt.Sprintf("Dashboard with UID %s not found", uid), fmt.Errorf("dashboard with UID %s not found", uid), 404)
 			return
 		}
+		resource.SetSpecValue("version", 1)
 
 		meta := map[string]interface{}{
 			"type":      "db",
@@ -372,36 +374,52 @@ func (h *DashboardHandler) DashboardJSONGetHandler(p grizzly.Server) http.Handle
 
 func (h *DashboardHandler) DashboardJSONPostHandler(p grizzly.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
-		dash := map[string]interface{}{}
+		resp := struct {
+			Dashboard map[string]any `json:"dashboard"`
+		}{}
 		content, _ := io.ReadAll(r.Body)
-		err := json.Unmarshal(content, &dash)
+		err := json.Unmarshal(content, &resp)
 		if err != nil {
-			http.Error(w, "Error parsing JSON", 400)
+			grizzly.SendError(w, "Error parsing JSON", err, 400)
 			return
 		}
-
-		resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), "dummy", dash)
+		resource, err := grizzly.NewResource(h.APIVersion(), h.Kind(), "dummy", resp.Dashboard)
 		if err != nil {
-			http.Error(w, "Error creating resource", 400)
+			grizzly.SendError(w, "Error creating resource", err, 400)
 			return
 		}
-		uid, err := h.GetUID(resource)
+		uid, err := h.GetSpecUID(resource)
 		if err != nil {
-			http.Error(w, "Error getting dashboard UID", 400)
+			grizzly.SendError(w, "Error getting dashboard UID", err, 400)
+			return
+		}
+		if uid == "" {
+			grizzly.SendError(w, "Dashboard has no UID", fmt.Errorf("dashboard has no UID"), 400)
 			return
 		}
 		resource.SetMetadata("name", uid)
+		resource.SetSpecString("uid", uid)
 
 		out, _, _, err := grizzly.Format(p.Registry, p.ResourcePath, &resource, p.OutputFormat, p.OnlySpec)
 		if err != nil {
-			http.Error(w, "Error formatting content", 400)
+			grizzly.SendError(w, "Error formatting content", err, 400)
 			return
 		}
 
-		err = os.WriteFile(p.ResourcePath, out, 0644)
+		resources, err := p.Parser.Parse()
 		if err != nil {
-			http.Error(w, fmt.Sprintf("Error writing file: %s", err), 400)
+			grizzly.SendError(w, "Error parsing existing resources", err, 400)
+			return
+		}
+		existing, found := resources.Find(grizzly.NewResourceRef("Dashboard", uid))
+		if !found {
+			grizzly.SendError(w, fmt.Sprintf("Dashboard with UID %s not found", uid), fmt.Errorf("dashboard with UID %s not found", uid), 404)
+			return
+		}
+
+		err = os.WriteFile(existing.Source.Path, out, 0644)
+		if err != nil {
+			grizzly.SendError(w, fmt.Sprintf("Error writing file: %s", err), err, 400)
 			return
 		}
 

--- a/pkg/grizzly/formatting.go
+++ b/pkg/grizzly/formatting.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Format(registry Registry, resourcePath string, resource *Resource, format string, onlySpec bool) ([]byte, string, string, error) {
-	var content string
+	var content []byte
 	var filename string
 	var extension string
 	var err error
@@ -25,21 +25,21 @@ func Format(registry Registry, resourcePath string, resource *Resource, format s
 		if err != nil {
 			return nil, "", "", err
 		}
-		content = string(j)
+		content = j
 	} else {
 		extension = "yaml"
 		y, err := yaml.Marshal(spec)
 		if err != nil {
 			return nil, "", "", err
 		}
-		content = string(y)
+		content = y
 	}
 	filename, err = getFilename(registry, resourcePath, resource, extension)
 	if err != nil {
 		return nil, "", "", err
 	}
 
-	return []byte(content), filename, extension, nil
+	return content, filename, extension, nil
 }
 
 func getFilename(registry Registry, resourcePath string, resource *Resource, extension string) (string, error) {

--- a/pkg/grizzly/json.go
+++ b/pkg/grizzly/json.go
@@ -34,7 +34,12 @@ func (parser *JSONParser) Parse(file string, options ParserOptions) (Resources, 
 		return nil, err
 	}
 
-	resources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID, "json", file, true)
+	source := Source{
+		Format:     "json",
+		Path:       file,
+		Rewritable: true,
+	}
+	resources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID, source)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grizzly/json.go
+++ b/pkg/grizzly/json.go
@@ -34,7 +34,7 @@ func (parser *JSONParser) Parse(file string, options ParserOptions) (Resources, 
 		return nil, err
 	}
 
-	resources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID)
+	resources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID, "json", file, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grizzly/jsonnet.go
+++ b/pkg/grizzly/jsonnet.go
@@ -48,7 +48,12 @@ func (parser *JsonnetParser) Parse(file string, options ParserOptions) (Resource
 		return nil, err
 	}
 
-	resources, err := parseAny(parser.registry, data, options.DefaultResourceKind, options.DefaultFolderUID, "jsonnet", file, false)
+	source := Source{
+		Format:     "jsonnet",
+		Path:       file,
+		Rewritable: false,
+	}
+	resources, err := parseAny(parser.registry, data, options.DefaultResourceKind, options.DefaultFolderUID, source)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grizzly/jsonnet.go
+++ b/pkg/grizzly/jsonnet.go
@@ -48,7 +48,7 @@ func (parser *JsonnetParser) Parse(file string, options ParserOptions) (Resource
 		return nil, err
 	}
 
-	resources, err := parseAny(parser.registry, data, options.DefaultResourceKind, options.DefaultFolderUID)
+	resources, err := parseAny(parser.registry, data, options.DefaultResourceKind, options.DefaultFolderUID, "jsonnet", file, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -370,6 +370,7 @@ func (w *walker) walkObj(obj map[string]any, path trace) error {
 
 		source := w.source
 		source.Location = path.Full()
+		source.Rewritable = false
 		resource.SetSource(source)
 		w.Resources = append(w.Resources, *resource)
 		return nil

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -30,6 +30,13 @@ func (ref ResourceRef) String() string {
 // Resource represents a single Resource destined for a single endpoint
 type Resource struct {
 	Body map[string]interface{}
+
+	Provenance struct {
+		Format     string
+		Location   string
+		Path       string
+		Rewritable bool
+	}
 }
 
 func ResourceFromMap(data map[string]interface{}) (*Resource, error) {
@@ -83,6 +90,13 @@ func (r *Resource) Ref() ResourceRef {
 		Kind: r.Kind(),
 		Name: r.Name(),
 	}
+}
+
+func (r *Resource) SetProvenance(format, location, path string, rewritable bool) {
+	r.Provenance.Format = format
+	r.Provenance.Location = location
+	r.Provenance.Path = path
+	r.Provenance.Rewritable = rewritable
 }
 
 func (r Resource) String() string {

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -169,7 +169,7 @@ func (r *Resource) SpecAsJSON() (string, error) {
 
 // YAML Gets the string representation for this resource
 func (r *Resource) YAML() (string, error) {
-	y, err := yaml.Marshal(*r)
+	y, err := yaml.Marshal(r.Spec())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -27,16 +27,19 @@ func (ref ResourceRef) String() string {
 	return fmt.Sprintf("%s.%s", ref.Kind, ref.Name)
 }
 
+// Source represents the on disk (etc) location of a resource
+type Source struct {
+	Format     string
+	Location   string
+	Path       string
+	Rewritable bool
+}
+
 // Resource represents a single Resource destined for a single endpoint
 type Resource struct {
 	Body map[string]interface{}
 
-	Provenance struct {
-		Format     string
-		Location   string
-		Path       string
-		Rewritable bool
-	}
+	Source Source
 }
 
 func ResourceFromMap(data map[string]interface{}) (*Resource, error) {
@@ -92,11 +95,8 @@ func (r *Resource) Ref() ResourceRef {
 	}
 }
 
-func (r *Resource) SetProvenance(format, location, path string, rewritable bool) {
-	r.Provenance.Format = format
-	r.Provenance.Location = location
-	r.Provenance.Path = path
-	r.Provenance.Rewritable = rewritable
+func (r *Resource) SetSource(source Source) {
+	r.Source = source
 }
 
 func (r Resource) String() string {
@@ -174,15 +174,6 @@ func (r *Resource) YAML() (string, error) {
 		return "", err
 	}
 	return string(y), nil
-}
-
-// JSON Gets the string representation for this resource
-func (r *Resource) JSON() (string, error) {
-	j, err := json.MarshalIndent(*r, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(j), nil
 }
 
 // Resources represents a set of resources

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -79,9 +79,7 @@ var blockJSONget = map[string]string{
 	"/api/search":       "[]",
 	"/api/usage/*":      "[]",
 
-	"/api/access-control/user/actions": `{
-        "dashboards:write": true,
-	}`,
+	"/api/access-control/user/actions": `{"dashboards:write": true}`,
 	"/api/prometheus/grafana/api/v1/rules": `{
       "status": "success",
       "data": { "groups": [] }
@@ -115,7 +113,6 @@ func (p *Server) Start() error {
 	for _, handler := range p.Registry.Handlers {
 		proxyHandler, ok := handler.(ProxyHandler)
 		if ok {
-			log.Printf("Handler: %s IS PROXY", handler.Kind())
 			for _, endpoint := range proxyHandler.GetProxyEndpoints(*p) {
 				switch endpoint.Method {
 				case "GET":

--- a/pkg/grizzly/utils.go
+++ b/pkg/grizzly/utils.go
@@ -18,6 +18,6 @@ func Pluraliser(count int, name string) string {
 }
 
 func SendError(w http.ResponseWriter, msg string, err error, code int) {
-	http.Error(w, msg, 400)
+	http.Error(w, msg, code)
 	log.Printf("%d - %s: %s", code, msg, err.Error())
 }

--- a/pkg/grizzly/utils.go
+++ b/pkg/grizzly/utils.go
@@ -2,6 +2,9 @@ package grizzly
 
 import (
 	"fmt"
+	"net/http"
+
+	"log"
 )
 
 // Pluraliser returns a string describing the count of items, with a plural 's'
@@ -12,4 +15,9 @@ func Pluraliser(count int, name string) string {
 	}
 
 	return fmt.Sprintf("%d %ss", count, name)
+}
+
+func SendError(w http.ResponseWriter, msg string, err error, code int) {
+	http.Error(w, msg, 400)
+	log.Printf("%d - %s: %s", code, msg, err.Error())
 }

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -85,9 +85,9 @@ func List(registry Registry, resources Resources, verbose bool) error {
 				handler.APIVersion(),
 				handler.Kind(),
 				resource.Name(),
-				resource.Provenance.Path,
-				resource.Provenance.Location,
-				resource.Provenance.Format)
+				resource.Source.Path,
+				resource.Source.Location,
+				resource.Source.Format)
 		} else {
 			fmt.Fprintf(w, f, handler.APIVersion(), handler.Kind(), resource.Name())
 		}

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -62,19 +62,35 @@ func Get(registry Registry, UID string, onlySpec bool, outputFormat string) erro
 }
 
 // List outputs the keys resources found in resulting json.
-func List(registry Registry, resources Resources) error {
+func List(registry Registry, resources Resources, verbose bool) error {
 	log.Infof("Listing %d resources", resources.Len())
 
-	f := "%s\t%s\t%s\n"
+	var f string
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
 
-	fmt.Fprintf(w, f, "API VERSION", "KIND", "UID")
+	if verbose {
+		f = "%s\t%s\t%s\t%s\t%s\t%s\n"
+		fmt.Fprintf(w, f, "API VERSION", "KIND", "UID", "PATH", "LOCATION", "FORMAT")
+	} else {
+		f = "%s\t%s\t%s\n"
+		fmt.Fprintf(w, f, "API VERSION", "KIND", "UID")
+	}
 	for _, resource := range resources {
 		handler, err := registry.GetHandler(resource.Kind())
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(w, f, handler.APIVersion(), handler.Kind(), resource.Name())
+		if verbose {
+			fmt.Fprintf(w, f,
+				handler.APIVersion(),
+				handler.Kind(),
+				resource.Name(),
+				resource.Provenance.Path,
+				resource.Provenance.Location,
+				resource.Provenance.Format)
+		} else {
+			fmt.Fprintf(w, f, handler.APIVersion(), handler.Kind(), resource.Name())
+		}
 	}
 	return w.Flush()
 }

--- a/pkg/grizzly/yaml.go
+++ b/pkg/grizzly/yaml.go
@@ -46,7 +46,7 @@ func (parser *YAMLParser) Parse(file string, options ParserOptions) (Resources, 
 			return nil, err
 		}
 
-		parsedResources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID)
+		parsedResources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID, "yaml", file, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/grizzly/yaml.go
+++ b/pkg/grizzly/yaml.go
@@ -46,7 +46,12 @@ func (parser *YAMLParser) Parse(file string, options ParserOptions) (Resources, 
 			return nil, err
 		}
 
-		parsedResources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID, "yaml", file, true)
+		source := Source{
+			Format:     "yaml",
+			Path:       file,
+			Rewritable: true,
+		}
+		parsedResources, err := parseAny(parser.registry, m, options.DefaultResourceKind, options.DefaultFolderUID, source)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Currently, when Grizzly parses resources, it does not track where those resources came from. Without this,
writing back to resources becomes impossible.

This PR adds source support, and while at it, fixes "save" so that dashboards saved via the proxy will work correctly.

Closes #378.