### PR TITLE
Ensure all directories in the config path exist

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -343,7 +343,7 @@ func Write() error {
 	// creating the file.
 	configDir := configdir.LocalConfig("grizzly")
 	if _, err := os.Stat(configDir); os.IsNotExist(err) {
-		if err := os.Mkdir(configDir, 0700); err != nil {
+		if err := os.MkdirAll(configDir, 0700); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Turns out my initial assumption was wrong and `~/.config` (or whatever is referred by `$XDG_CONFIG_HOME`) can not be assumed to exist.

See https://github.com/grafana/grizzly/pull/398#discussion_r1896875513