### PR TITLE
Skip warnings in web index

### DIFF
--- a/pkg/grizzly/embed/templates/proxy/index.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/index.html.tmpl
@@ -8,16 +8,17 @@
 <body dir="ltr">
 {{ template "proxy/header.html.tmpl" . }}
 
-
 <main>
     <div>
     {{ if ne (len .ParseErrors) 0 }}
         <h1>Errors</h1>
 
         {{ range .ParseErrors }}
+          {{ if not (IsWarning .) }}
             <li>
                 <code>{{ . }}</code>
             </li>
+          {{ end }}
         {{ end }}
     {{ end }}
     <h1>Available dashboards</h1>

--- a/pkg/grizzly/errors.go
+++ b/pkg/grizzly/errors.go
@@ -39,3 +39,20 @@ func NewUnrecognisedFormatError(file string) UnrecognisedFormatError {
 		File: file,
 	}
 }
+
+type Warning struct {
+	Err error
+}
+
+func NewWarning(err error) Warning {
+	return Warning{err}
+}
+
+func (w Warning) Error() string {
+	return w.Err.Error()
+}
+
+func IsWarning(err any) bool {
+	_, ok := err.(Warning)
+	return ok
+}

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -161,7 +161,7 @@ func (parser *ChainParser) parseFile(file string, options ParserOptions) (Resour
 		return resources, nil
 	}
 
-	return Resources{}, NewUnrecognisedFormatError(file)
+	return Resources{}, NewWarning(NewUnrecognisedFormatError(file))
 }
 
 func parseAny(registry Registry, data any, resourceKind, folderUID string, source Source) (Resources, error) {

--- a/pkg/grizzly/tmpl.go
+++ b/pkg/grizzly/tmpl.go
@@ -46,9 +46,7 @@ func findAndParseTemplates(vfs fs.FS, rootTmpl *template.Template, rootDir strin
 		templateName := strings.TrimPrefix(strings.TrimPrefix(path, rootDir), "/")
 		t := rootTmpl.New(templateName).Funcs(
 			template.FuncMap{
-				"IsWarning": func(i any) bool {
-					return IsWarning(i)
-				},
+				"IsWarning": IsWarning,
 			},
 		)
 		_, err = t.Parse(string(contents))

--- a/pkg/grizzly/tmpl.go
+++ b/pkg/grizzly/tmpl.go
@@ -44,7 +44,13 @@ func findAndParseTemplates(vfs fs.FS, rootTmpl *template.Template, rootDir strin
 		}
 
 		templateName := strings.TrimPrefix(strings.TrimPrefix(path, rootDir), "/")
-		t := rootTmpl.New(templateName)
+		t := rootTmpl.New(templateName).Funcs(
+			template.FuncMap{
+				"IsWarning": func(i any) bool {
+					return IsWarning(i)
+				},
+			},
+		)
 		_, err = t.Parse(string(contents))
 
 		return err


### PR DESCRIPTION
As described in #452, when parsing resources within the server, Grizzly collects up all parse errors. It reports these errors to both the console and to the index web page.

Some of these could be seen as warnings which are less appropriate on the web page. This PR adds a `Warning` error wrapper and skips warnings in the index UI.

Closes #452.
