### PR TITLE
Keep resources in memory in the proxy

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -396,14 +396,12 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 		if err != nil {
 			return err
 		}
+
 		targets := currentContext.GetTargets(opts.Targets)
-		parser := &jsonnetWatchParser{
-			resourcePath: args[0],
-			registry:     registry,
-			resourceKind: resourceKind,
-			folderUID:    folderUID,
-			targets:      targets,
-			jsonnetPaths: opts.JsonnetPaths,
+		parser := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths, grizzly.ParserContinueOnError(true))
+		parserOpts := grizzly.ParserOptions{
+			DefaultResourceKind: resourceKind,
+			DefaultFolderUID:    folderUID,
 		}
 
 		format, onlySpec, err := getOutputFormat(opts)
@@ -411,7 +409,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 
-		return grizzly.Serve(registry, parser, args[0], opts.ProxyPort, opts.OpenBrowser, onlySpec, format)
+		return grizzly.Serve(registry, parser, parserOpts, args[0], opts.ProxyPort, opts.OpenBrowser, onlySpec, format)
 	}
 	cmd.Flags().BoolVarP(&opts.OpenBrowser, "open-browser", "b", false, "Open Grizzly in default browser")
 	cmd.Flags().IntVarP(&opts.ProxyPort, "port", "p", 8080, "Port on which the server will listen")

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -382,7 +382,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "serve <resources>",
 		Short: "Run Grizzly server",
-		Args:  cli.ArgsExact(1),
+		Args:  cli.ArgsRange(0, 1),
 	}
 	var opts Opts
 
@@ -397,6 +397,11 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 
+		resourcesPath := ""
+		if len(args) > 0 {
+			resourcesPath = args[0]
+		}
+
 		targets := currentContext.GetTargets(opts.Targets)
 		parser := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths, grizzly.ParserContinueOnError(true))
 		parserOpts := grizzly.ParserOptions{
@@ -409,7 +414,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 
-		return grizzly.Serve(registry, parser, parserOpts, args[0], opts.ProxyPort, opts.OpenBrowser, onlySpec, format)
+		return grizzly.Serve(registry, parser, parserOpts, resourcesPath, opts.ProxyPort, opts.OpenBrowser, onlySpec, format)
 	}
 	cmd.Flags().BoolVarP(&opts.OpenBrowser, "open-browser", "b", false, "Open Grizzly in default browser")
 	cmd.Flags().IntVarP(&opts.ProxyPort, "port", "p", 8080, "Port on which the server will listen")

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -342,13 +342,7 @@ func (h *DashboardHandler) DashboardJSONGetHandler(p grizzly.Server) http.Handle
 			return
 		}
 
-		resources, err := p.Parser.Parse()
-		if err != nil {
-			grizzly.SendError(w, "Error parsing dashboard JSON", err, 500)
-			return
-		}
-
-		resource, found := resources.Find(grizzly.NewResourceRef("Dashboard", uid))
+		resource, found := p.Resources.Find(grizzly.NewResourceRef("Dashboard", uid))
 		if !found {
 			grizzly.SendError(w, fmt.Sprintf("Dashboard with UID %s not found", uid), fmt.Errorf("dashboard with UID %s not found", uid), 404)
 			return
@@ -407,12 +401,7 @@ func (h *DashboardHandler) DashboardJSONPostHandler(p grizzly.Server) http.Handl
 			return
 		}
 
