### PR TITLE
Show alerting rules edit page in serve

### DIFF
--- a/pkg/grafana/dashboard-proxy.go
+++ b/pkg/grafana/dashboard-proxy.go
@@ -23,6 +23,10 @@ func (c *dashboardProxyConfigurator) ProxyURL(uid string) string {
 	return fmt.Sprintf("/d/%s/slug", uid)
 }
 
+func (c *dashboardProxyConfigurator) ProxyEditURL(uid string) string {
+	return c.ProxyURL(uid)
+}
+
 func (c *dashboardProxyConfigurator) Endpoints(s grizzly.Server) []grizzly.HTTPEndpoint {
 	return []grizzly.HTTPEndpoint{
 		{

--- a/pkg/grafana/datasource-proxy.go
+++ b/pkg/grafana/datasource-proxy.go
@@ -20,6 +20,10 @@ func (c *datasourceProxyConfigurator) ProxyURL(uid string) string {
 	return fmt.Sprintf("/connections/datasources/edit/%s", uid)
 }
 
+func (c *datasourceProxyConfigurator) ProxyEditURL(uid string) string {
+	return c.ProxyURL(uid)
+}
+
 func (c *datasourceProxyConfigurator) Endpoints(s grizzly.Server) []grizzly.HTTPEndpoint {
 	return []grizzly.HTTPEndpoint{
 		{

--- a/pkg/grafana/folder-proxy.go
+++ b/pkg/grafana/folder-proxy.go
@@ -20,6 +20,10 @@ func (c *folderProxyConfigurator) ProxyURL(uid string) string {
 	return fmt.Sprintf("/dashboards/f/%s/", uid)
 }
 
+func (c *folderProxyConfigurator) ProxyEditURL(uid string) string {
+	return c.ProxyURL(uid)
+}
+
 func (c *folderProxyConfigurator) Endpoints(s grizzly.Server) []grizzly.HTTPEndpoint {
 	return []grizzly.HTTPEndpoint{
 		{

--- a/pkg/grafana/library-element-proxy.go
+++ b/pkg/grafana/library-element-proxy.go
@@ -21,6 +21,10 @@ func (c *libraryElementProxyConfigurator) ProxyURL(uid string) string {
 	return fmt.Sprintf("/api/library-elements/%s", uid)
 }
 
+func (c *libraryElementProxyConfigurator) ProxyEditURL(uid string) string {
+	return c.ProxyURL(uid)
+}
+
 func (c *libraryElementProxyConfigurator) Endpoints(s grizzly.Server) []grizzly.HTTPEndpoint {
 	return []grizzly.HTTPEndpoint{
 		{

--- a/pkg/grizzly/embed/templates/proxy/index.html.tmpl
+++ b/pkg/grizzly/embed/templates/proxy/index.html.tmpl
@@ -55,7 +55,7 @@
                     {{ .Spec.title }}
                     <ul>
                     {{ range .Spec.rules }}
-                        <li><a href="/grizzly/AlertRuleGroup/{{ .uid }}">{{ .title }}</a></li>
+                        <li><a href="/grizzly/AlertRuleGroup/{{ .uid }}">{{ .title }}</a> (<a href="/grizzly/AlertRuleGroup/{{ .uid }}/edit">Edit</a>)</li>
                     {{ end }}
                     </ul>
                 </li>

--- a/pkg/grizzly/handler.go
+++ b/pkg/grizzly/handler.go
@@ -158,5 +158,8 @@ type ProxyConfigurator interface {
 	// ProxyURL returns a URL path for a resource on the proxy
 	ProxyURL(uid string) string
 
+	// ProxyEditURL returns a URL path for a resource on the proxy
+	ProxyEditURL(uid string) string
+
 	StaticEndpoints() StaticProxyConfig
 }


### PR DESCRIPTION
Currently, only dashboards can be edited via the serve command.

In our case, we want to run grizzly serve on alerts, and manage them via our repo. This way, the changes will be saved locally in the repo, and can be reviewed.

Most of the infrastructure coded [here](https://github.com/grafana/grizzly/pull/526)