### PR TITLE
Fix creating AlertRuleGroup with incorrect params

### DIFF
--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -187,11 +187,11 @@ func (h *AlertRuleGroupHandler) createAlertRuleGroup(resource grizzly.Resource) 
 		return err
 	}
 	
-	folderUid, ruleGroup := h.splitUID(resource.Name())
+	folderUID, ruleGroup := h.splitUID(resource.Name())
 	params := provisioning.NewPutAlertRuleGroupParams().
 		WithBody(&group).
 		WithGroup(ruleGroup).
-		WithFolderUID(folderUid).
+		WithFolderUID(folderUID).
 		WithXDisableProvenance(&stringtrue)
 	_, err = client.Provisioning.PutAlertRuleGroup(params)
 	return err
@@ -282,11 +282,11 @@ func (h *AlertRuleGroupHandler) putAlertRuleGroup(existing, resource grizzly.Res
 		return err
 	}
 	
-	folderUid, ruleGroup := h.splitUID(resource.Name())
+	folderUID, ruleGroup := h.splitUID(resource.Name())
 	params := provisioning.NewPutAlertRuleGroupParams().
 		WithBody(group).
 		WithGroup(ruleGroup).
-		WithFolderUID(folderUid).
+		WithFolderUID(folderUID).
 		WithXDisableProvenance(&stringtrue)
 	_, err = client.Provisioning.PutAlertRuleGroup(params, nil)
 	return err

--- a/pkg/grafana/alertgroup-handler.go
+++ b/pkg/grafana/alertgroup-handler.go
@@ -186,11 +186,12 @@ func (h *AlertRuleGroupHandler) createAlertRuleGroup(resource grizzly.Resource) 
 	if err != nil {
 		return err
 	}
-
+	
+	folderUid, ruleGroup := h.splitUID(resource.Name())
 	params := provisioning.NewPutAlertRuleGroupParams().
 		WithBody(&group).
-		WithGroup(group.Title).
-		WithFolderUID(group.FolderUID).
+		WithGroup(ruleGroup).
+		WithFolderUID(folderUid).
 		WithXDisableProvenance(&stringtrue)
 	_, err = client.Provisioning.PutAlertRuleGroup(params)
 	return err
@@ -280,11 +281,12 @@ func (h *AlertRuleGroupHandler) putAlertRuleGroup(existing, resource grizzly.Res
 	if err != nil {
 		return err
 	}
-
+	
+	folderUid, ruleGroup := h.splitUID(resource.Name())
 	params := provisioning.NewPutAlertRuleGroupParams().
 		WithBody(group).
-		WithGroup(group.Title).
-		WithFolderUID(group.FolderUID).
+		WithGroup(ruleGroup).
+		WithFolderUID(folderUid).
 		WithXDisableProvenance(&stringtrue)
 	_, err = client.Provisioning.PutAlertRuleGroup(params, nil)
 	return err


### PR DESCRIPTION
This PR resolve issue https://github.com/grafana/grizzly/issues/602 , when user cannot update existing `AlertRuleGroup `because of grizzly send incorrect param in ruleGroup field