### PR TITLE
Allow --only-spec for grr export

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -456,6 +456,7 @@ func exportCmd(registry grizzly.Registry) *cli.Command {
 
 		return grizzly.Export(registry, dashboardDir, resources, onlySpec, format)
 	}
+	cmd = initialiseOnlySpec(cmd, &opts)
 	return initialiseCmd(cmd, &opts)
 }
 


### PR DESCRIPTION
Export is not an often used feature, so it has lagged behind a bit. Through ommission, it lacks the `--only-spec` functionality. This PR fixes that.

Fixes #480.
