### PR TITLE
Support loading dashboards into the proxy via a query parameter

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -382,7 +382,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "serve <resources>",
 		Short: "Run Grizzly server",
-		Args:  cli.ArgsExact(1),
+		Args:  cli.ArgsRange(0, 1),
 	}
 	var opts Opts
 
@@ -397,6 +397,11 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 
+		resourcesPath := ""
+		if len(args) > 0 {
+			resourcesPath = args[0]
+		}
+
 		targets := currentContext.GetTargets(opts.Targets)
 		parser := grizzly.DefaultParser(registry, targets, opts.JsonnetPaths, grizzly.ParserContinueOnError(true))
 		parserOpts := grizzly.ParserOptions{
@@ -409,7 +414,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 
-		return grizzly.Serve(registry, parser, parserOpts, args[0], opts.ProxyPort, opts.OpenBrowser, onlySpec, format)
+		return grizzly.Serve(registry, parser, parserOpts, resourcesPath, opts.ProxyPort, opts.OpenBrowser, onlySpec, format)
 	}
 	cmd.Flags().BoolVarP(&opts.OpenBrowser, "open-browser", "b", false, "Open Grizzly in default browser")
 	cmd.Flags().IntVarP(&opts.ProxyPort, "port", "p", 8080, "Port on which the server will listen")


### PR DESCRIPTION
With this PR, the proxy/server can be started without an initial resources catalog. Resources can then be dynamically parsed with a _magic_ query parameter when opening a dashboard.

Ex: opening `http://localhost:4242/d/JvOqE4gRk/slug?orgId=1&refresh=30s&grizzly_from_file=/home/kevin/sandbox/dashboard.json` will parse and display the dashboard defined in the file `/home/kevin/sandbox/dashboard.json`