### PR TITLE
Create unset function

### DIFF
--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -137,8 +137,8 @@ func getConfigCmd() *cli.Command {
 
 func setCmd() *cli.Command {
 	cmd := &cli.Command{
-		Use:   "set configuration value",
-		Short: "set a configuration value",
+		Use:   "set [provider.key value]",
+		Short: "Set a configuration value for the current context",
 		Args:  cli.ArgsExact(2),
 	}
 	var opts LoggingOpts
@@ -147,6 +147,19 @@ func setCmd() *cli.Command {
 		return config.Set(args[0], args[1])
 	}
 	return initialiseLogging(cmd, &opts)
+}
+
+func unsetCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "unset [provider.key]",
+		Short: "Unset a configuration value for the current context",
+		Args:  cli.ArgsExact(1),
+		Run: func(cmd *cli.Command, args []string) error {
+			return config.Unset(args[0])
+		},
+	}
+
+	return initialiseLogging(cmd, &LoggingOpts{})
 }
 
 func createContextCmd() *cli.Command {

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -500,6 +500,7 @@ func configCmd() *cli.Command {
 	cmd.AddCommand(configImportCmd())
 	cmd.AddCommand(getConfigCmd())
 	cmd.AddCommand(setCmd())
+	cmd.AddCommand(unsetCmd())
 	cmd.AddCommand(createContextCmd())
 	return cmd
 }

--- a/integration/context_test.go
+++ b/integration/context_test.go
@@ -60,4 +60,52 @@ func TestContexts(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("Unset value", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir: dir,
+			Commands: []Command{
+				{
+					Command:             "config set mimir.invalid http://mimir:9009",
+					ExpectedLogsContain: "key not recognised: mimir.invalid",
+					ExpectedCode:        1,
+				},
+				{
+					Command: "config set mimir.address http://mimir:9009",
+				},
+				{
+					Command: "config set mimir.tenant-id tenant-id",
+				},
+				{
+					Command:        "config get mimir -o yaml",
+					ExpectedOutput: "address: http://mimir:9009\ntenant-id: tenant-id",
+				},
+				{
+					Command: "config unset mimir.address",
+				},
+				{
+					Command:        "config get mimir -o yaml",
+					ExpectedOutput: "tenant-id: tenant-id",
+				},
+				{
+					Command: "config unset mimir.tenant-id",
+				},
+				{
+					Command:             "config get mimir -o yaml",
+					ExpectedLogsContain: "key not found: mimir",
+					ExpectedCode:        1,
+				},
+				{
+					Command:             "config unset mimir.invalid",
+					ExpectedLogsContain: "mimir.invalid is not a valid path",
+					ExpectedCode:        1,
+				},
+				{
+					Command:             "config unset mimir.tenant-id",
+					ExpectedLogsContain: "key mimir.tenant-id is already unset",
+					ExpectedCode:        1,
+				},
+			},
+		})
+	})
 }


### PR DESCRIPTION
Contributes to: https://github.com/grafana/grizzly/issues/416

Example: `./grr config unset synthetic-monitoring.logs-id`

It adds the `unset` value in case we want to remove a value. Some values are optional and Viper only allows setting empty values instead of remove them, so it needs to iterate the values to remove the proper one.

The function fails if the provided path isn't exist or isn't set.