### PR TITLE
feat: usage stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ integration: run-test-image-locally dev
 
 # Compilation
 dev:
-	go build -ldflags "-X main.Version=dev-${VERSION}" ./cmd/grr
+	go build -ldflags "-X github.com/grafana/grizzly/pkg/config.Version=dev-${VERSION}" ./cmd/grr
 
-LDFLAGS := '-s -w -extldflags "-static" -X main.Version=${VERSION}'
+LDFLAGS := '-s -w -extldflags "-static" -X github.com/grafana/grizzly/pkg/config.Version=${VERSION}'
 static:
 	CGO_ENABLED=0 GOOS=linux go build -ldflags=${LDFLAGS} ./cmd/grr
 

--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -198,24 +198,6 @@ func createContextCmd() *cli.Command {
 	return initialiseLogging(cmd, &opts)
 }
 
-func hashCmd() *cli.Command {
-	cmd := &cli.Command{
-		Use:   "hash",
-		Short: "Generate a hash over all configuration values",
-	}
-	var opts LoggingOpts
-
-	cmd.Run = func(cmd *cli.Command, args []string) error {
-		hash, err := config.Hash()
-		if err != nil {
-			return err
-		}
-		fmt.Printf("Config Hash: %s\n", hash)
-		return nil
-	}
-	return initialiseLogging(cmd, &opts)
-}
-
 func checkCmd(registry grizzly.Registry) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "check",

--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -23,6 +23,7 @@ type Opts struct {
 	JsonnetPaths []string
 	Targets      []string
 	OutputFormat string
+	DisableStats bool
 	IsDir        bool // used internally to denote that the resource path argument pointed at a directory
 
 	// Used for supporting resources without envelopes
@@ -193,6 +194,24 @@ func createContextCmd() *cli.Command {
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		return config.CreateContext(args[0])
+	}
+	return initialiseLogging(cmd, &opts)
+}
+
+func hashCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "hash",
+		Short: "Generate a hash over all configuration values",
+	}
+	var opts LoggingOpts
+
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		hash, err := config.Hash()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Config Hash: %s\n", hash)
+		return nil
 	}
 	return initialiseLogging(cmd, &opts)
 }

--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -13,10 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Version is the current version of the grr command.
-// To be overwritten at build time
-var Version = "dev"
-
 type silentError struct {
 	Err error
 }
