### PR TITLE
Fix `grr get` of an AlertRuleGroup with UID containing dots

### DIFF
--- a/integration/alertrules_test.go
+++ b/integration/alertrules_test.go
@@ -1,0 +1,37 @@
+package integration_test
+
+import (
+	"testing"
+)
+
+func TestAlertRuleGroups(t *testing.T) {
+	dir := "testdata/alert-rules"
+	setupContexts(t, dir)
+
+	t.Run("Apply rule group", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir:       dir,
+			RunOnContexts: allContexts,
+			Commands: []Command{
+				{
+					Command:      "apply sample-rule-group.json",
+					ExpectedCode: 0,
+				},
+			},
+		})
+	})
+
+	t.Run("Get previously applied rule group", func(t *testing.T) {
+		runTest(t, GrizzlyTest{
+			TestDir:       dir,
+			RunOnContexts: allContexts,
+			Commands: []Command{
+				{
+					// get [handler].[folder_uid].[rule_group_uid]
+					Command:      "get AlertRuleGroup.adxrm7wi8un0gf.test_eval_group",
+					ExpectedCode: 0,
+				},
+			},
+		})
+	})
+}

--- a/integration/testdata/alert-rules/sample-rule-group.json
+++ b/integration/testdata/alert-rules/sample-rule-group.json
@@ -1,0 +1,128 @@
+{
+  "apiVersion": "grizzly.grafana.com/v1alpha1",
+  "kind": "AlertRuleGroup",
+  "metadata": {
+    "name": "adxrm7wi8un0gf.test_eval_group"
+  },
+  "spec": {
+    "folderUid": "adxrm7wi8un0gf",
+    "interval": 60,
+    "rules": [
+      {
+        "condition": "C",
+        "data": [
+          {
+            "datasourceUid": "grafanacloud-prom",
+            "model": {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "count(blocky_build_info)",
+              "hide": false,
+              "instant": true,
+              "intervalMs": 1000,
+              "legendFormat": "__auto",
+              "maxDataPoints": 43200,
+              "range": false,
+              "refId": "A"
+            },
+            "refId": "A",
+            "relativeTimeRange": {
+              "from": 600
+            }
+          },
+          {
+            "datasourceUid": "__expr__",
+            "model": {
+              "conditions": [
+                {
+                  "evaluator": {
+                    "params": [],
+                    "type": "gt"
+                  },
+                  "operator": {
+                    "type": "and"
+                  },
+                  "query": {
+                    "params": [
+                      "B"
+                    ]
+                  },
+                  "reducer": {
+                    "params": [],
+                    "type": "last"
+                  },
+                  "type": "query"
+                }
+              ],
+              "datasource": {
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "A",
+              "intervalMs": 1000,
+              "maxDataPoints": 43200,
+              "reducer": "last",
+              "refId": "B",
+              "type": "reduce"
+            },
+            "refId": "B",
+            "relativeTimeRange": {}
+          },
+          {
+            "datasourceUid": "__expr__",
+            "model": {
+              "conditions": [
+                {
+                  "evaluator": {
+                    "params": [
+                      1
+                    ],
+                    "type": "lt"
+                  },
+                  "operator": {
+                    "type": "and"
+                  },
+                  "query": {
+                    "params": [
+                      "C"
+                    ]
+                  },
+                  "reducer": {
+                    "params": [],
+                    "type": "last"
+                  },
+                  "type": "query"
+                }
+              ],
+              "datasource": {
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "B",
+              "intervalMs": 1000,
+              "maxDataPoints": 43200,
+              "refId": "C",
+              "type": "threshold"
+            },
+            "refId": "C",
+            "relativeTimeRange": {}
+          }
+        ],
+        "execErrState": "Error",
+        "folderUID": "adxrm7wi8un0gf",
+        "for": "1m0s",
+        "id": 18,
+        "noDataState": "NoData",
+        "orgID": 1,
+        "ruleGroup": "test_eval_group",
+        "title": "test alert rule",
+        "uid": "ae2ylum6et0xsc",
+        "updated": "2024-11-04T20:12:46.000Z"
+      }
+    ],
+    "title": "test_eval_group"
+  }
+}

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -150,6 +150,7 @@ func (h *AlertRuleGroupHandler) createAlertRule(rule *models.ProvisionedAlertRul
 	_, err = client.Provisioning.PostAlertRule(params, nil)
 	return err
 }
+
 func (h *AlertRuleGroupHandler) createAlertRuleGroup(resource grizzly.Resource) error {
 	// TODO: Turn spec into a real models.AlertRuleGroup object
 	data, err := json.Marshal(resource.Spec())
@@ -282,6 +283,7 @@ func (h *AlertRuleGroupHandler) getUID(group models.AlertRuleGroup) string {
 func (h *AlertRuleGroupHandler) joinUID(folder, title string) string {
 	return fmt.Sprintf("%s.%s", folder, title)
 }
+
 func (h *AlertRuleGroupHandler) splitUID(uid string) (string, string) {
 	spl := strings.SplitN(uid, ".", 2)
 	return spl[0], spl[1]

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -25,20 +25,13 @@ var interactive = terminal.IsTerminal(int(os.Stdout.Fd()))
 func Get(registry Registry, uid string, onlySpec bool, outputFormat string) error {
 	log.Info("Getting ", uid)
 
-	count := strings.Count(uid, ".")
-	var handlerName, resourceID string
-	switch count {
-	case 1:
-		parts := strings.SplitN(uid, ".", 2)
-		handlerName = parts[0]
-		resourceID = parts[1]
-	case 2:
-		parts := strings.SplitN(uid, ".", 3)
-		handlerName = parts[0] + "." + parts[1]
-		resourceID = parts[2]
-	default:
+	if strings.Count(uid, ".") == 0 {
 		return fmt.Errorf("UID must be <provider>.<uid>: %s", uid)
 	}
+
+	parts := strings.SplitN(uid, ".", 2)
+	handlerName := parts[0]
+	resourceID := parts[1]
 
 	handler, err := registry.GetHandler(handlerName)
 	if err != nil {

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -73,10 +73,19 @@ func List(registry Registry, resources Resources, format string) error {
 		if err != nil {
 			return err
 		}
+
+		uid := resource.Name()
+		// Some resources need a custom logic to build their UID (ex: SyntheticMonitoringCheck)
+		// TODO: we shouldn't need a special case to get a resource's UID.
+		handlerUID, err := handler.GetUID(resource)
+		if err == nil {
+			uid = handlerUID
+		}
+
 		listedResources = append(listedResources, listedResource{
 			Handler:  handler.APIVersion(),
 			Kind:     handler.Kind(),
-			Name:     resource.Name(),
+			Name:     uid,
 			Path:     resource.Source.Path,
 			Location: resource.Source.Location,
 			Format:   resource.Source.Format,

--- a/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
+++ b/pkg/syntheticmonitoring/synthetic-monitoring-handler.go
@@ -91,6 +91,7 @@ func (h *SyntheticMonitoringHandler) GetUID(resource grizzly.Resource) (string, 
 	}
 	return fmt.Sprintf("%s.%s", resource.GetMetadata("type"), resource.Name()), nil
 }
+
 func (h *SyntheticMonitoringHandler) GetSpecUID(resource grizzly.Resource) (string, error) {
 	return "", fmt.Errorf("GetSpecUID not implemented for Synthetic Monitoring")
 }

--- a/test-docker-compose/docker-compose.yml
+++ b/test-docker-compose/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   grafana:
     image: &image grafana/grafana:10.2.0


### PR DESCRIPTION
Fixes #516 

Fixes the logic used by `grr get` to split the Handler name from the rest of the UID.