### PR TITLE
docs: rename 'preview' to 'snapshot'

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -316,7 +316,7 @@ func snapshotCmd(registry grizzly.Registry) *cli.Command {
 		Args:  cli.ArgsExact(1),
 	}
 	var opts Opts
-	expires := cmd.Flags().IntP("expires", "e", 0, "when the preview should expire. Default 0 (never)")
+	expires := cmd.Flags().IntP("expires", "e", 0, "when the snapshot should expire. Default 0 (never)")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		resourceKind, folderUID, err := getOnlySpec(opts)

--- a/docs/content/workflows.md
+++ b/docs/content/workflows.md
@@ -134,7 +134,7 @@ At present, only Grafana dashboards are supported, and will print out links for 
 snapshot that was uploaded.
 
 ```sh
-$ grr preview my-lib.libsonnet
+$ grr snapshot my-lib.libsonnet
 ```
 
 Grafana snapshots by default do not expire. Expiration can be set via the

--- a/pkg/grizzly/workflow.go
+++ b/pkg/grizzly/workflow.go
@@ -479,7 +479,7 @@ func Snapshot(registry Registry, resources Resources, expiresSeconds int) error 
 		}
 		snapshotHandler, ok := handler.(SnapshotHandler)
 		if !ok {
-			notifier.NotSupported(resource, "preview")
+			notifier.NotSupported(resource, "snapshot")
 			continue
 		}
 		err = snapshotHandler.Snapshot(resource, expiresSeconds)


### PR DESCRIPTION
This was originally changed in https://github.com/grafana/grizzly/pull/391, but it seems like a few cases were missing from renaming