### PR TITLE
fix: remove workaround for api issues

### DIFF
--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -261,10 +261,6 @@ func (h *AlertRuleGroupHandler) putAlertRuleGroup(existing, resource grizzly.Res
 		}
 	}
 
-	// clear rules as grafana will error if the spec contains more rules than are
-	// currently present
-	group.Rules = nil
-
 	client, err := h.Provider.(ClientProvider).Client()
 	if err != nil {
 		return err


### PR DESCRIPTION
This is no longer needed and prevents the deletion of rules

Fixes #472 