### PR TITLE
Support Datasources in `grr serve`

### DIFF
--- a/pkg/grafana/errors.go
+++ b/pkg/grafana/errors.go
@@ -34,5 +34,6 @@ func writeJSONOrLog(w http.ResponseWriter, content any) {
 		log.Errorf("error marshalling response to JSON: %v", err)
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	writeOrLog(w, responseJSON)
 }

--- a/pkg/grizzly/embed/templates/proxy/index.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/index.html.tmpl
@@ -10,7 +10,7 @@
 
 <main>
     <div>
-    {{ if ne (len .ParseErrors) 0 }}
+        {{ if ne (len .ParseErrors) 0 }}
         <h1>Errors</h1>
 
         {{ range .ParseErrors }}
@@ -20,18 +20,31 @@
             </li>
           {{ end }}
         {{ end }}
-    {{ end }}
-    <h1>Available dashboards</h1>
-
-    <ul>
-        {{ range .Resources }}
-            {{ if eq .Kind "Dashboard" }}
-                <li>
-                    <a href="/grizzly/{{.Kind}}/{{.Name}}">{{ .Spec.title }}</a>
-                </li>
-            {{ end }}
         {{ end }}
-    </ul>
+
+        <h1>Dashboards</h1>
+
+        <ul>
+            {{ range (.Resources.OfKind "Dashboard").AsList }}
+                <li>
+                    <a href="/grizzly/{{ .Kind }}/{{ .Name }}">{{ .Spec.title }}</a>
+                </li>
+            {{ else }}
+                <li>No dashboards.</li>
+            {{ end }}
+        </ul>
+
+        <h1>Datasources</h1>
+
+        <ul>
+            {{ range (.Resources.OfKind "Datasource").AsList }}
+                <li>
+                    <a href="/grizzly/{{ .Kind }}/{{ .Name }}">{{ .Spec.name }}</a>
+                </li>
+            {{ else }}
+                <li>No datasources.</li>
+            {{ end }}
+        </ul>
     </div>
 </main>
 </body>

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -240,6 +240,12 @@ func (r Resources) Filter(predicate func(Resource) bool) Resources {
 	return NewResources(filtered...)
 }
 
+func (r Resources) OfKind(kind string) Resources {
+	return r.Filter(func(resource Resource) bool {
+		return resource.Kind() == kind
+	})
+}
+
 func (r Resources) ForEach(callback func(Resource) error) error {
 	for pair := r.collection.Oldest(); pair != nil; pair = pair.Next() {
 		if err := callback(pair.Value); err != nil {


### PR DESCRIPTION
This PR adds support for datasources in `grr serve`.

Here's how it looks:

<details>
<summary>
Grizzly server home
</summary>

![Screenshot 2024-11-14 at 15-42-48 Grizzly](https://github.com/user-attachments/assets/67232fc3-ddf8-4414-99d3-fc62b022fa5a)

</details>


<details>
<summary>
Datasource page
</summary>

![Screenshot 2024-11-14 at 15-43-05 Grizzly](https://github.com/user-attachments/assets/6543ca33-acb9-4539-9db0-11355db9d45b)

</details>

Note: datasources can NOT be persisted via the grizzly server (yet, this may be implemented later).
