### PR TITLE
Jsonnet uid mismatch

### DIFF
--- a/pkg/grizzly/grizzly.jsonnet
+++ b/pkg/grizzly/grizzly.jsonnet
@@ -38,7 +38,7 @@ local convert(main, apiVersion) = {
           'Dashboard',
           uid(k, dashboards[k]),
           spec=dashboards[k] + {
-            uid::'',
+            uid: uid(k, dashboards[k]),
           },
           metadata={ folder: folder }
         )

--- a/pkg/grizzly/grizzly.jsonnet
+++ b/pkg/grizzly/grizzly.jsonnet
@@ -52,9 +52,9 @@ local convert(main, apiVersion) = {
       local fromMap(datasources) = [
         makeResource(
           'Datasource',
-          k,
+          if std.objectHasAll(datasources[k], "uid") then datasources[k].uid else k,
           spec=datasources[k] + {
-            name:: ''
+            uid:: if std.objectHasAll(datasources[k], "uid") then datasources[k].uid else k
           },
         )
         for k in std.objectFields(datasources)

--- a/pkg/grizzly/jsonnet.go
+++ b/pkg/grizzly/jsonnet.go
@@ -23,7 +23,7 @@ func NewJsonnetParser(registry Registry, jsonnetPaths []string) *JsonnetParser {
 	return &JsonnetParser{
 		registry:     registry,
 		jsonnetPaths: jsonnetPaths,
-		logger:       log.WithField("parser", "json"),
+		logger:       log.WithField("parser", "jsonnet"),
 	}
 }
 


### PR DESCRIPTION
Fixes #460

For dashboards and datasources defined with jsonnet, use the UID defined by the resource itself if it exists, otherwise fall back to the name defined in the surrounding "envelope"

Example:

```jsonnet
local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';

{
  grafanaDashboards:: {
    this_key_will_be_ignored: (
      g.dashboard.new('Dashboard from grafonnet with uid')
      + g.dashboard.withUid('test-jsonnet-uid')
    ),
    test_dashboard_jsonnet: (
      g.dashboard.new('Dashboard from grafonnet with no uid')
    ),
  },
}

```