### PR TITLE
Ignore secureJsonData field in Datasources when diff-ing 

### DIFF
--- a/pkg/grafana/datasource-handler.go
+++ b/pkg/grafana/datasource-handler.go
@@ -38,6 +38,7 @@ func (h *DatasourceHandler) ResourceFilePath(resource grizzly.Resource, filetype
 func (h *DatasourceHandler) Unprepare(resource grizzly.Resource) *grizzly.Resource {
 	resource.DeleteSpecKey("version")
 	resource.DeleteSpecKey("id")
+	resource.DeleteSpecKey("secureJsonData")
 	return &resource
 }
 

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -332,12 +332,13 @@ func Diff(registry Registry, resources Resources, onlySpec bool, outputFormat st
 			return err
 		}
 
+		resource = *handler.Unprepare(resource)
+
 		local, _, _, err := Format(registry, "", &resource, outputFormat, onlySpec)
 		if err != nil {
 			return err
 		}
 
-		resource = *handler.Unprepare(resource)
 		uid := resource.Name()
 
 		log.Debugf("Getting the remote value for `%s`", resource.Ref())


### PR DESCRIPTION
Fixes #487 

This issue was caused by two bugs:
* the `secureJsonData` field in datasources wasn't ignored when calculating a diff
* the diff was calculated using a representation of the local resource that was generated *before* it was modified by `Unprepare()`