### PR TITLE
Decrypt secrets in alerting contact points if possible

### DIFF
--- a/internal/utils/ptr.go
+++ b/internal/utils/ptr.go
@@ -1,0 +1,5 @@
+package utils
+
+func ToPtr[T any](input T) *T {
+	return &input
+}


### PR DESCRIPTION
Closes #546

When possible, alerting contact points should be fetched using the [`RouteGetContactpointsExport`](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#span-idroute-get-contactpoints-exportspan-export-all-contact-points-in-provisioning-file-format-_routegetcontactpointsexport_) endpoint since it allows decrypting secrets, allowing grizzly to faithfully store the state of existing contact points.