-		resources, err := p.Parser.Parse()
-		if err != nil {
-			grizzly.SendError(w, "Error parsing existing resources", err, 500)
-			return
-		}
-		existing, found := resources.Find(grizzly.NewResourceRef("Dashboard", uid))
+		existing, found := p.Resources.Find(grizzly.NewResourceRef("Dashboard", uid))
 		if !found {
 			grizzly.SendError(w, fmt.Sprintf("Dashboard with UID %s not found", uid), fmt.Errorf("dashboard with UID %s not found", uid), 500)
 			return

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -163,7 +163,7 @@ func (p *Server) Start() error {
 			return fmt.Errorf("no resources found to proxy")
 		}
 
-		if !stat.IsDir() && p.Resources.Len() != 0 {
+		if !stat.IsDir() && p.Resources.Len() == 1 {
 			resource := p.Resources.First()
 			handler, err := p.Registry.GetHandler(resource.Kind())
 			if err != nil {

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -17,13 +17,18 @@ import (
 )
 
 type Server struct {
-	proxy        *httputil.ReverseProxy
-	Port         int
+	proxy       *httputil.ReverseProxy
+	port        int
+	openBrowser bool
+
+	parser     Parser
+	parserOpts ParserOptions
+	parserErr  error
+
 	Registry     Registry
-	Parser       WatchParser
+	Resources    Resources
 	UserAgent    string
 	ResourcePath string
-	OpenBrowser  bool
 	OnlySpec     bool
 	OutputFormat string
 }
@@ -34,7 +39,7 @@ var upgrader = websocket.Upgrader{
 	CheckOrigin:     func(r *http.Request) bool { return true },
 }
 
-func NewGrizzlyServer(registry Registry, parser WatchParser, resourcePath string, port int, openBrowser bool, onlySpec bool, outputFormat string) (*Server, error) {
+func NewGrizzlyServer(registry Registry, parser Parser, parserOpts ParserOptions, resourcePath string, port int, openBrowser bool, onlySpec bool, outputFormat string) (*Server, error) {
 	prov, err := registry.GetProxyProvider()
 	if err != nil {
 		return nil, err
@@ -45,18 +50,19 @@ func NewGrizzlyServer(registry Registry, parser WatchParser, resourcePath string
 		return nil, err
 	}
 
-	server := Server{
+	return &Server{
 		Registry:     registry,
-		Parser:       parser,
+		Resources:    NewResources(),
+		parser:       parser,
+		parserOpts:   parserOpts,
 		UserAgent:    "grizzly",
 		ResourcePath: resourcePath,
-		Port:         port,
-		OpenBrowser:  openBrowser,
+		port:         port,
+		openBrowser:  openBrowser,
 		OnlySpec:     onlySpec,
 		OutputFormat: outputFormat,
 		proxy:        proxy,
-	}
-	return &server, nil
+	}, nil
 }
 
 var mustProxyGET = []string{
@@ -141,53 +147,71 @@ func (p *Server) Start() error {
 
 	r.Get("/api/live/ws", p.wsHandler)
 
-	if p.OpenBrowser {
-		var url string
+	if err := p.ParseResources(p.ResourcePath); err != nil {
+		return err
+	}
+
+	if p.openBrowser {
+		path := "/"
 
 		stat, err := os.Stat(p.ResourcePath)
 		if err != nil {
 			return err
 		}
 
-		if stat.IsDir() {
-			url = fmt.Sprintf("http://localhost:%d", p.Port)
-		} else {
-			resources, err := p.Parser.Parse()
+		if !stat.IsDir() && p.Resources.Len() == 0 {
+			return fmt.Errorf("no resources found to proxy")
+		}
+
+		if !stat.IsDir() && p.Resources.Len() != 0 {
+			resource := p.Resources.First()
+			handler, err := p.Registry.GetHandler(resource.Kind())
 			if err != nil {
 				return err
 			}
-			if resources.Len() > 1 {
-				url = fmt.Sprintf("http://localhost:%d", p.Port)
-			} else if resources.Len() == 0 {
-				return fmt.Errorf("no resources found to proxy")
-			} else {
-				resource := resources.First()
-				handler, err := p.Registry.GetHandler(resource.Kind())
+			proxyHandler, ok := handler.(ProxyHandler)
+			if !ok {
+				uid, err := handler.GetUID(resource)
 				if err != nil {
 					return err
 				}
-				proxyHandler, ok := handler.(ProxyHandler)
-				if !ok {
-					uid, err := handler.GetUID(resource)
-					if err != nil {
-						return err
-					}
-					return fmt.Errorf("kind %s (for resource %s) does not support proxying", resource.Kind(), uid)
-				}
-				proxyURL, err := proxyHandler.ProxyURL(resource)
-				if err != nil {
-					return err
-				}
-				url = fmt.Sprintf("http://localhost:%d%s", p.Port, proxyURL)
+				return fmt.Errorf("kind %s (for resource %s) does not support proxying", resource.Kind(), uid)
 			}
+			proxyURL, err := proxyHandler.ProxyURL(resource)
+			if err != nil {
+				return err
+			}
+			path = proxyURL
 		}
-		p.openBrowser(url)
+
+		p.openInBrowser(p.URL(path))
 	}
-	fmt.Printf("Listening on http://localhost:%d\n", p.Port)
-	return http.ListenAndServe(fmt.Sprintf(":%d", p.Port), r)
+
+	fmt.Printf("Listening on %s\n", p.URL("/"))
+	return http.ListenAndServe(fmt.Sprintf(":%d", p.port), r)
 }
 
-func (p *Server) openBrowser(url string) {
+func (p *Server) ParseResources(resourcesPath string) error {
+	resources, err := p.parser.Parse(resourcesPath, p.parserOpts)
+	p.parserErr = err
+	if err != nil {
+		return err
+	}
+
+	p.Resources.Merge(resources)
+
+	return nil
+}
+
+func (p *Server) URL(path string) string {
+	if len(path) == 0 || path[0] != '/' {
+		path = "/" + path
+	}
+
+	return fmt.Sprintf("http://localhost:%d%s", p.port, path)
+}
+
+func (p *Server) openInBrowser(url string) {
 	var err error
 
 	switch runtime.GOOS {
@@ -230,23 +254,21 @@ func (p *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
 func (p *Server) RootHandler(w http.ResponseWriter, _ *http.Request) {
 	var parseErrors []error
 
-	resources, err := p.Parser.Parse()
-	if err != nil {
-		if merr, ok := err.(*multierror.Error); ok {
+	if p.parserErr != nil {
+		if merr, ok := p.parserErr.(*multierror.Error); ok {
 			parseErrors = merr.Errors
 		} else {
-			parseErrors = []error{err}
+			parseErrors = []error{p.parserErr}
 		}
 	}
 
 	templateVars := map[string]any{
-		"Resources":   resources.AsList(),
+		"Resources":   p.Resources.AsList(),
 		"ParseErrors": parseErrors,
-		"ServerPort":  p.Port,
+		"ServerPort":  p.port,
 	}
 	if err := templates.ExecuteTemplate(w, "proxy/index.html.tmpl", templateVars); err != nil {
-		log.Error("Error while executing template: ", err)
-		http.Error(w, fmt.Sprintf("Error: %s", err), 500)
+		SendError(w, "Error while executing template", err, 500)
 		return
 	}
 }

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -556,8 +556,8 @@ func Watch(registry Registry, watchDir string, parser WatchParser, trailRecorder
 // Serve starts an HTTP server that can be used to navigate Grizzly resources,
 // as well as allowing visualisation of resources handed to Grizzly.
 // If pure files, they can be saved too.
-func Serve(registry Registry, parser WatchParser, resourcePath string, port int, openBrowser, onlySpec bool, outputFormat string) error {
-	server, err := NewGrizzlyServer(registry, parser, resourcePath, port, openBrowser, onlySpec, outputFormat)
+func Serve(registry Registry, parser Parser, parserOpts ParserOptions, resourcePath string, port int, openBrowser, onlySpec bool, outputFormat string) error {
+	server, err := NewGrizzlyServer(registry, parser, parserOpts, resourcePath, port, openBrowser, onlySpec, outputFormat)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Instead of parsing the entire resource collection every time we need to access a single resource, let's parse it once when the proxy starts and give the handlers access to that collection.