### PR TITLE
Fix interval cast to int when viewing AlertRuleGroup resources in `grr serve`

### DIFF
--- a/pkg/grafana/alertgroup-proxy.go
+++ b/pkg/grafana/alertgroup-proxy.go
@@ -64,7 +64,12 @@ func (c *alertRuleProxyConfigurator) alertRuleGroupJSONGetHandler(s grizzly.Serv
 			return
 		}
 
-		interval := time.Duration(ruleGroup.GetSpecValue("interval").(int)) * time.Second
+		intervalInt, ok := ruleGroup.GetSpecValueInt("interval")
+		if !ok {
+			httputils.Error(w, fmt.Sprintf("Could not parse alert rule interval as int: %s", fullUID), fmt.Errorf("could not parse alert rule interval as int: %s", fullUID), http.StatusBadRequest)
+			return
+		}
+		interval := time.Duration(intervalInt) * time.Second
 
 		rules := ruleGroup.GetSpecValue("rules").([]any)
 		formattedRules := make([]map[string]any, 0, len(rules))
@@ -115,7 +120,12 @@ func (c *alertRuleProxyConfigurator) alertRuleJSONGetHandler(s grizzly.Server) h
 			return
 		}
 
-		interval := time.Duration(ruleGroup.GetSpecValue("interval").(int)) * time.Second
+		intervalInt, ok := ruleGroup.GetSpecValueInt("interval")
+		if !ok {
+			httputils.Error(w, fmt.Sprintf("Could not parse alert rule interval as int: %s", ruleUID), fmt.Errorf("could not parse alert rule interval as int: %s", ruleUID), http.StatusBadRequest)
+			return
+		}
+		interval := time.Duration(intervalInt) * time.Second
 
 		httputils.WriteJSON(w, toGrafanaAlert(rule, interval))
 	}

--- a/pkg/grizzly/resources.go
+++ b/pkg/grizzly/resources.go
@@ -154,6 +154,19 @@ func (r *Resource) GetSpecValue(key string) interface{} {
 	return r.Spec()[key]
 }
 
+func (r *Resource) GetSpecValueInt(key string) (int, bool) {
+	valInt, ok := r.Spec()[key].(int)
+	if ok {
+		return valInt, true
+	}
+	valFloat64, ok := r.Spec()[key].(float64)
+	if ok {
+		return int(valFloat64), true
+	}
+
+	return 0, false
+}
+
 func (r *Resource) SetSpecValue(key string, value interface{}) {
 	spec := r.Spec()
 	spec[key] = value


### PR DESCRIPTION
Fixes #572

Depending on the original format (yaml, json, ...), a number will be parsed as an int/float/...