### PR TITLE
Add `--continue-on-error` support for the grr export command

### DIFF
--- a/internal/utils/fs.go
+++ b/internal/utils/fs.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"os"
+)
+
+func EnsureDirectoryExists(directory string, perm os.FileMode) error {
+	_, err := os.Stat(directory)
+	if err == nil {
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	return os.MkdirAll(directory, perm)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grafana/grizzly/internal/utils"
 	"github.com/kirsle/configdir"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -342,10 +343,8 @@ func Write() error {
 	// Ensure that our configuration directory exists: viper only takes care of
 	// creating the file.
 	configDir := configdir.LocalConfig("grizzly")
-	if _, err := os.Stat(configDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(configDir, 0700); err != nil {
-			return err
-		}
+	if err := utils.EnsureDirectoryExists(configDir, 0700); err != nil {
+		return err
 	}
 
 	// Viper failed because no configuration file exists in the "config path".

--- a/pkg/grizzly/notifier/notifier.go
+++ b/pkg/grizzly/notifier/notifier.go
@@ -2,7 +2,6 @@ package notifier
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/fatih/color"
 )
@@ -50,15 +49,6 @@ func Info(obj fmt.Stringer, msg string) {
 		fmt.Println(green(msg))
 	} else {
 		fmt.Printf("%s %s\n", obj.String(), green(msg))
-	}
-}
-
-// Info announces a message in green (to stderr)
-func InfoStderr(obj fmt.Stringer, msg string) {
-	if obj == nil {
-		os.Stderr.WriteString(green(msg) + "\n")
-	} else {
-		os.Stderr.WriteString(fmt.Sprintf("%s %s\n", obj.String(), green(msg)))
 	}
 }
 


### PR DESCRIPTION
Closes #562

This makes the `grr export` function consistent with `grr apply` and `grr pull` when it comes to error management.