### PR TITLE
fix: added SetConfigPermissions(0600)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,9 +29,9 @@ var Version = "dev"
 func Initialise() {
 	viper.SetConfigName("settings")
 	viper.SetConfigType("yaml")
-
 	viper.AddConfigPath(".")
 	viper.AddConfigPath(configdir.LocalConfig("grizzly"))
+	viper.SetConfigPermissions(0600)
 }
 
 func override(v *viper.Viper) {


### PR DESCRIPTION
fix: added SetConfigPermissions(0600) in the initialization for the configs. This is a better default. Probably need code to change permissions to end user preference. 