### PR TITLE
Check for blank UID in server requests

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -386,7 +386,7 @@ func (h *DashboardHandler) DashboardJSONPostHandler(s grizzly.Server) http.Handl
 			return
 		}
 		uid, ok := resp.Dashboard["uid"].(string)
-		if !ok {
+		if !ok || uid == "" {
 			grizzly.SendError(w, "Dashboard has no UID", fmt.Errorf("dashboard has no UID"), 400)
 			return
 		}


### PR DESCRIPTION
Under certain circumstances, Grafana can deliver a dashboard with a blank UID. This PR
corrects the logic to detect this.
