### PR TITLE
Support executing watch script on Windows

### DIFF
--- a/pkg/grizzly/server.go
+++ b/pkg/grizzly/server.go
@@ -343,7 +343,13 @@ func (s *Server) executeWatchScript() ([]byte, error) {
 	var stderr bytes.Buffer
 	log.Debugf("[watch script] executing %s", s.watchScript)
 
-	cmd := exec.Command("sh", "-c", s.watchScript)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", s.watchScript)
+	} else {
+		cmd = exec.Command("sh", "-c", s.watchScript)
+	}
+
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()


### PR DESCRIPTION
It doesn't seem that Windows is officially supported, but I managed to build it with `go build`. However, I ran into an issue with the watch script while working with the Grizzly server, which is executed using `sh -c`. Since `sh` isn't available on Windows, I updated the code to perform a runtime OS check and use an equivalent shell instance `cmd /c` for Windows.