### PR TITLE
Added mTLS support to MimirClient

### DIFF
--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -9,15 +9,16 @@ type GrafanaConfig struct {
 }
 
 type MimirConfig struct {
-	Address  string 		 `yaml:"address" mapstructure:"address"`
-	TenantID string 	     `yaml:"tenant-id" mapstructure:"tenant-id"`
-	APIKey   string          `yaml:"api-key" mapstructure:"api-key"`
-	Auth 	 MimirAuthConfig `yaml:"auth" mapstructure:"auth"`
+	Address  string         `yaml:"address" mapstructure:"address"`
+	TenantID string         `yaml:"tenant-id" mapstructure:"tenant-id"`
+	APIKey   string         `yaml:"api-key" mapstructure:"api-key"`
+	TLS      MimirTLSConfig `yaml:"tls" mapstructure:"auth"`
 }
 
-type MimirAuthConfig struct {
-	ClientCertPath string `yaml:"client-cert-path" mapstructure:"client-cert-path"`
-	ClientKeyPath  string `yaml:"client-key-path" mapstructure:"client-key-path"`
+type MimirTLSConfig struct {
+	ClientCertPath string `yaml:"client-cert-path,omitempty" mapstructure:"client-cert-path"`
+	ClientKeyPath  string `yaml:"client-key-path,omitempty" mapstructure:"client-key-path"`
+	CAPath 		   string `yaml:"ca-path" mapstruceture:"ca-path"`
 }
 
 type SyntheticMonitoringConfig struct {

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -12,7 +12,7 @@ type MimirConfig struct {
 	Address  string         `yaml:"address" mapstructure:"address"`
 	TenantID string         `yaml:"tenant-id" mapstructure:"tenant-id"`
 	APIKey   string         `yaml:"api-key" mapstructure:"api-key"`
-	TLS      MimirTLSConfig `yaml:"tls" mapstructure:"auth"`
+	TLS      MimirTLSConfig `yaml:"tls" mapstructure:"tls"`
 }
 
 type MimirTLSConfig struct {

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -9,9 +9,15 @@ type GrafanaConfig struct {
 }
 
 type MimirConfig struct {
-	Address  string `yaml:"address" mapstructure:"address"`
-	TenantID string `yaml:"tenant-id" mapstructure:"tenant-id"`
-	APIKey   string `yaml:"api-key" mapstructure:"api-key"`
+	Address  string 		 `yaml:"address" mapstructure:"address"`
+	TenantID string 	     `yaml:"tenant-id" mapstructure:"tenant-id"`
+	APIKey   string          `yaml:"api-key" mapstructure:"api-key"`
+	Auth 	 MimirAuthConfig `yaml:"auth" mapstructure:"auth"`
+}
+
+type MimirAuthConfig struct {
+	ClientCertPath string `yaml:"client-cert-path" mapstructure:"client-cert-path"`
+	ClientKeyPath  string `yaml:"client-key-path" mapstructure:"client-key-path"`
 }
 
 type SyntheticMonitoringConfig struct {

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -18,7 +18,7 @@ type MimirConfig struct {
 type MimirTLSConfig struct {
 	ClientCertPath string `yaml:"client-cert-path,omitempty" mapstructure:"client-cert-path"`
 	ClientKeyPath  string `yaml:"client-key-path,omitempty" mapstructure:"client-key-path"`
-	CAPath 		   string `yaml:"ca-path" mapstructure:"ca-path"`
+	CAPath         string `yaml:"ca-path" mapstructure:"ca-path"`
 }
 
 type SyntheticMonitoringConfig struct {

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -18,7 +18,7 @@ type MimirConfig struct {
 type MimirTLSConfig struct {
 	ClientCertPath string `yaml:"client-cert-path,omitempty" mapstructure:"client-cert-path"`
 	ClientKeyPath  string `yaml:"client-key-path,omitempty" mapstructure:"client-key-path"`
-	CAPath 		   string `yaml:"ca-path" mapstruceture:"ca-path"`
+	CAPath 		   string `yaml:"ca-path" mapstructure:"ca-path"`
 }
 
 type SyntheticMonitoringConfig struct {

--- a/pkg/mimir/client/http_client.go
+++ b/pkg/mimir/client/http_client.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strconv"
 	"time"
+	"crypto/tls"
+	"crypto/x509"
 
 	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/mimir/models"
@@ -94,7 +96,7 @@ func (c *Client) doRequest(method string, url string, body []byte) ([]byte, erro
 		req.Header.Set("X-Scope-OrgID", c.config.TenantID)
 	}
 
-	client, err := createHTTPClient()
+	client, err := c.createHTTPClient()
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +118,7 @@ func (c *Client) doRequest(method string, url string, body []byte) ([]byte, erro
 	return b, nil
 }
 
-func createHTTPClient() (*http.Client, error) {
+func (c *Client) createHTTPClient() (*http.Client, error) {
 	timeout := 10 * time.Second
 	// TODO: Move this configuration to the global configuration
 	if timeoutStr := os.Getenv("GRIZZLY_HTTP_TIMEOUT"); timeoutStr != "" {
@@ -126,5 +128,42 @@ func createHTTPClient() (*http.Client, error) {
 		}
 		timeout = time.Duration(timeoutSeconds) * time.Second
 	}
-	return &http.Client{Timeout: timeout}, nil
+
+	tlsConfig := &tls.Config{}
+	httpClient := http.Client{
+		Timeout: timeout, 
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+	}
+
+	if c.config.TLS.CAPath != "" {
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
+
+		caCertPEM, err := os.ReadFile(c.config.TLS.CAPath)
+		if err != nil {
+			return nil, err
+		} 
+		
+		ok := certPool.AppendCertsFromPEM(caCertPEM)
+		if !ok {
+			return nil, err
+		}
+		
+		tlsConfig.RootCAs = certPool
+	}
+
+	if c.config.TLS.ClientCertPath != "" || c.config.TLS.ClientKeyPath != "" {
+		clientTLSCert, err := tls.LoadX509KeyPair(c.config.TLS.ClientCertPath, c.config.TLS.ClientKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{clientTLSCert}
+	}
+	
+	httpClient.Transport = &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+	return &httpClient, nil
 }


### PR DESCRIPTION
Added optional mTLS config to Mimir client.
Added an option to append an additional ca bundle file to mimir client.

I think it should wait for #415 as the changes could not be tested at the moment.

Fixes #426 