### PR TITLE
Fix watching dirs

### DIFF
--- a/pkg/grizzly/watch.go
+++ b/pkg/grizzly/watch.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/fsnotify.v1"
@@ -53,6 +54,9 @@ func (w *Watcher) Add(path string) error {
 				return err
 			}
 			if d.IsDir() {
+				if !strings.HasSuffix(path, "/") {
+					path = path + "/"
+				}
 				w.watches = append(w.watches, watch{path: path, parent: path, isDir: true})
 				return w.watcher.Add(path)
 			}
@@ -100,7 +104,7 @@ func (w *Watcher) Wait() error {
 }
 
 func (w *Watcher) isFiltered(path string) bool {
-	parent := filepath.Dir(path)
+	parent := filepath.Dir(path) + "/"
 	for _, watch := range w.watches {
 		if parent == watch.parent {
 			if watch.isDir || watch.path == path {

--- a/pkg/grizzly/watch.go
+++ b/pkg/grizzly/watch.go
@@ -42,7 +42,7 @@ func (w *Watcher) Add(path string) error {
 
 	if !stat.IsDir() {
 		// `vim` renames and replaces, doesn't create a WRITE event. So we need to watch the whole dir and filter for our file
-		parent := filepath.Dir(path)
+		parent := filepath.Dir(path) + "/"
 		w.watches = append(w.watches, watch{path: path, parent: parent, isDir: false})
 		err := w.watcher.Add(parent)
 		if err != nil {

--- a/pkg/grizzly/watch.go
+++ b/pkg/grizzly/watch.go
@@ -55,7 +55,7 @@ func (w *Watcher) Add(path string) error {
 			}
 			if d.IsDir() {
 				if !strings.HasSuffix(path, "/") {
-					path = path + "/"
+					path += "/"
 				}
 				w.watches = append(w.watches, watch{path: path, parent: path, isDir: true})
 				return w.watcher.Add(path)


### PR DESCRIPTION
In #470, watching single files was fixed. However, in some cases, this didn't support watching directories correctly. By consistently ensuring a trailing slash on directory names, this PR makes this scenario work as expected.
