### PR TITLE
Support watch scripts for serve

### DIFF
--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -33,6 +33,7 @@ type Opts struct {
 	ProxyPort   int
 	CanSave     bool
 	Watch       bool
+	WatchScript string
 }
 
 func configPathCmd() *cli.Command {

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -376,12 +376,16 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 		}
 
 		resourcesPath := ""
-		if len(args) > 0 {
-			resourcesPath = args[0]
-		}
 		watchPaths := []string{resourcesPath}
-		if len(args) > 1 {
-			watchPaths = args[1:]
+		if opts.WatchScript != "" {
+			watchPaths = args
+		} else {
+			if len(args) > 0 {
+				resourcesPath = args[0]
+			}
+			if len(args) > 1 {
+				watchPaths = args[1:]
+			}
 		}
 
 		targets := currentContext.GetTargets(opts.Targets)
@@ -405,6 +409,9 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 		server.SetFormatting(onlySpec, format)
 		if opts.Watch {
 			server.Watch(watchPaths)
+			if opts.WatchScript != "" {
+				server.WatchScript(opts.WatchScript)
+			}
 		}
 		if opts.OpenBrowser {
 			server.OpenBrowser()
@@ -414,6 +421,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 	cmd.Flags().BoolVarP(&opts.Watch, "watch", "w", false, "Watch filesystem for changes")
 	cmd.Flags().BoolVarP(&opts.OpenBrowser, "open-browser", "b", false, "Open Grizzly in default browser")
 	cmd.Flags().IntVarP(&opts.ProxyPort, "port", "p", 8080, "Port on which the server will listen")
+	cmd.Flags().StringVarP(&opts.WatchScript, "script", "S", "", "Script to execute on filesystem change")
 	cmd = initialiseOnlySpec(cmd, &opts)
 	return initialiseCmd(cmd, &opts)
 }

--- a/docs/content/server.md
+++ b/docs/content/server.md
@@ -64,19 +64,13 @@ grr serve -w examples/grr.jsonnet examples/*.*sonnet examples/vendor
 ### Reviewing changes to code in other languages in Grafana
 The [Grafana Foundation SDK](https://github.com/grafana/grafana-foundation-sdk) provides libraries in a
 range of languages that can be used to render Grafana dashboards. Watching changes to these with Grizzly
-is a two stage process, currently requiring an additional tool to watch for changes to source code and
-render your dashboard(s) to files. One such tool is [entr](https://github.com/eradman/entr), which can be
-used like so (with the Foundation SDK's TypeScript support):
+is also possible.
 
 ```
 git clone https://github.com/grafana/grafana-foundation-sdk
 cd grafana-foundation-sdk/examples/typescript/red-method
 npm install
-find . | entr -s 'npm run -s dev > ts.json'
-```
-Then, in another window:
-```
-grr serve -w ts.json
+grr serve -w -S 'npm run -s dev' .
 ```
 Finally, open the Grizzly server at [http://localhost:8080](http://localhost:8080) and select the Red
 Method dashboard.

--- a/examples/array-of-resources.jsonnet
+++ b/examples/array-of-resources.jsonnet
@@ -1,0 +1,14 @@
+local dashboard(uid, title) = {
+  uid: uid,
+  title: title,
+  tags: ['templated'],
+  timezone: 'browser',
+  schemaVersion: 17,
+  panels: [],
+};
+
+[
+  dashboard("dashboard-1", "Dashboard 1"),
+  dashboard("dashboard-2", "Dashboard 2"),
+  dashboard("dashboard-3", "Dashboard 3"),
+]


### PR DESCRIPTION
Grizzly supports static (YAML/JSON) files, along with Jsonnet - directly executing the jsonnet when a source file changes.

However, for other languages (e.g. those supported by the [Grafana Foundation SDK](https://github.com/grafana/grafana-foundation-sdk)), it is much harder to watch for changes.

This PR adds the concept of "watch scripts", that is, a script that is executed on filesystem changes, the stdout of which will be new resources to be parsed.

Thus, to use a TypeScript example in the Foundation SDK repo:

```
git clone https://github.com/grafana/grafana-foundation-sdk
cd grafana-foundation-sdk/examples/typescript/red-method
npm install
grr serve -w -S 'npm run -s dev' .
```
