### PR TITLE
Support configuring the address to listen on in `grr serve`

### DIFF
--- a/cmd/grr/config.go
+++ b/cmd/grr/config.go
@@ -33,11 +33,12 @@ type Opts struct {
 	ResourceKind string
 
 	// Used for supporting the proxy server
-	OpenBrowser bool
-	ProxyPort   int
-	CanSave     bool
-	Watch       bool
-	WatchScript string
+	OpenBrowser     bool
+	ProxyListenAddr string
+	ProxyPort       int
+	CanSave         bool
+	Watch           bool
+	WatchScript     string
 }
 
 func configPathCmd() *cli.Command {

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -399,7 +399,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 			return err
 		}
 
-		server, err := grizzly.NewGrizzlyServer(registry, resourcesPath, opts.ProxyPort)
+		server, err := grizzly.NewGrizzlyServer(registry, resourcesPath, opts.ProxyListenAddr, opts.ProxyPort)
 		if err != nil {
 			return err
 		}
@@ -419,6 +419,7 @@ func serveCmd(registry grizzly.Registry) *cli.Command {
 	}
 	cmd.Flags().BoolVarP(&opts.Watch, "watch", "w", false, "Watch filesystem for changes")
 	cmd.Flags().BoolVarP(&opts.OpenBrowser, "open-browser", "b", false, "Open Grizzly in default browser")
+	cmd.Flags().StringVar(&opts.ProxyListenAddr, "listen", "", "Address on which the server will listen")
 	cmd.Flags().IntVarP(&opts.ProxyPort, "port", "p", 8080, "Port on which the server will listen")
 	cmd.Flags().StringVarP(&opts.WatchScript, "script", "S", "", "Script to execute on filesystem change")
 	cmd = initialiseOnlySpec(cmd, &opts)


### PR DESCRIPTION
By default the server listens on `0.0.0.0`. In some cases, this might not be desirable so this PR introduces a CLI flag to set a different listening address.

Relates to #594