### PR TITLE
Allow offline providers

### DIFF
--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -81,17 +81,14 @@ func main() {
 }
 
 func createRegistry(context *config.Context) grizzly.Registry {
-	providerInitFuncs := []func() grizzly.Provider{
-		func() grizzly.Provider { return grafana.NewProvider(&context.Grafana) },
-		func() grizzly.Provider { return mimir.NewProvider(&context.Mimir) },
-		func() grizzly.Provider { return syntheticmonitoring.NewProvider(&context.SyntheticMonitoring) },
+	providers := []grizzly.Provider{
+		grafana.NewProvider(&context.Grafana),
+		mimir.NewProvider(&context.Mimir),
+		syntheticmonitoring.NewProvider(&context.SyntheticMonitoring),
 	}
 
-	var providers []grizzly.Provider
-
 	var providerList []string
-	for _, initFunc := range providerInitFuncs {
-		provider := initFunc()
+	for _, provider := range providers {
 		err := provider.Validate()
 		if err != nil {
 			providerList = append(providerList, fmt.Sprintf("%s - inactive (%s)", provider.Name(), err.Error()))

--- a/integration/dashboard_test.go
+++ b/integration/dashboard_test.go
@@ -196,8 +196,7 @@ func TestDashboard(t *testing.T) {
 }
 
 func TestDashboardHandler(t *testing.T) {
-	provider, err := grafana.NewProvider(&testutil.TestContext().Grafana)
-	require.NoError(t, err)
+	provider := grafana.NewProvider(&testutil.TestContext().Grafana)
 	handler := grafana.NewDashboardHandler(provider)
 
 	t.Run("get remote dashboard - success", func(t *testing.T) {

--- a/integration/datasource_test.go
+++ b/integration/datasource_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestDatasources(t *testing.T) {
-	provider, err := grafana.NewProvider(&testutil.TestContext().Grafana)
-	require.NoError(t, err)
+	provider := grafana.NewProvider(&testutil.TestContext().Grafana)
 	handler := grafana.NewDatasourceHandler(provider)
 
 	t.Run("get remote datasource - success", func(t *testing.T) {

--- a/integration/folder_test.go
+++ b/integration/folder_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestFolders(t *testing.T) {
-	provider, err := grafana.NewProvider(&testutil.TestContext().Grafana)
-	require.NoError(t, err)
+	provider := grafana.NewProvider(&testutil.TestContext().Grafana)
 	handler := grafana.NewFolderHandler(provider)
 
 	dir := "testdata/folders"

--- a/integration/library-element_test.go
+++ b/integration/library-element_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestLibraryElements(t *testing.T) {
-	provider, err := grafana.NewProvider(&testutil.TestContext().Grafana)
-	require.NoError(t, err)
+	provider := grafana.NewProvider(&testutil.TestContext().Grafana)
 	handler := grafana.NewLibraryElementHandler(provider)
 
 	t.Run("create libraryElement - success", func(t *testing.T) {

--- a/integration/mimir/rules_test.go
+++ b/integration/mimir/rules_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestRules(t *testing.T) {
-	provider, err := mimir.NewProvider(&testutil.TestContext().Mimir)
-	require.NoError(t, err)
+	provider := mimir.NewProvider(&testutil.TestContext().Mimir)
 	handler := provider.GetHandlers()[0]
 
 	t.Run("create rule group", func(t *testing.T) {

--- a/integration/provider_test.go
+++ b/integration/provider_test.go
@@ -39,5 +39,4 @@ func TestEmptyProviders(t *testing.T) {
 			},
 		})
 	})
-
 }

--- a/integration/provider_test.go
+++ b/integration/provider_test.go
@@ -1,0 +1,43 @@
+package integration_test
+
+import (
+	"testing"
+)
+
+func TestEmptyProviders(t *testing.T) {
+	dir := "testdata/providers"
+	setupContexts(t, dir)
+
+	t.Run("Providers work for offline commands", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir: dir,
+			Commands: []Command{
+				{
+					Command:      "config use-context empty",
+					ExpectedCode: 0,
+				},
+				{
+					Command:            "show folder.yaml",
+					ExpectedCode:       0,
+					ExpectedOutputFile: "folder-output.txt",
+				},
+			},
+		})
+	})
+
+	t.Run("Providers fail online commands without configs", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir: dir,
+			Commands: []Command{
+				{
+					Command: "config use-context empty",
+				},
+				{
+					Command:      "apply folder.yaml",
+					ExpectedCode: 1,
+				},
+			},
+		})
+	})
+
+}

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestPull(t *testing.T) {
 			RunOnContexts: allContexts,
 			Commands: []Command{
 				{
-					Command:                "pull " + pullDir,
+					Command:                fmt.Sprintf("pull %s -t Dashboard -t Dashboardfolder -t Datasource", pullDir),
 					ExpectedCode:           0,
 					ExpectedOutputContains: `Dashboard.ReciqtgGk pulled`,
 				},

--- a/integration/testdata/contexts/get-contexts.txt
+++ b/integration/testdata/contexts/get-contexts.txt
@@ -1,4 +1,5 @@
   basic_auth
 * default
+  empty
   invalid_auth
   subpath

--- a/integration/testdata/providers/folder-output.txt
+++ b/integration/testdata/providers/folder-output.txt
@@ -1,0 +1,7 @@
+DashboardFolder.sample:
+apiVersion: grizzly.grafana.com/v1alpha1
+kind: DashboardFolder
+metadata:
+    name: sample
+spec:
+    title: Sample Folder

--- a/integration/testdata/providers/folder.yaml
+++ b/integration/testdata/providers/folder.yaml
@@ -1,0 +1,6 @@
+apiVersion: grizzly.grafana.com/v1alpha1
+kind: DashboardFolder
+metadata:
+    name: sample
+spec:
+    title: Sample Folder

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -118,6 +118,8 @@ func setupContexts(t *testing.T, dir string) {
 		"config set grafana.url http://localhost:3004",
 		"config set grafana.user admin",
 		"config set grafana.token invalid",
+
+		"config create-context empty",
 	} {
 		_, _, err = runLocalGrizzly(t, dir, command)
 		require.NoError(t, err)

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -27,13 +27,17 @@ type ClientProvider interface {
 }
 
 // NewProvider instantiates a new Provider.
-func NewProvider(config *config.GrafanaConfig) (*Provider, error) {
-	if config.URL == "" {
-		return nil, fmt.Errorf("grafana URL is not set")
-	}
+func NewProvider(config *config.GrafanaConfig) *Provider {
 	return &Provider{
 		config: config,
-	}, nil
+	}
+}
+
+func (p *Provider) Validate() error {
+	if p.config.URL == "" {
+		return fmt.Errorf("grafana URL is not set")
+	}
+	return nil
 }
 
 func (p *Provider) Name() string {

--- a/pkg/grafana/utils_test.go
+++ b/pkg/grafana/utils_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestExtractFolderUID(t *testing.T) {
-	provider, err := NewProvider(&config.GrafanaConfig{URL: "http://localhost:3000"})
-	require.NoError(t, err)
+	provider := NewProvider(&config.GrafanaConfig{URL: "http://localhost:3000"})
 
 	client, err := provider.Client()
 	require.NoError(t, err)

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -15,6 +15,7 @@ type Provider interface {
 	Version() string
 	APIVersion() string
 	GetHandlers() []Handler
+	Validate() error
 }
 
 type ProxyProvider interface {

--- a/pkg/mimir/provider.go
+++ b/pkg/mimir/provider.go
@@ -16,19 +16,22 @@ type Provider struct {
 }
 
 // NewProvider instantiates a new Provider.
-func NewProvider(config *config.MimirConfig) (*Provider, error) {
+func NewProvider(config *config.MimirConfig) *Provider {
 	clientTool := client.NewHTTPClient(config)
-	if config.Address == "" {
-		return nil, fmt.Errorf("mimir address is not set")
-	}
-	if config.TenantID == "" {
-		return nil, fmt.Errorf("mimir tenant id is not set")
-	}
-
 	return &Provider{
 		config:     config,
 		clientTool: clientTool,
-	}, nil
+	}
+}
+
+func (p *Provider) Validate() error {
+	if p.config.Address == "" {
+		return fmt.Errorf("mimir address is not set")
+	}
+	if p.config.TenantID == "" {
+		return fmt.Errorf("mimir tenant id is not set")
+	}
+	return nil
 }
 
 func (p *Provider) Name() string {

--- a/pkg/syntheticmonitoring/provider.go
+++ b/pkg/syntheticmonitoring/provider.go
@@ -21,26 +21,29 @@ type ClientProvider interface {
 }
 
 // NewProvider instantiates a new Provider.
-func NewProvider(config *config.SyntheticMonitoringConfig) (*Provider, error) {
-	if config.URL == "" {
-		config.URL = "https://synthetic-monitoring-api.grafana.net"
-	}
-	if config.StackID == 0 {
-		return nil, fmt.Errorf("stack id is not set")
-	}
-	if config.MetricsID == 0 {
-		return nil, fmt.Errorf("metrics id is not set")
-	}
-	if config.LogsID == 0 {
-		return nil, fmt.Errorf("logs id is not set")
-	}
-	if config.Token == "" {
-		return nil, fmt.Errorf("token is not set")
-	}
-
+func NewProvider(config *config.SyntheticMonitoringConfig) *Provider {
 	return &Provider{
 		config: config,
-	}, nil
+	}
+}
+
+func (p *Provider) Validate() error {
+	if p.config.URL == "" {
+		p.config.URL = "https://synthetic-monitoring-api.grafana.net"
+	}
+	if p.config.StackID == 0 {
+		return fmt.Errorf("stack id is not set")
+	}
+	if p.config.MetricsID == 0 {
+		return fmt.Errorf("metrics id is not set")
+	}
+	if p.config.LogsID == 0 {
+		return fmt.Errorf("logs id is not set")
+	}
+	if p.config.Token == "" {
+		return fmt.Errorf("token is not set")
+	}
+	return nil
 }
 
 func (p *Provider) Name() string {


### PR DESCRIPTION
#362 added details of which providers were configured. It also prevented unconfigured
providers from being added to the list of available providers.

This has the unfortunate consequence of preventing "offline" commands from working,
e.g. `grr show`, `grr list` or `grr export`.

This PR resolves this by still allowing an unconfigured provider to be used for such
situations. Now, an unconfigured provider will just error out when it attempts to
connect to its backend.

Closes #424.
