### PR TITLE
Lengthen mimir test delay

### DIFF
--- a/integration/mimir/rules_test.go
+++ b/integration/mimir/rules_test.go
@@ -35,7 +35,7 @@ func TestRules(t *testing.T) {
 	})
 
 	// Mimir takes some seconds in sync the rules. If we get the list of them immediately, it could return an empty list.
-	time.Sleep(1 * time.Second)
+	time.Sleep(1500 * time.Millisecond)
 
 	t.Run("get remote rule list", func(t *testing.T) {
 		ids, err := handler.ListRemote()


### PR DESCRIPTION
When pushing resources to Mimir, there's a delay before they show in the API. Therefore,
our tests need to wait ~1s before listing pushed resources.

The current 1s delay is causing occasional test failures. This PR increases this delay to
1.5s, which appears to make the test pass consistently.
