### PR TITLE
Add new dashboard support to serve

### DIFF
--- a/pkg/grizzly/embed/assets/style.css
+++ b/pkg/grizzly/embed/assets/style.css
@@ -109,3 +109,23 @@ iframe {
     width: 100%;
     height: 100%;
 }
+
+.button {
+  position: relative;
+  display: inline-block;
+  border: 1px solid #1866d4;
+  background-color: #1866d4;
+  color: #fefefe;
+  text-decoration: none !important;
+  box-sizing: border-box;
+  border-radius: 3px;
+  font-size: 14px;
+  line-height: 24px;
+  margin: 10px;
+  padding: 5px 15px !important;
+}
+
+.button:hover {
+    border: 1px solid white;
+    color: #fefefe;
+}

--- a/pkg/grizzly/embed/assets/style.css
+++ b/pkg/grizzly/embed/assets/style.css
@@ -138,3 +138,8 @@ iframe {
     border: 1px solid lightgray;
     width: 250px;
 }
+
+.code {
+    font-family:'Courier New', Courier, monospace;
+    font-size: 90%;
+}

--- a/pkg/grizzly/embed/assets/style.css
+++ b/pkg/grizzly/embed/assets/style.css
@@ -129,3 +129,12 @@ iframe {
     border: 1px solid white;
     color: #fefefe;
 }
+
+.input-text {
+    font-size: 14px;
+    padding: 5px;
+    margin: 5px;
+    border-radius: 2px;
+    border: 1px solid lightgray;
+    width: 250px;
+}

--- a/pkg/grizzly/embed/templates/proxy/index.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/index.html.tmpl
@@ -23,6 +23,7 @@
     {{ end }}
     <h1>Available dashboards</h1>
 
+    <span><a class="button" href="/grizzly/new/dashboard">New dashboard</a></span>
     <ul>
         {{ range .Resources }}
             {{ if eq .Kind "Dashboard" }}

--- a/pkg/grizzly/embed/templates/proxy/new-dashboard.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/new-dashboard.html.tmpl
@@ -10,11 +10,12 @@
 
 <main>
     <div>
+      <h1>Create a new dashboard</h1>
       <form method="POST" action="#">
-        <input name="title" placeholder="Dashboard title"><br/>
-        <input name="uid" placeholder="Dashboard UID"><br/>
-        <input name="path" placeholder="Local file path"><br/>
-        <input type="submit" value="Create dashboard"/>
+        <input class="input-text" name="title" placeholder="Dashboard title"><br/>
+        <input class="input-text" name="uid" placeholder="Dashboard UID"> can be a human readable alphanumeric (plus dash) string. <br/>
+        <input class="input-text" name="path" placeholder="Local file path"> relative to your Grizzly resource path.<br/>
+        <input class="button" type="submit" value="Create and edit dashboard"/>
       </form>
     </div>
 </main>

--- a/pkg/grizzly/embed/templates/proxy/new-dashboard.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/new-dashboard.html.tmpl
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset=utf-8>
+    <title>Grizzly</title>
+    <link rel="stylesheet" href="/grizzly/assets/style.css"/>
+</head>
+<body dir="ltr">
+{{ template "proxy/header.html.tmpl" . }}
+
+<main>
+    <div>
+      <form method="POST" action="#">
+        <input name="title" placeholder="Dashboard title"><br/>
+        <input name="uid" placeholder="Dashboard UID"><br/>
+        <input name="path" placeholder="Local file path"><br/>
+        <input type="submit" value="Create dashboard"/>
+      </form>
+    </div>
+</main>
+</body>
+</html>

--- a/pkg/grizzly/embed/templates/proxy/new-dashboard.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/new-dashboard.html.tmpl
@@ -12,9 +12,9 @@
     <div>
       <h1>Create a new dashboard</h1>
       <form method="POST" action="#">
