### PR TITLE
Use appropriate authentication header for basicauth in Grafana provider

### DIFF
--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -134,7 +134,7 @@ func (p *Provider) SetupProxy() (*httputil.ReverseProxy, error) {
 			if p.config.User != "" {
 				header := fmt.Sprintf("%s:%s", p.config.User, p.config.Token)
 				encoded := base64.StdEncoding.EncodeToString([]byte(header))
-				r.Out.Header.Set("Authorization", "Bearer "+encoded)
+				r.Out.Header.Set("Authorization", "Basic "+encoded)
 			} else {
 				r.Out.Header.Set("Authorization", "Bearer "+p.config.Token)
 			}


### PR DESCRIPTION
Hi team!

Currently Grizzly tries to send `Authentication: Bearer <base64(username:password)>` instead of `Authentication: Basic <base64(username:password)>` even when basicauth is explicitly required by specifying `config.User` and `config.Token`.
This didn't work for me so I've dug into the sources and made this change which fixed my issues. I glanced through Grafana documentation and didn't find any requirement to send the encoded basicauth credentials in bearer header, so I deduced that this is indeed a bug.