### PR TITLE
fix: handle contact point before rule group

### DIFF
--- a/pkg/grafana/provider.go
+++ b/pkg/grafana/provider.go
@@ -135,9 +135,9 @@ func (p *Provider) GetHandlers() []grizzly.Handler {
 		NewFolderHandler(p),
 		NewLibraryElementHandler(p),
 		NewDashboardHandler(p),
+		NewAlertContactPointHandler(p),
 		NewAlertRuleGroupHandler(p),
 		NewAlertNotificationPolicyHandler(p),
-		NewAlertContactPointHandler(p),
 		NewAlertNotificationTemplateHandler(p),
 	}
 }


### PR DESCRIPTION
Suggestion from @malcolmholmes in https://github.com/grafana/grizzly/issues/611#issuecomment-2879465444 , trying to fix the issue of alert rules being applied before contact points.

CC @oysteinlondal