### PR TITLE
Support watching files

### DIFF
--- a/pkg/grizzly/watch.go
+++ b/pkg/grizzly/watch.go
@@ -33,7 +33,10 @@ func (w *Watcher) Watch(path string) error {
 	}
 
 	if !stat.IsDir() {
-		w.watcher.Add(path)
+		err := w.watcher.Add(path)
+		if err != nil {
+			return err
+		}
 	} else {
 		err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {


### PR DESCRIPTION
Currently the "watch" code assumes that the command line resource-path argument is a directory. If it isn't, it doesn't trigger. This PR fixes this.
