### PR TITLE
Auto watch jpath

### DIFF
--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -407,7 +407,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 		server.SetContext(currentContext.Name)
 		server.SetFormatting(onlySpec, format)
 		if opts.Watch {
-			server.Watch(watchPaths)
+			server.Watch(watchPaths, opts.JsonnetPaths)
 			if opts.WatchScript != "" {
 				server.WatchScript(opts.WatchScript)
 			}


### PR DESCRIPTION
The jpath contains additional library used to manifest the dashboards. During the development workflow one might modify the underlying lib. This commit makes grr automatically watch the jpath. Moreover, a change in the jpath will trigger the reload of all watched files.

Fixes: #555