### PR TITLE
Fix typo in SyntheticMonitoringConfig struct tags that broke configuration via AccessToken

### DIFF
--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -28,7 +28,7 @@ type SyntheticMonitoringConfig struct {
 	StackID     int64  `yaml:"stack-id" mapstructure:"stack-id"`
 	LogsID      int64  `yaml:"logs-id" mapstructure:"logs-id"`
 	MetricsID   int64  `yaml:"metrics-id" mapstructure:"metrics-id"`
-	AccessToken string `yaml:"access-token" mapsructure:"access-token"`
+	AccessToken string `yaml:"access-token" mapstructure:"access-token"`
 }
 
 type Context struct {


### PR DESCRIPTION
Configuration of Synthetic Monitoring (https://grafana.github.io/grizzly/configuration/#grafana-synthetic-monitoring) is broken due to a typo in the struct tags for the new AccessToken parameter. 

Fix: `mapsructure` -> `mapstructure`

I tested and validated that this change fixes the issue locally.