### PR TITLE
Config diagnostics

### DIFF
--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -209,6 +209,14 @@ func checkCmd(registry grizzly.Registry) *cli.Command {
 		yellow := color.New(color.FgYellow).SprintfFunc()
 		green := color.New(color.FgGreen).SprintfFunc()
 
+		gCtx, err := config.CurrentContext()
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Configuration file: %s\n", green(viper.ConfigFileUsed()))
+		fmt.Printf("Current context: %s\n\n", green(gCtx.Name))
+
 		for i, provider := range registry.Providers {
 			fmt.Println(yellow(provider.Name()))
 			fmt.Println(yellow(strings.Repeat("=", len(provider.Name()))))

--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -2,15 +2,12 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/go-clix/cli"
 	"github.com/grafana/grizzly/pkg/config"
 	"github.com/grafana/grizzly/pkg/grafana"
 	"github.com/grafana/grizzly/pkg/grizzly"
-	"github.com/grafana/grizzly/pkg/grizzly/notifier"
 	"github.com/grafana/grizzly/pkg/mimir"
 	"github.com/grafana/grizzly/pkg/syntheticmonitoring"
 	log "github.com/sirupsen/logrus"
@@ -64,7 +61,7 @@ func main() {
 		exportCmd(registry),
 		snapshotCmd(registry),
 		providersCmd(registry),
-		configCmd(),
+		configCmd(registry),
 		serveCmd(registry),
 		selfUpdateCmd(),
 	)
@@ -87,15 +84,5 @@ func createRegistry(context *config.Context) grizzly.Registry {
 		syntheticmonitoring.NewProvider(&context.SyntheticMonitoring),
 	}
 
-	var providerList []string
-	for _, provider := range providers {
-		err := provider.Validate()
-		if err != nil {
-			providerList = append(providerList, fmt.Sprintf("%s - inactive (%s)", provider.Name(), err.Error()))
-		} else {
-			providerList = append(providerList, provider.Name()+" - active")
-		}
-	}
-	notifier.InfoStderr(nil, "Providers: "+strings.Join(providerList, ", "))
 	return grizzly.NewRegistry(providers)
 }

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -489,7 +489,7 @@ func providersCmd(registry grizzly.Registry) *cli.Command {
 	return initialiseLogging(cmd, &opts)
 }
 
-func configCmd() *cli.Command {
+func configCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "config <sub-command>",
 		Short: "Show, select or configure configuration",
@@ -504,6 +504,7 @@ func configCmd() *cli.Command {
 	cmd.AddCommand(setCmd())
 	cmd.AddCommand(unsetCmd())
 	cmd.AddCommand(createContextCmd())
+	cmd.AddCommand(checkCmd(registry))
 	return cmd
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -207,7 +207,6 @@ func Get(path, outputFormat string) (string, error) {
 
 			val, ok = values[part]
 			if !ok {
-
 				val = nil
 				break
 			}

--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -40,6 +40,32 @@ func (p *Provider) Validate() error {
 	return nil
 }
 
+func (p *Provider) Status() grizzly.ProviderStatus {
+	status := grizzly.ProviderStatus{}
+
+	if err := p.Validate(); err != nil {
+		status.ActiveReason = err.Error()
+		return status
+	}
+
+	status.Active = true
+
+	client, err := p.Client()
+	if err != nil {
+		status.OnlineReason = err.Error()
+		return status
+	}
+
+	if _, err = client.Dashboards.GetHomeDashboard(); err != nil {
+		status.OnlineReason = err.Error()
+		return status
+	}
+
+	status.Online = true
+
+	return status
+}
+
 func (p *Provider) Name() string {
 	return "Grafana"
 }

--- a/pkg/grizzly/registry.go
+++ b/pkg/grizzly/registry.go
@@ -8,6 +8,15 @@ import (
 	"github.com/gobwas/glob"
 )
 
+type ProviderStatus struct {
+	// Active indicates that the provider is properly configured.
+	Active       bool
+	ActiveReason string
+	// Online indicates that the configuration could be used successfully to perform requests.
+	Online       bool
+	OnlineReason string
+}
+
 // Provider describes a single Endpoint Provider
 type Provider interface {
 	Name() string
@@ -16,6 +25,10 @@ type Provider interface {
 	APIVersion() string
 	GetHandlers() []Handler
 	Validate() error
+
+	// Status performs checks to determine if the provider is active (ie: properly configured)
+	// and "online" (able to perform requests).
+	Status() ProviderStatus
 }
 
 type ProxyProvider interface {

--- a/pkg/mimir/provider.go
+++ b/pkg/mimir/provider.go
@@ -34,6 +34,26 @@ func (p *Provider) Validate() error {
 	return nil
 }
 
+func (p *Provider) Status() grizzly.ProviderStatus {
+	status := grizzly.ProviderStatus{}
+
+	if err := p.Validate(); err != nil {
+		status.ActiveReason = err.Error()
+		return status
+	}
+
+	status.Active = true
+
+	if _, err := p.clientTool.ListRules(); err != nil {
+		status.OnlineReason = err.Error()
+		return status
+	}
+
+	status.Online = true
+
+	return status
+}
+
 func (p *Provider) Name() string {
 	return "Mimir"
 }

--- a/pkg/syntheticmonitoring/provider.go
+++ b/pkg/syntheticmonitoring/provider.go
@@ -45,6 +45,34 @@ func (p *Provider) Validate() error {
 	return nil
 }
 
+func (p *Provider) Status() grizzly.ProviderStatus {
+	status := grizzly.ProviderStatus{}
+
+	if err := p.Validate(); err != nil {
+		status.ActiveReason = err.Error()
+		return status
+	}
+
+	status.Active = true
+
+	client, err := p.Client()
+	if err != nil {
+		status.OnlineReason = err.Error()
+		return status
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err = client.ListChecks(ctx); err != nil {
+		status.OnlineReason = err.Error()
+		return status
+	}
+
+	status.Online = true
+
+	return status
+}
+
 func (p *Provider) Name() string {
 	return "Synthetic Monitoring"
 }


### PR DESCRIPTION
While helping a first time grizzly user, we ran into some difficulties trying to identify some configuration issues.

The two changes in this PR would have helped us:

* the first commit introduces a new `grr config check` command, exposing a quick view of what provider is active or not and whether they're online or not (see screenshot below)
* the second one fixes a bug where `grr config get` fails to take environment variables into configuration when printing the current config.

![Screenshot from 2024-10-10 17-28-17](https://github.com/user-attachments/assets/b48dcce0-f70f-4cb0-ac69-615daf5a7a57)
