### PR TITLE
Proxy library elements in grr serve

### DIFF
--- a/pkg/grafana/dashboard-handler.go
+++ b/pkg/grafana/dashboard-handler.go
@@ -357,20 +357,17 @@ func (h *DashboardHandler) DashboardJSONGetHandler(s grizzly.Server) http.Handle
 		if resource.GetSpecValue("version") == nil {
 			resource.SetSpecValue("version", 1)
 		}
-		meta := map[string]interface{}{
-			"type":      "db",
-			"isStarred": false,
-			"folderID":  0,
-			"folderUID": "",
-			"url":       fmt.Sprintf("/d/%s/slug", uid),
-		}
-		wrapper := map[string]interface{}{
-			"dashboard": resource.Spec(),
-			"meta":      meta,
-		}
 
-		out, _ := json.Marshal(wrapper)
-		writeOrLog(w, out)
+		writeJSONOrLog(w, map[string]any{
+			"dashboard": resource.Spec(),
+			"meta": map[string]any{
+				"type":      "db",
+				"isStarred": false,
+				"folderID":  0,
+				"folderUID": "",
+				"url":       h.ProxyURL(uid),
+			},
+		})
 	}
 }
 

--- a/pkg/grafana/errors.go
+++ b/pkg/grafana/errors.go
@@ -1,6 +1,7 @@
 package grafana
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -25,4 +26,13 @@ func writeOrLog(w http.ResponseWriter, content []byte) {
 	if _, err := w.Write(content); err != nil {
 		log.Errorf("error writing response: %v", err)
 	}
+}
+
+func writeJSONOrLog(w http.ResponseWriter, content any) {
+	responseJSON, err := json.Marshal(content)
+	if err != nil {
+		log.Errorf("error marshalling response to JSON: %v", err)
+	}
+
+	writeOrLog(w, responseJSON)
 }

--- a/pkg/grafana/library-element-handler.go
+++ b/pkg/grafana/library-element-handler.go
@@ -4,11 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 
+	"github.com/go-chi/chi"
 	library "github.com/grafana/grafana-openapi-client-go/client/library_elements"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grizzly/pkg/grizzly"
+	log "github.com/sirupsen/logrus"
 )
+
+const LibraryElementKind = "LibraryElement"
 
 // LibraryElementHandler is a Grizzly Handler for Grafana dashboard folders
 type LibraryElementHandler struct {
@@ -20,7 +25,7 @@ var _ grizzly.Handler = &LibraryElementHandler{}
 // NewLibraryElementHandler returns configuration defining a new Grafana Library Element Handler
 func NewLibraryElementHandler(provider grizzly.Provider) *LibraryElementHandler {
 	return &LibraryElementHandler{
-		BaseHandler: grizzly.NewBaseHandler(provider, "LibraryElement", false),
+		BaseHandler: grizzly.NewBaseHandler(provider, LibraryElementKind, false),
 	}
 }
 
@@ -113,6 +118,45 @@ func (h *LibraryElementHandler) Add(resource grizzly.Resource) error {
 // Update pushes an element to Grafana via the API
 func (h *LibraryElementHandler) Update(existing, resource grizzly.Resource) error {
 	return h.updateElement(existing, resource)
+}
+
+func (h *LibraryElementHandler) GetProxyEndpoints(s grizzly.Server) []grizzly.HTTPEndpoint {
+	return []grizzly.HTTPEndpoint{
+		{
+			Method:  "GET",
+			URL:     "/api/library-elements/{uid}",
+			Handler: h.LibraryElementJSONGetHandler(s),
+		},
+	}
+}
+
+func (h *LibraryElementHandler) ProxyURL(uid string) string {
+	return fmt.Sprintf("/api/library-elements/%s", uid)
+}
+
+func (h *LibraryElementHandler) LibraryElementJSONGetHandler(s grizzly.Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		uid := chi.URLParam(r, "uid")
+		if uid == "" {
+			grizzly.SendError(w, "No UID specified", fmt.Errorf("no UID specified within the URL"), 400)
+			return
+		}
+
+		resource, found := s.Resources.Find(grizzly.NewResourceRef(LibraryElementKind, uid))
+		if !found {
+			log.Debug("Library element not found in memory, proxying request...", "uid", uid)
+			s.ProxyRequestHandler(w, r)
+			return
+		}
+
+		if resource.GetSpecValue("version") == nil {
+			resource.SetSpecValue("version", 1)
+		}
+
+		writeJSONOrLog(w, map[string]any{
+			"result": resource.Spec(),
+		})
+	}
 }
 
 func (h *LibraryElementHandler) listElements() ([]string, error) {

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -101,6 +101,7 @@ var mustProxyGET = []string{
 	"/public/*",
 	"/api/datasources/proxy/*",
 	"/api/datasources/*",
+	"/api/library-elements/*",
 	"/api/plugins/*",
 	"/avatar/*",
 }

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -101,7 +101,6 @@ var mustProxyGET = []string{
 	"/public/*",
 	"/api/datasources/proxy/*",
 	"/api/datasources/*",
-	"/api/library-elements/*",
 	"/api/plugins/*",
 	"/avatar/*",
 }

--- a/pkg/grizzly/utils.go
+++ b/pkg/grizzly/utils.go
@@ -2,9 +2,8 @@ package grizzly
 
 import (
 	"fmt"
-	"net/http"
-
 	"log"
+	"net/http"
 )
 
 // Pluraliser returns a string describing the count of items, with a plural 's'


### PR DESCRIPTION
Fixes #493

This PR allows `/api/library-elements/*` URLs to be proxied by grr serve, enabling library panels to be resolved and displayed in grizzly.