### PR TITLE
Put provider list on a single line

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-clix/cli"
 	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/grafana"
 	"github.com/grafana/grizzly/pkg/grizzly"
+	"github.com/grafana/grizzly/pkg/grizzly/notifier"
 	"github.com/grafana/grizzly/pkg/mimir"
 	"github.com/grafana/grizzly/pkg/syntheticmonitoring"
 	log "github.com/sirupsen/logrus"
@@ -85,16 +88,17 @@ func createRegistry(context *config.Context) grizzly.Registry {
 	}
 
 	var providers []grizzly.Provider
-	initMessage := "Providers:"
+
+	var providerList []string
 	for _, initFunc := range providerInitFuncs {
 		provider, err := initFunc()
 		if err != nil {
-			initMessage += "\n  " + provider.Name() + " - inactive: " + err.Error()
+			providerList = append(providerList, fmt.Sprintf("%s - inactive (%s)", provider.Name(), err.Error()))
 			continue
 		}
-		initMessage += "\n  " + provider.Name() + " - active"
+		providerList = append(providerList, provider.Name()+" - active")
 		providers = append(providers, provider)
 	}
-	log.Info(initMessage)
+	notifier.Info(nil, "Providers: "+strings.Join(providerList, ", "))
 	return grizzly.NewRegistry(providers)
 }

--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -99,6 +99,6 @@ func createRegistry(context *config.Context) grizzly.Registry {
 		providerList = append(providerList, provider.Name()+" - active")
 		providers = append(providers, provider)
 	}
-	notifier.Info(nil, "Providers: "+strings.Join(providerList, ", "))
+	notifier.InfoStderr(nil, "Providers: "+strings.Join(providerList, ", "))
 	return grizzly.NewRegistry(providers)
 }

--- a/pkg/grizzly/notifier/notifier.go
+++ b/pkg/grizzly/notifier/notifier.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/fatih/color"
 )
@@ -49,6 +50,15 @@ func Info(obj fmt.Stringer, msg string) {
 		fmt.Println(green(msg))
 	} else {
 		fmt.Printf("%s %s\n", obj.String(), green(msg))
+	}
+}
+
+// Info announces a message in green (to stderr)
+func InfoStderr(obj fmt.Stringer, msg string) {
+	if obj == nil {
+		os.Stderr.WriteString(green(msg))
+	} else {
+		os.Stderr.WriteString(fmt.Sprintf("%s %s\n", obj.String(), green(msg)))
 	}
 }
 


### PR DESCRIPTION
Grizzly was recently extended to report the list of providers and their status. This PR pulls these into a single line, 
to make the output more compact.
