### PR TITLE
Grizzly serve should not panic if no provider set

### DIFF
--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -45,6 +45,10 @@ func NewGrizzlyServer(registry Registry, parser Parser, parserOpts ParserOptions
 		return nil, err
 	}
 
+	if prov == nil {
+		return nil, fmt.Errorf("no proxy provider found")
+	}
+
 	proxy, err := (*prov).SetupProxy()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Quick bug I notice while reviewing another PR