### PR TITLE
chore: bump to use go1.23

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,12 +34,12 @@ jobs:
         arch:
           - amd64
           - arm64
-    
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       - run: GOOS=linux GOARCH=${{ matrix.arch }} make static
       - name: Docker meta
         id: meta
@@ -57,7 +57,7 @@ jobs:
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: grafana/shared-workflows/actions/dockerhub-login@main
-  
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v5
@@ -75,7 +75,7 @@ jobs:
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"          
+          touch "/tmp/digests/${digest#sha256:}"
           echo "artifact_name=digests-linux/${{ matrix.arch }}" | sed -e 's/\//-/g' >> "$GITHUB_OUTPUT"
 
       - name: Upload digest
@@ -86,11 +86,11 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-  
+
   merge:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
-    needs: 
+    needs:
       - build
     steps:
       - name: Download digests (linux/amd64)
@@ -113,7 +113,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-    
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -128,7 +128,7 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}          
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -1,4 +1,5 @@
 name: Publish TechDocs
+
 on:
   push:
     branches:
@@ -8,9 +9,11 @@ on:
       - 'mkdocs.yml'
       - 'catalog-info.yaml'
       - '.github/workflows/publish-techdocs.yaml'
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.ref }}'
   cancel-in-progress: true
+
 jobs:
   publish-docs:
     uses: grafana/shared-workflows/.github/workflows/publish-techdocs.yaml@main

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -27,4 +27,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/public
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       - run: make cross
       - id: docker_tag
         run: echo "DOCKER_TAG=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: run tests
 
 on:
-  pull_request: {}
+  pull_request:
 
 jobs:
   lint:
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       - name: Lint
         run: make lint
   tests:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       - name: Make
         run: make test
   integration:
@@ -28,6 +28,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       - name: Make
         run: make integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.5
+FROM golang:1.23.0
 ARG JSONNET_VERSION=v0.19.1
 ARG JB_VERSION=v0.5.1
 RUN CGO_ENABLED=0 go install github.com/google/go-jsonnet/cmd/jsonnet@${JSONNET_VERSION} && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grizzly
 
-go 1.22
+go 1.23
 
 require (
 	github.com/fatih/color v1.15.0


### PR DESCRIPTION
- bump to use go1.23
- also update setup-go to use go-version-file to simplify go version management

relates to https://github.com/Homebrew/homebrew-core/pull/183138