### PR TITLE
Validate auth on server start

### DIFF
--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -3,12 +3,14 @@ package grafana
 import (
 	"crypto/tls"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http/httputil"
 	"net/url"
 	"path/filepath"
 
 	gclient "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
 	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/grizzly"
 )
@@ -111,7 +113,10 @@ func (p *Provider) SetupProxy() (*httputil.ReverseProxy, error) {
 	}
 	_, err = client.Dashboards.GetHomeDashboard()
 	if err != nil {
-		return nil, fmt.Errorf("error checking authentication: %v", err)
+		if errors.Is(err, &dashboards.GetHomeDashboardUnauthorized{}) {
+			return nil, fmt.Errorf("error checking authentication: %v", err)
+		}
+		return nil, fmt.Errorf("error setting the proxy: %v", err)
 	}
 
 	u, err := url.Parse(p.config.URL)

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -105,6 +105,15 @@ func (p *Provider) GetHandlers() []grizzly.Handler {
 }
 
 func (p *Provider) SetupProxy() (*httputil.ReverseProxy, error) {
+	client, err := p.Client()
+	if err != nil {
+		return nil, err
+	}
+	_, err = client.Dashboards.GetHomeDashboard()
+	if err != nil {
+		return nil, fmt.Errorf("error checking authentication: %v", err)
+	}
+
 	u, err := url.Parse(p.config.URL)
 	if err != nil {
 		return nil, err

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -18,6 +18,7 @@ type Provider interface {
 }
 
 type ProxyProvider interface {
+	// SetupProxy establishes the proxy connection
 	SetupProxy() (*httputil.ReverseProxy, error)
 }
 


### PR DESCRIPTION
At present, the Grizzly server will start, even if the Grafana creds are
invalid. Problems only show up when attempting to view a web page.

This PR adds a simple authentication check when establishing the proxy,
to confirm authentication, and give prompt feedback if all is not
extablished correctly.
