### PR TITLE
Add only-spec to watch and avoid nil pointer error

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -307,6 +307,7 @@ func watchCmd(registry grizzly.Registry) *cli.Command {
 		}
 		return grizzly.Watch(registry, watchDir, parser, parserOpts, trailRecorder)
 	}
+	cmd = initialiseOnlySpec(cmd, &opts)
 	return initialiseCmd(cmd, &opts)
 }
 

--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -43,7 +43,9 @@ func (h *DatasourceHandler) Unprepare(resource grizzly.Resource) *grizzly.Resour
 
 // Prepare gets a resource ready for dispatch to the remote endpoint
 func (h *DatasourceHandler) Prepare(existing *grizzly.Resource, resource grizzly.Resource) *grizzly.Resource {
-	resource.SetSpecValue("id", existing.GetSpecValue("id"))
+	if existing != nil && existing.GetSpecValue("id") != nil {
+		resource.SetSpecValue("id", existing.GetSpecValue("id"))
+	}
 	resource.DeleteSpecKey("version")
 	if !resource.HasSpecString("uid") {
 		resource.SetSpecValue("uid", resource.Name())

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -194,7 +194,7 @@ func parseAny(registry Registry, data any, resourceKind, folderUID string, sourc
 
 		if handler.UsesFolders() && folderUID == "" {
 			// TODO: the error shouldn't assume a CLI environment
-			return Resources{}, fmt.Errorf("folder (-f) required with --onlyspec")
+			return Resources{}, fmt.Errorf("folder (-f) required with --only-spec")
 		}
 
 		m := data.(map[string]any)


### PR DESCRIPTION
Resolves #448 and #449.

For #448, check that `existing` is defined before using it.

For #449, add `--only-spec` and `-f` to `grr watch` and correct an error message to say `--only-spec`not `--onlyspec`.


