### PR TITLE
- add docs for Grafana Cloud mimir configuration to avoid auth pitfall I ran into

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -79,7 +79,8 @@ grr config set mimir.api-key abcdef12345 # Authentication token (if you are usin
 ```
 
 **Notes**
-* Be sure to set `api-key` when you need to interact with Grafana Cloud.
+* For Grafana Cloud, set `mimir.address` to the base URL from your [hosted metrics details page](https://grafana.com/orgs/<your-stack-name>/hosted-metrics/<your-stack-id>). For example, if your hosted metrics URL is `https://prometheus-prod-17-prod-us-east-0.grafana.net/api/prom`, use `https://prometheus-prod-71-prod-us-east-0.grafana.net/` as the address.
+* Be sure to set `api-key` to an [access policy token](https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/) when you need to interact with Grafana Cloud
 
 ## Authenticate with Grafana Synthetic Monitoring
 To interact with Grafana Synthetic Monitoring, you must configure the below settings:


### PR DESCRIPTION

context: I originally set up Grizzly with Grafana Cloud Mimir with the following config, which do not pass `grr config check`.
```
grr config set mimir.address https://prometheus-xyz.grafana.net/api/prom
grr config set mimir.tenant-id 123456
grr config set mimir.api-key abcdef12345
```

A simple change fixed this, but I didn't realize until a Grafana PS engineer pointed it out to me. Hopefully I can help someone else with this in the future. Here is what I should have done
```
grr config set mimir.address https://prometheus-xyz.grafana.net/
grr config set mimir.tenant-id 123456
grr config set mimir.api-key abcdef12345
```


Signed-off-by: Alex Hokanson <alex.hokanson@docker.com>
