### PR TITLE
Preserve folders when saving via server

### DIFF
--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -164,6 +164,10 @@ func (r *Resource) Spec() map[string]interface{} {
 	return r.Body["spec"].(map[string]interface{})
 }
 
+func (r *Resource) SetSpec(spec map[string]any) {
+	r.Body["spec"] = spec
+}
+
 func (r *Resource) SpecAsJSON() (string, error) {
 	j, err := json.MarshalIndent(r.Spec(), "", "  ")
 	if err != nil {


### PR DESCRIPTION
Currently, when a dashboard is saved via the server, it looses track of the dashboard folder, if set.

This PR fixes that. Rather than create a new resource to be saved, it retrieves the old resource from the existing resource set managed by the server, and replaces it's spec with the one being saved. This preserves the folder UID.

Depends upon #386.

Closes #425.
