### PR TITLE
Make page header clickable

### DIFF
--- a/pkg/grizzly/embed/assets/style.css
+++ b/pkg/grizzly/embed/assets/style.css
@@ -89,6 +89,7 @@ main div {
     position: relative;
     left: -10px;
     font-size: 180%;
+    color: white;
 }
 .context {
     vertical-align: middle;

--- a/pkg/grizzly/embed/templates/proxy/header.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/header.html.tmpl
@@ -4,7 +4,7 @@
             <a href="/"><img class="icon" src="/grizzly/assets/grizzly-logo.svg"></a>
         </div>
         <div class="float-left header-title">
-            <h1>Grizzly Server</h1>
+            <a href="/"><h1>Grizzly Server</h1></a>
         </div>
         <div class="float-right context">
             <form action="#" method="post">


### PR DESCRIPTION
Clicking the Grizzly logo takes you to the Grizzly server homepage. Clicking on the "Grizzly Server" title doesn't. This has often annoyed me, as I'd expect this to work.

This PR fixes this.
