### PR TITLE
Add MIMIR_AUTH_TOKEN for self-hosted Mimir

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -147,11 +147,12 @@ docs](https://grafana.com/docs/grafana/latest/http_api/auth/) for more info.
 ## Grafana Cloud Prometheus
 To interact with Grafana Cloud Prometheus, you must have these environment variables set:
 
-| Name              | Description                                         | Required |
-|-------------------|-----------------------------------------------------|----------|
-| `MIMIR_ADDRESS`   | URL for Grafana Cloud Prometheus instance           | true     |
-| `MIMIR_TENANT_ID` | Tenant ID for your Grafana Cloud Prometheus account | true     |
-| `MIMIR_API_KEY`   | Authentication token/api key                        | false    |
+| Name               | Description                                         | Required |
+|--------------------|-----------------------------------------------------|----------|
+| `MIMIR_ADDRESS`    | URL for Grafana Cloud Prometheus instance           | true     |
+| `MIMIR_TENANT_ID`  | Tenant ID for your Grafana Cloud Prometheus account | true     |
+| `MIMIR_API_KEY`    | Authentication token/api key                        | false    |
+| `MIMIR_AUTH_TOKEN` | Authorization Bearer Token                          | false    |
 
 Note, this will also work with other Mimir installations, alongside Grafana Cloud Prometheus.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,9 +40,10 @@ func override(v *viper.Viper) {
 		"synthetic-monitoring.metrics-id":   "GRAFANA_SM_METRICS_ID",
 		"synthetic-monitoring.url":          "GRAFANA_SM_URL",
 
-		"mimir.address":   "MIMIR_ADDRESS",
-		"mimir.tenant-id": "MIMIR_TENANT_ID",
-		"mimir.api-key":   "MIMIR_API_KEY",
+		"mimir.address":    "MIMIR_ADDRESS",
+		"mimir.tenant-id":  "MIMIR_TENANT_ID",
+		"mimir.api-key":    "MIMIR_API_KEY",
+		"mimir.auth-token": "MIMIR_AUTH_TOKEN",
 	}
 
 	// To keep retro compatibility
@@ -170,6 +171,7 @@ var acceptableKeys = map[string]string{
 	"mimir.address":                     "string",
 	"mimir.tenant-id":                   "string",
 	"mimir.api-key":                     "string",
+	"mimir.auth-token":                  "string",
 	"synthetic-monitoring.access-token": "string",
 	"synthetic-monitoring.token":        "string",
 	"synthetic-monitoring.stack-id":     "int",

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -9,10 +9,11 @@ type GrafanaConfig struct {
 }
 
 type MimirConfig struct {
-	Address  string         `yaml:"address" mapstructure:"address"`
-	TenantID string         `yaml:"tenant-id" mapstructure:"tenant-id"`
-	APIKey   string         `yaml:"api-key" mapstructure:"api-key"`
-	TLS      MimirTLSConfig `yaml:"tls" mapstructure:"tls"`
+	Address   string         `yaml:"address" mapstructure:"address"`
+	TenantID  string         `yaml:"tenant-id" mapstructure:"tenant-id"`
+	APIKey    string         `yaml:"api-key" mapstructure:"api-key"`
+	TLS       MimirTLSConfig `yaml:"tls" mapstructure:"tls"`
+	AuthToken string         `yaml:"auth-token" mapstructure:"auth-token""`
 }
 
 type MimirTLSConfig struct {

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -13,7 +13,7 @@ type MimirConfig struct {
 	TenantID  string         `yaml:"tenant-id" mapstructure:"tenant-id"`
 	APIKey    string         `yaml:"api-key" mapstructure:"api-key"`
 	TLS       MimirTLSConfig `yaml:"tls" mapstructure:"tls"`
-	AuthToken string         `yaml:"auth-token" mapstructure:"auth-token""`
+	AuthToken string         `yaml:"auth-token" mapstructure:"auth-token"`
 }
 
 type MimirTLSConfig struct {

--- a/pkg/mimir/client/http_client.go
+++ b/pkg/mimir/client/http_client.go
@@ -92,6 +92,8 @@ func (c *Client) doRequest(method string, url string, body []byte) ([]byte, erro
 	req.Header.Set("Content-Type", "application/yaml")
 	if c.config.APIKey != "" {
 		req.SetBasicAuth(c.config.TenantID, c.config.APIKey)
+	} else if c.config.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.config.AuthToken)
 	} else {
 		req.Header.Set("X-Scope-OrgID", c.config.TenantID)
 	}

--- a/pkg/mimir/client/http_client.go
+++ b/pkg/mimir/client/http_client.go
@@ -90,11 +90,12 @@ func (c *Client) doRequest(method string, url string, body []byte) ([]byte, erro
 	}
 
 	req.Header.Set("Content-Type", "application/yaml")
-	if c.config.APIKey != "" {
+	switch {
+	case c.config.APIKey != "":
 		req.SetBasicAuth(c.config.TenantID, c.config.APIKey)
-	} else if c.config.AuthToken != "" {
+	case c.config.AuthToken != "":
 		req.Header.Set("Authorization", "Bearer "+c.config.AuthToken)
-	} else {
+	default:
 		req.Header.Set("X-Scope-OrgID", c.config.TenantID)
 	}
 


### PR DESCRIPTION
For self-hosted Mimir installations, an authenticating reverse proxy is typically required (https://grafana.com/docs/mimir/latest/manage/secure/authentication-and-authorization/#with-an-authenticating-reverse-proxy).

Implementations can choose any method to perform that authentication, but it's typically basic auth (which is already supported here), or a Bearer token in the Authorization header. This adds support for the latter.