### PR TITLE
Fix folder diffs and UIDs

### DIFF
--- a/integration/dashboard_test.go
+++ b/integration/dashboard_test.go
@@ -320,7 +320,7 @@ func TestDashboardHandler(t *testing.T) {
 					return
 				}
 				require.NoError(t, err)
-				newResource := handler.Prepare(grizzly.Resource{}, test.Resource)
+				newResource := handler.Prepare(nil, test.Resource)
 				uid, _ := handler.GetUID(*newResource)
 				require.Equal(t, uid, test.ExpectedUID)
 			})

--- a/integration/folder_test.go
+++ b/integration/folder_test.go
@@ -17,6 +17,61 @@ func TestFolders(t *testing.T) {
 	require.NoError(t, err)
 	handler := grafana.NewFolderHandler(provider)
 
+	dir := "testdata/folders"
+	setupContexts(t, dir)
+
+	t.Run("Apply folder with no UID twice", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir:       dir,
+			RunOnContexts: allContexts,
+			Commands: []Command{
+				{
+					Command:      "apply folder-no-uid.json",
+					ExpectedCode: 0,
+				},
+				{
+					Command:      "apply folder-no-uid.json",
+					ExpectedCode: 0,
+				},
+			},
+		})
+	})
+
+	t.Run("Apply nested folder with no UID twice", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir:       dir,
+			RunOnContexts: allContexts,
+			Commands: []Command{
+				{
+					Command:      "apply nested-folder-no-uid.json",
+					ExpectedCode: 0,
+				},
+				{
+					Command:      "apply nested-folder-no-uid.json",
+					ExpectedCode: 0,
+				},
+			},
+		})
+	})
+
+	t.Run("Diff folder should show no changes", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir:       dir,
+			RunOnContexts: allContexts,
+			Commands: []Command{
+				{
+					Command:      "apply folder-with-uid.json",
+					ExpectedCode: 0,
+				},
+				{
+					Command:        "diff folder-with-uid.json",
+					ExpectedCode:   0,
+					ExpectedOutput: "DashboardFolder.new-folder-with-uid no differences",
+				},
+			},
+		})
+	})
+
 	t.Run("get remote folder - success", func(t *testing.T) {
 		resource, err := handler.GetByUID("abcdefghi")
 		require.NoError(t, err)
@@ -36,7 +91,7 @@ func TestFolders(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, resources)
-		require.Len(t, resources, 1)
+		require.Len(t, resources, 4)
 	})
 
 	t.Run("post remote folder - success", func(t *testing.T) {

--- a/integration/testdata/folders/folder-no-uid.json
+++ b/integration/testdata/folders/folder-no-uid.json
@@ -2,10 +2,9 @@
   "apiVersion": "grizzly.grafana.com/v1alpha1",
   "kind": "DashboardFolder",
   "metadata": {
-    "name": "newFolder"
+    "name": "new-folder-no-uid"
   },
   "spec": {
-    "title": "New Folder",
-    "uid": "newFolder"
+    "title": "Folder without UID"
   }
 }

--- a/integration/testdata/folders/folder-with-uid.json
+++ b/integration/testdata/folders/folder-with-uid.json
@@ -2,10 +2,10 @@
   "apiVersion": "grizzly.grafana.com/v1alpha1",
   "kind": "DashboardFolder",
   "metadata": {
-    "name": "newFolder"
+    "name": "new-folder-with-uid"
   },
   "spec": {
-    "title": "New Folder",
-    "uid": "newFolder"
+    "title": "Folder with UID",
+    "uid": "new-folder-with-uid"
   }
 }

--- a/integration/testdata/folders/nested-folder-no-uid.json
+++ b/integration/testdata/folders/nested-folder-no-uid.json
@@ -1,11 +1,13 @@
 {
+  "folders": [
+    {
   "apiVersion": "grizzly.grafana.com/v1alpha1",
   "kind": "DashboardFolder",
   "metadata": {
-    "name": "newFolder"
+    "name": "new-nested-folder-no-uid"
   },
   "spec": {
-    "title": "New Folder",
-    "uid": "newFolder"
+    "title": "Nested Folder without UID"
   }
+}]
 }

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -32,11 +32,6 @@ func (h *AlertRuleGroupHandler) ResourceFilePath(resource grizzly.Resource, file
 	return fmt.Sprintf(alertRuleGroupPattern, resource.Name(), filetype)
 }
 