@@ -34,7 +30,7 @@ func main() {
 	rootCmd := &cli.Command{
 		Use:     "grr",
 		Short:   "Grizzly",
-		Version: Version,
+		Version: config.Version,
 	}
 
 	log.SetFormatter(&log.TextFormatter{

--- a/cmd/grr/selfupdate.go
+++ b/cmd/grr/selfupdate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-clix/cli"
 	"github.com/grafana/grizzly/internal/grizzly"
+	"github.com/grafana/grizzly/pkg/config"
 )
 
 func selfUpdateCmd() *cli.Command {
@@ -21,12 +22,12 @@ func selfUpdateCmd() *cli.Command {
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		updater := grizzly.NewSelfUpdater(http.DefaultClient)
 
-		newVersion, err := updater.UpdateSelf(context.Background(), Version)
+		newVersion, err := updater.UpdateSelf(context.Background(), config.Version)
 		if errors.Is(err, grizzly.ErrNextVersionIsMajorBump) {
-			return fmt.Errorf("self-update aborted as the next version (%[1]s) is a major bump from the current one (%[2]s). Please update manually: https://github.com/grafana/grizzly/releases/tag/%[1]s", newVersion, Version)
+			return fmt.Errorf("self-update aborted as the next version (%[1]s) is a major bump from the current one (%[2]s). Please update manually: https://github.com/grafana/grizzly/releases/tag/%[1]s", newVersion, config.Version)
 		}
 		if errors.Is(err, grizzly.ErrCurrentVersionIsLatest) {
-			fmt.Printf("Current version is the latest: %s\n", Version)
+			fmt.Printf("Current version is the latest: %s\n", config.Version)
 			return nil
 		}
 		if err != nil {

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -562,7 +562,7 @@ func getDefaultJsonnetFolders() []string {
 
 func getEventsRecorder(opts Opts) grizzly.EventsRecorder {
 	wr := grizzly.NewWriterRecorder(os.Stdout, getEventFormatter())
-	if opts.DisableStats {
+	if opts.DisableStats || config.UsageStatsDisabled() {
 		return wr
 	}
 	return grizzly.NewUsageRecorder(wr)

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -507,7 +507,6 @@ func configCmd(registry grizzly.Registry) *cli.Command {
 	cmd.AddCommand(unsetCmd())
 	cmd.AddCommand(createContextCmd())
 	cmd.AddCommand(checkCmd(registry))
-	cmd.AddCommand(hashCmd())
 	return cmd
 }
 

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -49,9 +49,12 @@ menu:
     - name: Hidden Elements
       url: /hidden-elements/
       weight: 11
+    - name: Usage statistics
+      url: /usage-statistics/
+      weight: 12
     - name: GitHub
       url: https://github.com/grafana/grizzly/
-      weight: 12
+      weight: 13
 
 markup:
   defaultMarkdownHandler: goldmark

--- a/docs/content/usage-statistics.md
+++ b/docs/content/usage-statistics.md
@@ -1,0 +1,25 @@
+---
+date: "2024-10-24T00:00:00+00:00"
+title: "Usage statistics"
+---
+
+By default, Grizzly sends anonymous, but uniquely identifiable usage information to Grafana Labs. These statistics are sent to stats.grafana.org.
+
+Statistics help Grafana better understand how Grizzly is used. This helps us prioritize features and documentation.
+
+The usage information includes the following details:
+
+* A hash of your config file
+* Timestamp of when the report was created
+* The version of Grizzly.
+* The operating system Grizzly is running on.
+* The system architecture Grizzly is running on.
+* The operation performed (`pull`/`apply`)
+* The number of resources affected
+
+This list may change over time.
+For auditing, the code performing this reporting can be found at the end of the [events.go](https://github.com/grafana/grizzly/blob/main/pkg/grizzly/events.go) file.
+
+## Opt-out of data collection
+
+You can use the `--disable-reporting` command line flag to disable the reporting and opt-out of the data collection.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	CurrentContextSetting = "current-context"
+	CurrentContextSetting   = "current-context"
+	DisableReportingSetting = "disable-reporting"
 )
 
 // Version is the current version of the grr command.
@@ -145,6 +146,10 @@ func UseContext(context string) error {
 		}
 	}
 	return fmt.Errorf("context %s not found", context)
+}
+
+func UsageStatsDisabled() bool {
+	return viper.GetBool(DisableReportingSetting)
 }
 
 func CurrentContext() (*Context, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,10 @@ const (
 	CurrentContextSetting = "current-context"
 )
 
+// Version is the current version of the grr command.
+// To be overwritten at build time
+var Version = "dev"
+
 func Initialise() {
 	viper.SetConfigName("settings")
 	viper.SetConfigType("yaml")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -185,6 +186,16 @@ var acceptableKeys = map[string]string{
 	"targets":                           "[]string",
 	"output-format":                     "string",
 	"only-spec":                         "bool",
+}
+
+func Hash() (string, error) {
+	cfg := viper.AllSettings()
+	out := sha256.New()
+	err := json.NewEncoder(out).Encode(cfg)
+	if err != nil {
+		return "", fmt.Errorf("writing to hash")
+	}
+	return fmt.Sprintf("%X", out.Sum(nil)), nil
 }
 
 func Get(path, outputFormat string) (string, error) {

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -177,7 +177,7 @@ func listWide(listedResources []listedResource) ([]byte, error) {
 // Pull pulls remote resources and stores them in the local file system.
 // The given resourcePath must be a directory, where all resources will be stored.
 // If opts.JSONSpec is true, which is only applicable for dashboards, saves the spec as a JSON file.
-func Pull(registry Registry, resourcePath string, onlySpec bool, outputFormat string, targets []string, continueOnError bool, eventsRecorder eventsRecorder) error {
+func Pull(registry Registry, resourcePath string, onlySpec bool, outputFormat string, targets []string, continueOnError bool, eventsRecorder EventsRecorder) error {
 	resourcePathIsFile, err := isFile(resourcePath)
 	if err != nil {
 		return err
@@ -377,12 +377,13 @@ func Diff(registry Registry, resources Resources, onlySpec bool, outputFormat st
 	return nil
 }
 
-type eventsRecorder interface {
+type EventsRecorder interface {
 	Record(event Event)
+	Summary() Summary
 }
 
 // Apply pushes resources to endpoints
-func Apply(registry Registry, resources Resources, continueOnError bool, eventsRecorder eventsRecorder) error {
+func Apply(registry Registry, resources Resources, continueOnError bool, eventsRecorder EventsRecorder) error {
 	var finalErr error
 
 	for _, resource := range resources.AsList() {
@@ -405,7 +406,7 @@ func Apply(registry Registry, resources Resources, continueOnError bool, eventsR
 	return finalErr
 }
 
-func applyResource(registry Registry, resource Resource, trailRecorder eventsRecorder) error {
+func applyResource(registry Registry, resource Resource, trailRecorder EventsRecorder) error {
 	resourceRef := resource.Ref().String()
 
 	handler, err := registry.GetHandler(resource.Kind())
@@ -489,7 +490,7 @@ func Snapshot(registry Registry, resources Resources, expiresSeconds int) error 
 
 // Watch watches a directory for changes then pushes Jsonnet resource to endpoints
 // when changes are noticed.
-func Watch(registry Registry, watchDir string, resourcePath string, parser Parser, parserOpts ParserOptions, trailRecorder eventsRecorder) error {
+func Watch(registry Registry, watchDir string, resourcePath string, parser Parser, parserOpts ParserOptions, trailRecorder EventsRecorder) error {
 	updateWatchedResource := func(path string) error {
 		log.Infof("Changes detected in %q. Applying %q", path, resourcePath)
 		resources, err := parser.Parse(resourcePath, parserOpts)


### PR DESCRIPTION
This PR adds anonymous usage tracking to Grizzly.

It collects:

* A hash of your config file
* Timestamp of when the report was created
* The version of Grizzly.
* The operating system Grizzly is running on.
* The system architecture Grizzly is running on.
* The operation performed (`pull`/`apply`)
* The number of resources affected

so that we can better prioritize features and use cases.
