### PR TITLE
Print configs in cmd package only

### DIFF
--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -106,7 +106,23 @@ func getContextsCmd() *cli.Command {
 	var opts LoggingOpts
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		return config.GetContexts()
+		contexts, err := config.GetContexts()
+		if err != nil {
+			return err
+		}
+		currentContext, err := config.CurrentContext()
+		if err != nil {
+			return err
+		}
+
+		for _, context := range contexts {
+			if context == currentContext.Name {
+				fmt.Printf("* %s\n", context)
+			} else {
+				fmt.Printf("  %s\n", context)
+			}
+		}
+		return nil
 	}
 	return initialiseLogging(cmd, &opts)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -113,25 +113,17 @@ func NewConfig() {
 	viper.Set("contexts.default.name", "default")
 }
 
-func GetContexts() error {
+func GetContexts() ([]string, error) {
 	contexts := map[string]interface{}{}
-	currentContext := viper.GetString(CurrentContextSetting)
 	if err := viper.UnmarshalKey("contexts", &contexts); err != nil {
-		return err
+		return nil, err
 	}
 	keys := make([]string, 0, len(contexts))
 	for k := range contexts {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	for _, k := range keys {
-		if k == currentContext {
-			fmt.Printf("* %s\n", k)
-		} else {
-			fmt.Printf("  %s\n", k)
-		}
-	}
-	return nil
+	return keys, nil
 }
 
 func UseContext(context string) error {


### PR DESCRIPTION
Minor change to make printing contexts happen in the `cmd` package rather than
deeper into the code.
