### PR TITLE
Add remote resource viewing support

### DIFF
--- a/pkg/grizzly/embed/assets/style.css
+++ b/pkg/grizzly/embed/assets/style.css
@@ -64,3 +64,8 @@ main {
     margin-right: auto;
     max-width: 61rem;
 }
+
+.codebox {
+    width: 80%;
+    height: 600px;
+}

--- a/pkg/grizzly/embed/templates/proxy/index.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/index.html.tmpl
@@ -28,6 +28,7 @@
     {{ end }}
     <h1>Available dashboards</h1>
 
+    <p><a href="/remote/">&gt;&gt; See remote resources</a></p>
     <ul>
         {{ range .Resources }}
             {{ if eq .Kind "Dashboard" }}

--- a/pkg/grizzly/embed/templates/proxy/remote.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/remote.html.tmpl
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset=utf-8>
+    <title>Grizzly</title>
+    <link rel="stylesheet" href="/grizzly/assets/style.css"/>
+</head>
+<body dir="ltr">
+<header>
+    <nav>
+        <a href="/" class="logo">
+            <img src="/grizzly/assets/logo.svg" alt="logo"/>
+        </a>
+
+        <h1>Grizzly</h1>
+    </nav>
+</header>
+
+<main>
+    <h1>Available remote resources</h1>
+    <p><a href="/">&gt;&gt; See local resources</a></p>
+
+    <p><input type="checkbox">select all</p>
+    <ul>
+        {{ range .Resources }}
+                <li>
+                    <input type="checkbox"> {{.Kind}} / {{.Name}}
+                    <a href="/view/?kind={{.Kind}}&uid={{.Name}}&format=json">json</a>
+                    |
+                    <a href="/view/?kind={{.Kind}}&uid={{.Name}}&format=yaml">yaml</a>
+                    |
+                    <a href="">view in Grafana</a>
+                </li>
+        {{ end }}
+    </ul>
+    <div class="downloads">
+    Download all resources as <a href="">json</a> | <a hef="">yaml</a>
+    </div>
+</main>
+</body>
+</html>

--- a/pkg/grizzly/embed/templates/proxy/view.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/view.html.tmpl
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset=utf-8>
+    <title>Grizzly</title>
+    <link rel="stylesheet" href="/grizzly/assets/style.css"/>
+</head>
+<body dir="ltr">
+<header>
+    <nav>
+        <a href="/" class="logo">
+            <img src="/grizzly/assets/logo.svg" alt="logo"/>
+        </a>
+
+        <h1>Grizzly</h1>
+    </nav>
+</header>
+
+<main>
+    <h1>Resource {{.Kind}} // {{.UID }}</h1>
+
+    <p>
+        {{if eq .Format "json"}}json{{else}}<a href="?format=json&uid={{.UID}}&kind={{.Kind}}">json</a>{{end}}
+        |
+        {{if eq .Format "yaml"}}yaml{{else}}<a href="?format=yaml&uid={{.UID}}&kind={{.Kind}}">yaml</a>{{end}}
+    </p>
+    <textarea class="codebox" readonly>
+{{.Content}}
+    </textarea>
+</main>
+</body>
+</html>


### PR DESCRIPTION
The Grizzly server allows users to see local resources, i.e. on the local workstation.

This PR adds support for viewing remote resources (as seen by `grr list -r`). On top of that, it offers the ability to see those resources as YAML/JSON.

There's plenty of UI/UX opportunities here. This PR (currently) just shows what's possible.

Another possibility is offering the ability to "download" or rather "save" resources to disk. They would then show up in the local view. My only concern here is that that isn't expected behaviour of a web page so might confuse people.
