### PR TITLE
Add option to 'get' directly to a file

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -24,6 +24,8 @@ func getCmd(registry grizzly.Registry) *cli.Command {
 		Args:  cli.ArgsExact(1),
 	}
 	var opts Opts
+	var output string
+	cmd.Flags().StringVarP(&output, "output-file", "O", "", "write resource to specific file")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		uid := args[0]
@@ -31,7 +33,7 @@ func getCmd(registry grizzly.Registry) *cli.Command {
 		if err != nil {
 			return err
 		}
-		return grizzly.Get(registry, uid, onlySpec, format)
+		return grizzly.Get(registry, uid, onlySpec, format, output)
 	}
 	cmd = initialiseOnlySpec(cmd, &opts)
 	return initialiseCmd(cmd, &opts)

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -25,7 +25,7 @@ import (
 var interactive = terminal.IsTerminal(int(os.Stdout.Fd()))
 
 // Get retrieves a resource from a remote endpoint using its UID
-func Get(registry Registry, UID string, onlySpec bool, outputFormat string) error {
+func Get(registry Registry, UID string, onlySpec bool, outputFormat, output string) error {
 	log.Info("Getting ", UID)
 
 	count := strings.Count(UID, ".")
@@ -40,7 +40,7 @@ func Get(registry Registry, UID string, onlySpec bool, outputFormat string) erro
 		resourceID = parts[2]
 
 	} else {
-		return fmt.Errorf("UID must be <provider>.<uid>: %s", UID)
+		return fmt.Errorf("UID must be <kind>.<uid>: %s", UID)
 	}
 
 	handler, err := registry.GetHandler(handlerName)
@@ -60,7 +60,15 @@ func Get(registry Registry, UID string, onlySpec bool, outputFormat string) erro
 		return err
 	}
 
-	fmt.Println(string(content))
+	if output == "" {
+		fmt.Println(string(content))
+	} else {
+		err := os.WriteFile(output, content, 0644)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Currently, `grr get` prints the output. This PR adds a `-O` option to write the output to a 
named file.

This can work well, for example, for prepping work with the server/proxy:

```
grr get -O mydash.json -o json Dashboard.mydash
grr proxy mydash.json
```

