### PR TITLE
Server: only parse acceptable files

### DIFF
--- a/examples/dashboard-simple.libsonnet
+++ b/examples/dashboard-simple.libsonnet
@@ -1,4 +1,5 @@
 {
+  uid: 'prod-overview',
   title: 'Production Overview',
   tags: ['templated'],
   timezone: 'browser',

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -102,13 +102,14 @@ var mustProxyPOST = []string{
 	"/api/ds/query",
 }
 var blockJSONget = map[string]string{
-	"/api/ma/events":    "[]",
-	"/api/live/publish": "[]",
-	"/api/live/list":    "[]",
-	"/api/user/orgs":    "[]",
-	"/api/annotations":  "[]",
-	"/api/search":       "[]",
-	"/api/usage/*":      "[]",
+	"/api/ma/events":       "[]",
+	"/api/live/publish":    "[]",
+	"/api/live/list":       "[]",
+	"/api/user/orgs":       "[]",
+	"/api/annotations":     "[]",
+	"/api/search":          "[]",
+	"/api/usage/*":         "[]",
+	"/api/frontend/assets": "{}",
 
 	"/api/access-control/user/actions": `{"dashboards:write": true}`,
 	"/api/prometheus/grafana/api/v1/rules": `{
@@ -208,8 +209,8 @@ func (s *Server) Start() error {
 	return http.ListenAndServe(fmt.Sprintf(":%d", s.port), r)
 }
 
-func (s *Server) ParseResources(resourcesPath string) (Resources, error) {
-	resources, err := s.parser.Parse(resourcesPath, s.parserOpts)
+func (s *Server) ParseResources(resourcePath string) (Resources, error) {
+	resources, err := s.parser.Parse(resourcePath, s.parserOpts)
 	s.parserErr = err
 	s.Resources.Merge(resources)
 	return resources, err
@@ -224,9 +225,13 @@ func (s *Server) URL(path string) string {
 }
 
 func (s *Server) updateWatchedResource(name string) error {
-	resources, err := s.ParseResources(name)
+	if !s.parser.Accept(name) {
+		return nil
+	}
+	resources, err := s.ParseResources(s.ResourcePath)
 	if errors.As(err, &UnrecognisedFormatError{}) {
-		log.Printf("Skipping %s", name)
+		uerr := err.(UnrecognisedFormatError)
+		log.Printf("Skipping %s", uerr.File)
 		return nil
 	}
 	if err != nil {
@@ -241,7 +246,7 @@ func (s *Server) updateWatchedResource(name string) error {
 		}
 		_, ok := handler.(ProxyHandler)
 		if ok {
-			log.Info("Changes detected. Applying ", name)
+			log.Infof("Changes detected. Reloading %s", resource.Name())
 			err = livereload.Reload(resource.Kind(), resource.Name(), resource.Spec())
 			if err != nil {
 				return err
@@ -250,6 +255,7 @@ func (s *Server) updateWatchedResource(name string) error {
 	}
 	return nil
 }
+
 func (s *Server) blockHandler(response string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
The server, by default, triggers on every file change. When editing Jsonnet files with `vim`, the server can end up attempting to execute the Jsonnet at a time when vim has not yet moved the file into place. This ends up with weird, "file not found" errors, when the file being reported as not found is the very file you've just been editing.

This is because it triggers on vim's `.swp` file - at that point, the edited file does not actually exist.

This is easily resolved: the parser now has an `Accept()` method, and any file can be checked to see whether Grizzly wants to trigger on it.

Also adds a UID to an example dashboard, which is needed for the server to work correctly.
