### PR TITLE
Accept arrays of objects

### DIFF
--- a/pkg/grizzly/grizzly.jsonnet
+++ b/pkg/grizzly/grizzly.jsonnet
@@ -111,4 +111,6 @@ local convert(main, apiVersion) = {
     then fromMap(main.syntheticMonitoring)
     else {},
 };
-convert(main, 'grizzly.grafana.com/v1alpha1') + main
+if std.isArray(main)
+  then main
+  else (convert(main, 'grizzly.grafana.com/v1alpha1') + main)

--- a/pkg/grizzly/json.go
+++ b/pkg/grizzly/json.go
@@ -28,7 +28,7 @@ func (parser *JSONParser) Parse(file string, options ParserOptions) (Resources, 
 	}
 	defer f.Close()
 
-	m := map[string]any{}
+	var m any
 	err = json.NewDecoder(f).Decode(&m)
 	if err != nil {
 		return Resources{}, err

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -179,6 +180,20 @@ func (parser *ChainParser) parseFile(file string, options ParserOptions) (Resour
 }
 
 func parseAny(registry Registry, data any, resourceKind, folderUID string, source Source) (Resources, error) {
+	if slice, ok := isSlice(data); ok {
+		resources := NewResources()
+		for _, elem := range slice {
+			parsedResources, err := parseAny(registry, elem, resourceKind, folderUID, source)
+			if err != nil {
+				return Resources{}, err
+			}
+			for _, resource := range parsedResources.AsList() {
+				j, _ := resource.JSON()
+				resources.Add(resource)
+			}
+		}
+		return resources, nil
+	}
 	hasEnvelope := DetectEnvelope(data)
 	if hasEnvelope {
 		m := data.(map[string]any)
@@ -259,6 +274,15 @@ func DetectEnvelope(data any) bool {
 		}
 	}
 	return true
+}
+
+func isSlice(data any) ([]any, bool) {
+	switch reflect.TypeOf(data).Kind() {
+	case reflect.Slice:
+		return data.([]any), true
+	default:
+		return nil, false
+	}
 }
 
 // ValidateEnvelope confirms that this resource is a complete enveloped resource

--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -188,7 +188,6 @@ func parseAny(registry Registry, data any, resourceKind, folderUID string, sourc
 				return Resources{}, err
 			}
 			for _, resource := range parsedResources.AsList() {
-				j, _ := resource.JSON()
 				resources.Add(resource)
 			}
 		}

--- a/pkg/grizzly/parsing_test.go
+++ b/pkg/grizzly/parsing_test.go
@@ -195,6 +195,12 @@ func TestParseKindDetection(t *testing.T) {
 				ExpectedResources: 2,
 			},
 			{
+				Name:              "jsonnet dashboards input, as array",
+				InputFile:         "testdata/parsing/dashboards-as-array.jsonnet",
+				ExpectedKind:      "Dashboard",
+				ExpectedResources: 50,
+			},
+			{
 				Name:         "json datasource input, with envelope",
 				InputFile:    "testdata/parsing/datasource-with-envelope.json",
 				ExpectedKind: "Datasource",

--- a/pkg/grizzly/parsing_test.go
+++ b/pkg/grizzly/parsing_test.go
@@ -183,6 +183,18 @@ func TestParseKindDetection(t *testing.T) {
 				ExpectedResources: 2,
 			},
 			{
+				Name:              "json dashboards input, as array",
+				InputFile:         "testdata/parsing/dashboards-as-array.json",
+				ExpectedKind:      "Dashboard",
+				ExpectedResources: 2,
+			},
+			{
+				Name:              "yaml dashboards input, as array",
+				InputFile:         "testdata/parsing/dashboards-as-array.yaml",
+				ExpectedKind:      "Dashboard",
+				ExpectedResources: 2,
+			},
+			{
 				Name:         "json datasource input, with envelope",
 				InputFile:    "testdata/parsing/datasource-with-envelope.json",
 				ExpectedKind: "Datasource",
@@ -209,6 +221,9 @@ func TestParseKindDetection(t *testing.T) {
 					require.Error(t, err)
 					require.Equal(t, test.ExpectedError, err.Error())
 					return
+				}
+				for _, resource := range resources.AsList() {
+					require.Equal(t, test.ExpectedKind, resource.Kind())
 				}
 				require.NoError(t, err)
 				if test.ExpectedResources == 0 { // i.e. the default, which actually means 1

--- a/pkg/grizzly/testdata/parsing/dashboards-as-array.json
+++ b/pkg/grizzly/testdata/parsing/dashboards-as-array.json
@@ -1,0 +1,22 @@
+[
+   {
+      "panels": [ ],
+      "schemaVersion": 17,
+      "tags": [
+         "templated"
+      ],
+      "timezone": "browser",
+      "title": "Dashboard 1",
+      "uid": "dashboard-1"
+   },
+   {
+      "panels": [ ],
+      "schemaVersion": 17,
+      "tags": [
+         "templated"
+      ],
+      "timezone": "browser",
+      "title": "Dashboard 2",
+      "uid": "dashboard-2"
+   }
+]

--- a/pkg/grizzly/testdata/parsing/dashboards-as-array.jsonnet
+++ b/pkg/grizzly/testdata/parsing/dashboards-as-array.jsonnet
@@ -1,0 +1,13 @@
+local dashboard(uid, title) = {
+  uid: uid, 
+  title: title,
+  tags: ['templated'],
+  timezone: 'browser',
+  schemaVersion: 17,
+  panels: [],
+};
+
+[
+  dashboard("dashboard-%d" % num, "Dashboard %d" % num)
+  for num in std.range(1,50)
+]

--- a/pkg/grizzly/testdata/parsing/dashboards-as-array.yaml
+++ b/pkg/grizzly/testdata/parsing/dashboards-as-array.yaml
@@ -1,0 +1,14 @@
+- panels: []
+  schemaVersion: 17
+  tags:
+  - templated
+  timezone: browser
+  title: Dashboard 1
+  uid: dashboard-1
+- panels: []
+  schemaVersion: 17
+  tags:
+  - templated
+  timezone: browser
+  title: Dashboard 2
+  uid: dashboard-2

--- a/pkg/grizzly/yaml.go
+++ b/pkg/grizzly/yaml.go
@@ -37,7 +37,7 @@ func (parser *YAMLParser) Parse(file string, options ParserOptions) (Resources, 
 	decoder := yaml.NewDecoder(reader)
 	resources := NewResources()
 	for i := 0; ; i++ {
-		var m map[string]any
+		var m any
 		err = decoder.Decode(&m)
 		if err == io.EOF {
 			break


### PR DESCRIPTION
At present, you can either provide a single object (e.g. a dashboard) to Grizzly, or you provide a tree of objects, containing enveloped resources.

This PR allows users to provide an array of resources, with the type of those resourcs detected by Grizzly. Thus, they can be enveloped, or they can be simple dashboards.

This is a simple, entry-level way to get multiple resources into Grizzly.
