### PR TITLE
Support previewing `AlertRuleGroup` resources in `grr serve`

### DIFF
--- a/pkg/grafana/utils.go
+++ b/pkg/grafana/utils.go
@@ -9,6 +9,7 @@ import (
 
 	gclient "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grizzly/internal/httputils"
 	"github.com/grafana/grizzly/pkg/grizzly"
 )
 
@@ -74,7 +75,12 @@ func authenticateAndProxyHandler(s grizzly.Server, provider grizzly.Provider) ht
 
 		req.Header.Set("User-Agent", s.UserAgent)
 
-		client := &http.Client{}
+		client, err := httputils.NewHTTPClient()
+		if err != nil {
+			grizzly.SendError(w, http.StatusText(http.StatusInternalServerError), err, http.StatusInternalServerError)
+			return
+		}
+
 		resp, err := client.Do(req)
 
 		if err == nil {

--- a/pkg/grizzly/embed/templates/proxy/index.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/index.html.tmpl
@@ -45,6 +45,21 @@
                 <li>No datasources.</li>
             {{ end }}
         </ul>
+
+        <h1>Alert rule groups</h1>
+
+        <ul>
+            {{ range (.Resources.OfKind "AlertRuleGroup").AsList }}
+                <li>
+                    {{ .Spec.title }}
+                    <ul>
+                    {{ range .Spec.rules }}
+                        <li><a href="/grizzly/AlertRuleGroup/{{ .uid }}">{{ .title }}</a></li>
+                    {{ end }}
+                    </ul>
+                </li>
+            {{ end }}
+        </ul>
     </div>
 </main>
 </body>


### PR DESCRIPTION
This PR adds support for previewing `AlertRuleGroup` resources in `grr serve`.

Here's how it looks:

<details>
<summary>
Grizzly server home
</summary>

![Screenshot 2024-11-15 at 14-18-26 Grizzly](https://github.com/user-attachments/assets/a9978a19-26a0-45c5-a43a-2e23d6776edc)

</details>


<details>
<summary>
AlertRuleGroup page
</summary>

![Screenshot 2024-11-15 at 14-18-39 Grizzly](https://github.com/user-attachments/assets/89678ff1-0a76-4724-9ec3-e802f4306d10)

</details>

Note: `AlertRuleGroup` resources can NOT be persisted via the grizzly server (yet, this may be implemented later).