-        <input class="input-text" name="title" placeholder="Dashboard title"><br/>
+        <input class="input-text" name="title" placeholder="Dashboard title"> a title for your new dashboard<br/>
         <input class="input-text" name="uid" placeholder="Dashboard UID"> can be a human readable alphanumeric (plus dash) string. <br/>
-        <input class="input-text" name="path" placeholder="Local file path"> relative to your Grizzly resource path.<br/>
+        <input class="input-text" name="path" placeholder="Local file path"> relative to <span class="code">{{ .Path }}</code>.<br/>
         <input class="button" type="submit" value="Create and edit dashboard"/>
       </form>
     </div>

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -387,9 +387,24 @@ func (s *Server) RootHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) NewResourceGetHandler(w http.ResponseWriter, r *http.Request) {
+	isaFile, err := isFile(s.ResourcePath)
+	if err != nil {
+		SendError(w, "Error finding resource path", err, 400)
+		return
+	}
+	path, err := filepath.Abs(s.ResourcePath)
+	if err != nil {
+		SendError(w, "Error finding resource path", err, 400)
+		return
+	}
+	if isaFile {
+		path = filepath.Base(path)
+	}
+
 	templateVars := map[string]any{
 		"ServerPort":     s.port,
 		"CurrentContext": s.CurrentContext,
+		"Path":           path,
 	}
 	if err := templates.ExecuteTemplate(w, "proxy/new-dashboard.html.tmpl", templateVars); err != nil {
 		SendError(w, "Error while executing template", err, 500)

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -416,7 +416,9 @@ func (s *Server) NewResourcePostHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var filename string
-	if isaFile {
+	if filepath.IsAbs(path) {
+		filename = path
+	} else if isaFile {
 		filename = filepath.Join(s.ResourcePath, path)
 	} else {
 		filename = filepath.Join(filepath.Base(s.ResourcePath), path)

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -410,11 +410,22 @@ func (s *Server) NewResourcePostHandler(w http.ResponseWriter, r *http.Request) 
 		SendError(w, "Error rendering new resource", err, 400)
 		return
 	}
+	isaFile, err := isFile(s.ResourcePath)
+	if err != nil {
+		SendError(w, "Error rendering new resource", err, 400)
+		return
+	}
+	var filename string
+	if isaFile {
+		filename = filepath.Join(s.ResourcePath, path)
+	} else {
+		filename = filepath.Join(filepath.Base(s.ResourcePath), path)
+	}
+
 	resource.Source.Rewritable = true
-	resource.Source.Path = path
+	resource.Source.Path = filename
 	resource.Source.Format = s.OutputFormat
 
-	filename := filepath.Join(s.ResourcePath, path)
 	content, _, _, err := Format(s.Registry, filename, &resource, s.OutputFormat, s.OnlySpec)
 	if err != nil {
 		SendError(w, "Error rendering new resource", err, 400)

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -412,7 +412,11 @@ func (s *Server) NewResourceGetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func (s *Server) NewResourcePostHandler(w http.ResponseWriter, r *http.Request) {
-	r.ParseForm()
+	err := r.ParseForm()
+	if err != nil {
+		SendError(w, "Error rendering new resource", err, 400)
+		return
+	}
 	uid := r.Form.Get("uid")
 	spec := map[string]any{
 		"title":         r.Form.Get("title"),
@@ -430,12 +434,8 @@ func (s *Server) NewResourcePostHandler(w http.ResponseWriter, r *http.Request) 
 		SendError(w, "Error rendering new resource", err, 400)
 		return
 	}
-	var filename string
-	if filepath.IsAbs(path) {
-		filename = path
-	} else if isaFile {
-		filename = filepath.Join(s.ResourcePath, path)
-	} else {
+	filename := filepath.Join(s.ResourcePath, path)
+	if !isaFile {
 		filename = filepath.Join(filepath.Base(s.ResourcePath), path)
 	}
 


### PR DESCRIPTION
Currently, there's no mechanism to create a new dashboard in Grizzly serve. This PR adds a framework for such a feature. The basics are there, it just needs pushing to a conclusion.﻿
