### PR TITLE
Make the watch and watch script options behave more intuitively

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -378,9 +378,6 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 		resourcesPath := args[0]
 		watchPaths := args
 
-		if opts.WatchScript != "" {
-			resourcesPath = ""
-		}
 		if len(args) > 1 {
 			watchPaths = args[1:]
 		}
@@ -404,7 +401,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 		server.SetParser(parser, parserOpts)
 		server.SetContext(currentContext.Name)
 		server.SetFormatting(onlySpec, format)
-		if opts.Watch {
+		if opts.Watch || opts.WatchScript != "" {
 			server.Watch(watchPaths)
 			if opts.WatchScript != "" {
 				server.WatchScript(opts.WatchScript)


### PR DESCRIPTION
Related to #492

This PR makes `grr serve` behave in a more intuitive manner when the `-S` flag is used.
With this change, `-S` (watch script) implies `-w` (watch). Furthermore, the given resources path is no longer ignored when a watch script is given.