### PR TITLE
Preserve resource format when saving a resource via `grr serve`

### DIFF
--- a/pkg/grizzly/parsing.go
+++ b/pkg/grizzly/parsing.go
@@ -213,6 +213,8 @@ func parseAny(registry Registry, data any, resourceKind, folderUID string, sourc
 		if err != nil {
 			return Resources{}, err
 		}
+
+		source.WithEnvelope = true
 		resource.SetSource(source)
 
 		return NewResources(*resource), nil

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -28,12 +28,18 @@ func (ref ResourceRef) String() string {
 	return fmt.Sprintf("%s.%s", ref.Kind, ref.Name)
 }
 
-// Source represents the on disk (etc) location of a resource
+// Source holds metadata regarding the origin of a resource on disk.
 type Source struct {
-	Format     string
-	Location   string
-	Path       string
+	// Format represents the original format. Ex: json, yaml, ...
+	Format   string
+	Location string
+	// Path represents the path on disk to the file describing the resource.
+	Path string
+	// Rewritable indicates whether the resource can be written or not.
+	// Ex: resources parsed from a watch script are not rewritable.
 	Rewritable bool
+	// WithEnvelope indicates whether the resource had an envelope or not.
+	WithEnvelope bool
 }
 
 // Resource represents a single Resource destined for a single endpoint

--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -416,7 +416,7 @@ func (s *Server) faviconHandlerFunc() http.HandlerFunc {
 }
 
 func (s *Server) UpdateResource(name string, resource Resource) error {
-	out, _, _, err := Format(s.Registry, s.ResourcePath, &resource, s.OutputFormat, s.OnlySpec)
+	out, _, _, err := Format(s.Registry, s.ResourcePath, &resource, resource.Source.Format, !resource.Source.WithEnvelope)
 	if err != nil {
 		return fmt.Errorf("error formatting content: %s", err)
 	}


### PR DESCRIPTION
While editing a dashboard via `grr serve` – plain JSON, with no envelope – I was surprised to see that Grizzly wrote my update to disk in YAML, with an envelope.

This PR changes that behavior. Dashboards saved via `grr serve` are now written in their original format.