-// Parse parses a manifest object into a struct for this resource type
-func (h *AlertRuleGroupHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
-	return grizzly.ResourceFromMap(m)
-}
-
 // Validate checks that the uid format is valid
 func (h *AlertRuleGroupHandler) Validate(resource grizzly.Resource) error {
 	data, err := json.Marshal(resource.Spec())

--- a/pkg/grafana/contactpoint-handler.go
+++ b/pkg/grafana/contactpoint-handler.go
@@ -30,25 +30,20 @@ func (h *AlertContactPointHandler) ResourceFilePath(resource grizzly.Resource, f
 	return fmt.Sprintf(contactPointPattern, resource.Name(), filetype)
 }
 
-// Parse parses a manifest object into a struct for this resource type
-func (h *AlertContactPointHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
-	resource, err := grizzly.ResourceFromMap(m)
-	if err != nil {
-		return nil, err
+// Prepare gets a resource ready for dispatch to the remote endpoint
+func (h *AlertContactPointHandler) Prepare(existing *grizzly.Resource, resource grizzly.Resource) *grizzly.Resource {
+	uid, _ := resource.GetSpecString("uid")
+	if uid == "" {
+		resource.SetSpecString("uid", resource.Name())
 	}
-
-	resource.SetSpecString("uid", resource.Name())
-
-	return resource, nil
+	return &resource
 }
 
 // Validate returns the uid of resource
 func (h *AlertContactPointHandler) Validate(resource grizzly.Resource) error {
 	uid, exist := resource.GetSpecString("uid")
-	if exist {
-		if uid != resource.Name() {
-			return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
-		}
+	if exist && uid != resource.Name() {
+		return fmt.Errorf("uid '%s' and name '%s', don't match", uid, resource.Name())
 	}
 	return nil
 }

--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -41,21 +41,6 @@ func (h *DashboardHandler) ResourceFilePath(resource grizzly.Resource, filetype 
 	return fmt.Sprintf(dashboardPattern, resource.GetMetadata("folder"), resource.Name(), filetype)
 }
 
-// Parse parses a manifest object into a struct for this resource type
-func (h *DashboardHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
-	resource, err := grizzly.ResourceFromMap(m)
-	if err != nil {
-		return nil, err
-	}
-
-	resource.SetSpecString("uid", resource.Name())
-	if !resource.HasMetadata("folder") {
-		resource.SetMetadata("folder", generalFolderUID)
-	}
-
-	return resource, nil
-}
-
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 func (h *DashboardHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
 	resource.DeleteSpecKey("id")
@@ -64,10 +49,12 @@ func (h *DashboardHandler) Unprepare(resource grizzly.Resource) *grizzly.Resourc
 }
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
-func (h *DashboardHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	uid, _ := resource.GetSpecString("uid")
-	if uid == "" {
+func (h *DashboardHandler) Prepare(existing *grizzly.Resource, resource grizzly.Resource) *grizzly.Resource {
+	if !resource.HasSpecString("uid") {
 		resource.SetSpecString("uid", resource.Name())
+	}
+	if !resource.HasMetadata("folder") {
+		resource.SetMetadata("folder", generalFolderUID)
 	}
 	return &resource
 }

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -42,18 +42,6 @@ func (h *LibraryElementHandler) ResourceFilePath(resource grizzly.Resource, file
 	return fmt.Sprintf(libraryElementPattern, kind, resource.Name(), filetype)
 }
 
-// Parse parses a manifest object into a struct for this resource type
-func (h *LibraryElementHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
-	resource, err := grizzly.ResourceFromMap(m)
-	if err != nil {
-		return nil, err
-	}
-
-	resource.SetSpecString("uid", resource.Name())
-
-	return resource, nil
-}
-
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 func (h *LibraryElementHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
 	resource.DeleteSpecKey("meta")
@@ -63,10 +51,17 @@ func (h *LibraryElementHandler) Unprepare(resource grizzly.Resource) *grizzly.Re
 }
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
-func (h *LibraryElementHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
-	val := existing.GetSpecValue("version")
-	resource.SetSpecValue("version", val)
+func (h *LibraryElementHandler) Prepare(existing *grizzly.Resource, resource grizzly.Resource) *grizzly.Resource {
+	if existing != nil {
+		val := existing.GetSpecValue("version")
+		resource.SetSpecValue("version", val)
+	}
 	resource.DeleteSpecKey("meta")
+
+	uid, _ := resource.GetSpecString("uid")
+	if uid == "" {
+		resource.SetSpecString("uid", resource.Name())
+	}
 	return &resource
 }
 

--- a/pkg/grafana/notificationpolicy-handler.go
+++ b/pkg/grafana/notificationpolicy-handler.go
@@ -34,16 +34,6 @@ func (h *AlertNotificationPolicyHandler) ResourceFilePath(resource grizzly.Resou
 	return alertNotificationPolicyFile
 }
 
-// Parse parses a manifest object into a struct for this resource type
-func (h *AlertNotificationPolicyHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
-	resource, err := grizzly.ResourceFromMap(m)
-	if err != nil {
-		return nil, err
-	}
-
-	return resource, h.Validate(*resource)
-}
-
 // Validate returns the uid of resource
 func (h *AlertNotificationPolicyHandler) Validate(resource grizzly.Resource) error {
 	if resource.Name() != GlobalAlertNotificationPolicyName {

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -34,7 +34,7 @@ func (h *BaseHandler) Unprepare(resource Resource) *Resource {
 	return &resource
 }
 
-func (h *BaseHandler) Prepare(existing, resource Resource) *Resource {
+func (h *BaseHandler) Prepare(existing *Resource, resource Resource) *Resource {
 	return &resource
 }
 
@@ -58,14 +58,11 @@ type Handler interface {
 	// ResourceFilePath returns the location on disk where a resource should be updated
 	ResourceFilePath(resource Resource, filetype string) string
 
-	// Parse parses a manifest object into a struct for this resource type
-	Parse(m map[string]any) (*Resource, error)
-
 	// Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 	Unprepare(resource Resource) *Resource
 
 	// Prepare gets a resource ready for dispatch to the remote endpoint
-	Prepare(existing, resource Resource) *Resource
+	Prepare(existing *Resource, resource Resource) *Resource
 
 	// Retrieves a UID for a resource
 	GetUID(resource Resource) (string, error)

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -140,7 +140,6 @@ func (parser *ChainParser) Parse(resourcePath string, options ParserOptions) (Re
 				return nil
 			}
 		}
-
 		parsedResources.Merge(r)
 
 		return nil
@@ -173,13 +172,7 @@ func parseAny(registry Registry, data any, resourceKind, folderUID string, sourc
 		if err != nil {
 			return Resources{}, err
 		}
-
-		handler, err := registry.GetHandler(m["kind"].(string))
-		if err != nil {
-			return Resources{}, err
-		}
-
-		resource, err := handler.Parse(m)
+		resource, err := ResourceFromMap(m)
 		if err != nil {
 			return Resources{}, err
 		}
@@ -221,15 +214,11 @@ func parseAny(registry Registry, data any, resourceKind, folderUID string, sourc
 			resource.SetMetadata("folder", folderUID)
 		}
 
-		r, err := handler.Parse(resource.Body)
-		if err != nil {
-			return Resources{}, err
-		}
-
-		return NewResources(*r), nil
+		return NewResources(resource), nil
 	}
 
 	walker := walker{
+		registry:  registry,
 		source:    source,
 		resources: NewResources(),
 	}
@@ -313,6 +302,7 @@ func ValidateEnvelope(data any) error {
 }
 
 type walker struct {
+	registry  Registry
 	resources Resources
 	source    Source
 }
@@ -369,7 +359,6 @@ func (w *walker) walkObj(obj map[string]any, path trace) error {
 		if err != nil {
 			return err
 		}
-
 		source := w.source
 		source.Location = path.Full()
 		source.Rewritable = false

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -126,6 +126,11 @@ func (r *Resource) SetMetadata(key, value string) {
 	r.Body["metadata"] = metadata
 }
 
+func (r *Resource) HasSpecString(key string) bool {
+	_, ok := r.Spec()[key]
+	return ok
+}
+
 func (r *Resource) GetSpecString(key string) (string, bool) {
 	if val, ok := r.Spec()[key]; ok {
 		return val.(string), true

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -422,6 +422,7 @@ func applyResource(registry Registry, resource Resource, trailRecorder eventsRec
 	if errors.Is(err, ErrNotFound) {
 		log.Debugf("`%s` was not found, adding it...", resource.Ref())
 
+		resource = *handler.Prepare(nil, resource)
 		if err := handler.Add(resource); err != nil {
 			return err
 		}
@@ -443,7 +444,7 @@ func applyResource(registry Registry, resource Resource, trailRecorder eventsRec
 		return err
 	}
 
-	resource = *handler.Prepare(*existingResource, resource)
+	resource = *handler.Prepare(existingResource, resource)
 	existingResource = handler.Unprepare(*existingResource)
 	existingResourceRepresentation, err := existingResource.YAML()
 	if err != nil {

--- a/pkg/mimir/rules-handler.go
+++ b/pkg/mimir/rules-handler.go
@@ -33,11 +33,6 @@ func (h *RuleHandler) ResourceFilePath(resource grizzly.Resource, filetype strin
 	return fmt.Sprintf(prometheusRuleGroupPattern, resource.Name(), filetype)
 }
 
-// Parse parses a manifest object into a struct for this resource type
-func (h *RuleHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
-	return grizzly.ResourceFromMap(m)
-}
-
 // Validate returns the uid of resource
 func (h *RuleHandler) Validate(resource grizzly.Resource) error {
 	uid, exist := resource.GetSpecString("uid")

--- a/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
+++ b/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
@@ -54,18 +54,6 @@ func (h *SyntheticMonitoringHandler) ResourceFilePath(resource grizzly.Resource,
 	return fmt.Sprintf(syntheticMonitoringPattern, resource.Name(), filetype)
 }
 
-// Parse parses a manifest object into a struct for this resource type
-func (h *SyntheticMonitoringHandler) Parse(m map[string]any) (*grizzly.Resource, error) {
-	resource, err := grizzly.ResourceFromMap(m)
-	if err != nil {
-		return nil, err
-	}
-
-	resource.SetSpecString("job", resource.GetMetadata("name"))
-
-	return resource, nil
-}
-
 // Unprepare removes unnecessary elements from a remote resource ready for presentation/comparison
 func (h *SyntheticMonitoringHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
 	resource.DeleteSpecKey("tenantId")
@@ -76,9 +64,13 @@ func (h *SyntheticMonitoringHandler) Unprepare(resource grizzly.Resource) *grizz
 }
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
-func (h *SyntheticMonitoringHandler) Prepare(existing, resource grizzly.Resource) *grizzly.Resource {
+func (h *SyntheticMonitoringHandler) Prepare(existing *grizzly.Resource, resource grizzly.Resource) *grizzly.Resource {
 	resource.SetSpecValue("tenantId", existing.GetSpecValue("tenantId"))
 	resource.SetSpecValue("id", existing.GetSpecValue("id"))
+	_, exists := resource.GetSpecString("job")
+	if !exists {
+		resource.SetSpecString("job", resource.GetMetadata("name"))
+	}
 	return &resource
 }
 


### PR DESCRIPTION
If a UID is expressed inside the spec, Grizzly expects it to either be missing from the spec (when it will use the metadata/name), or for the metadata/name and spec/uid to match.

This isn't the case for Folders, causing issues. For example, in #97, if a UID is not provided in the spec, Grafana will assign one randomly, preventing future applies for that resource.

Also, Grizzly implements diffs by comparing existing resources with the new ones. In some cases, Grafana will return read-only fields in the spec of the resource, meaning the diff will always suggest changes. This is the case with the folder resource. See #220.

This PR fixes both of these - folders without UIDs will use the metadata/name as a UID. Folders should now also diff correctly.

Closes #97
Closes #220
