### PR TITLE
(docs) Use GRAFANA_SM_ACCESS_TOKEN instead of GRAFANA_SM_TOKEN

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -192,13 +192,13 @@ Note, this will also work with other Mimir installations, alongside Grafana Clou
 ## Grafana Synthetic Monitoring
 To interact with Grafana Synthetic Monitoring, you must have these environment variable set:
 
-| Name                    | Description                                                           | Required |
-|-------------------------|-----------------------------------------------------------------------|----------|
-| `GRAFANA_SM_TOKEN`      | Authentication token/api key (must have MetricsPublisher permissions) | true     |
-| `GRAFANA_SM_STACK_ID`   | Grafana instance/stack ID                                             | true     |
-| `GRAFANA_SM_LOGS_ID`    | Logs instance ID                                                      | true     |
-| `GRAFANA_SM_METRICS_ID` | Metrics instance ID                                                   | true     |
-| `GRAFANA_SM_URL`        | Synthetic Monitoring instance URL                                     | true     |
+| Name                      | Description                                                           | Required |
+|---------------------------|-----------------------------------------------------------------------|----------|
+| `GRAFANA_SM_ACCESS_TOKEN` | Authentication token/api key (must have MetricsPublisher permissions) | true     |
+| `GRAFANA_SM_STACK_ID`     | Grafana instance/stack ID                                             | true     |
+| `GRAFANA_SM_LOGS_ID`      | Logs instance ID                                                      | true     |
+| `GRAFANA_SM_METRICS_ID`   | Metrics instance ID                                                   | true     |
+| `GRAFANA_SM_URL`          | Synthetic Monitoring instance URL                                     | true     |
 
 Your stack ID is the number at the end of the url when you view your Grafana instance details, ie. `grafana.com/orgs/myorg/stacks/123456` would be `123456`. Your metrics and logs ID's are the `User` when you view your Prometheus or Loki instance details in Grafana Cloud.
 You can find your instance URL under your Synthetic Monitoring configuration.


### PR DESCRIPTION
Document usage of `GRAFANA_SM_ACCESS_TOKEN` which internally maps into `SyntheticMonitoringConfig.AccessToken`
Usage of `GRAFANA_SM_TOKEN` has no pratical effect.